### PR TITLE
Initial implementation of tokenizer

### DIFF
--- a/tsdoc/.vscode/launch.json
+++ b/tsdoc/.vscode/launch.json
@@ -1,0 +1,26 @@
+{
+  // Use IntelliSense to learn about possible attributes.
+  // Hover to view descriptions of existing attributes.
+  // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "type": "node",
+      "request": "launch",
+      "name": "Jest All",
+      "program": "${workspaceFolder}/node_modules/jest/bin/jest",
+      "args": ["--runInBand"],
+      "console": "integratedTerminal",
+      "internalConsoleOptions": "neverOpen"
+    },
+    {
+      "type": "node",
+      "request": "launch",
+      "name": "Jest Current File",
+      "program": "${workspaceFolder}/node_modules/jest/bin/jest",
+      "args": ["${relativeFile}"],
+      "console": "integratedTerminal",
+      "internalConsoleOptions": "neverOpen"
+    }
+  ]
+}

--- a/tsdoc/scripts/deploy.js
+++ b/tsdoc/scripts/deploy.js
@@ -1,0 +1,4 @@
+console.log('Executing common/scripts/deploy.js');
+console.log('ARGV: ' + JSON.stringify(process.argv));
+console.log('CWD: ' + process.cwd());
+console.log('NPM_INITCWD: ' + process.env['INIT_CWD']);

--- a/tsdoc/scripts/deploy.js
+++ b/tsdoc/scripts/deploy.js
@@ -1,4 +1,0 @@
-console.log('Executing common/scripts/deploy.js');
-console.log('ARGV: ' + JSON.stringify(process.argv));
-console.log('CWD: ' + process.cwd());
-console.log('NPM_INITCWD: ' + process.env['INIT_CWD']);

--- a/tsdoc/src/__tests__/Tokenizer.test.ts
+++ b/tsdoc/src/__tests__/Tokenizer.test.ts
@@ -28,12 +28,29 @@ function matchSnapshot(buffer: string): void {
   })).toMatchSnapshot();
 }
 
-test('test', () => {
-  const buffer: string = [
+test('00 Tokenizer simple case', () => {
+  matchSnapshot([
     '/**',
     ' * line 1 ', // extra space at end of line
     ' * line 2',
     ' */'
-  ].join('\n');
-  matchSnapshot(buffer);
+  ].join('\n'));
+});
+
+test('01 Tokenizer degenerate cases', () => {
+  matchSnapshot('/***/');
+
+  matchSnapshot([
+    '/**',
+    ' *',
+    ' */'
+  ].join('\n'));
+
+  matchSnapshot([
+    '/**',
+    ' ',
+    ' ',
+    ' */'
+  ].join('\n'));
+
 });

--- a/tsdoc/src/__tests__/Tokenizer.test.ts
+++ b/tsdoc/src/__tests__/Tokenizer.test.ts
@@ -20,6 +20,11 @@ function matchSnapshot(buffer: string): void {
     tokens.push(token);
   }
 
+  // Assert that getToken() should return EndOfInput repeatedly
+  expect(tokenizer.getToken().kind).toEqual(TokenKind.EndOfInput);
+  expect(tokenizer.getToken().kind).toEqual(TokenKind.EndOfInput);
+
+  // Generate a snapshot of the token list
   expect(tokens.map(token => {
     return {
       tokenKind: TokenKind[token.kind],

--- a/tsdoc/src/__tests__/Tokenizer.test.ts
+++ b/tsdoc/src/__tests__/Tokenizer.test.ts
@@ -1,0 +1,39 @@
+import { TSDocParser, DocComment } from '../index';
+import { Tokenizer, Token, TokenKind } from '../api/Tokenizer';
+
+function escape(s: string): string {
+  return s.replace(/\n/g, '[n]');
+}
+
+function matchSnapshot(buffer: string): void {
+  const tsdocParser: TSDocParser = new TSDocParser();
+  const docComment: DocComment = tsdocParser.parseString(buffer);
+  const tokenizer: Tokenizer = new Tokenizer(docComment.lines);
+
+  const tokens: Token[] = [];
+
+  while (true) {
+    const token: Token = tokenizer.getToken();
+    if (token.kind === TokenKind.EndOfInput) {
+      break;
+    }
+    tokens.push(token);
+  }
+
+  expect(tokens.map(token => {
+    return {
+      tokenKind: TokenKind[token.kind],
+      range: escape(token.range.getDebugDump('|', '|'))
+    };
+  })).toMatchSnapshot();
+}
+
+test('test', () => {
+  const buffer: string = [
+    '/**',
+    ' * line 1 ', // extra space at end of line
+    ' * line 2',
+    ' */'
+  ].join('\n');
+  matchSnapshot(buffer);
+});

--- a/tsdoc/src/__tests__/__snapshots__/Tokenizer.test.ts.snap
+++ b/tsdoc/src/__tests__/__snapshots__/Tokenizer.test.ts.snap
@@ -1,0 +1,22 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`test 1`] = `
+Array [
+  Object {
+    "range": "/**[n] * |line 1| [n] * line 2[n] */",
+    "tokenKind": "PlainText",
+  },
+  Object {
+    "range": "/**[n] * line 1|| [n] * line 2[n] */",
+    "tokenKind": "Newline",
+  },
+  Object {
+    "range": "/**[n] * line 1 [n] * |line 2|[n] */",
+    "tokenKind": "PlainText",
+  },
+  Object {
+    "range": "/**[n] * line 1 [n] * line 2||[n] */",
+    "tokenKind": "Newline",
+  },
+]
+`;

--- a/tsdoc/src/__tests__/__snapshots__/Tokenizer.test.ts.snap
+++ b/tsdoc/src/__tests__/__snapshots__/Tokenizer.test.ts.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`test 1`] = `
+exports[`00 Tokenizer simple case 1`] = `
 Array [
   Object {
     "range": "/**[n] * |line 1| [n] * line 2[n] */",
@@ -16,6 +16,30 @@ Array [
   },
   Object {
     "range": "/**[n] * line 1 [n] * line 2||[n] */",
+    "tokenKind": "Newline",
+  },
+]
+`;
+
+exports[`01 Tokenizer degenerate cases 1`] = `Array []`;
+
+exports[`01 Tokenizer degenerate cases 2`] = `
+Array [
+  Object {
+    "range": "/**[n] *||[n] */",
+    "tokenKind": "Newline",
+  },
+]
+`;
+
+exports[`01 Tokenizer degenerate cases 3`] = `
+Array [
+  Object {
+    "range": "/**[n] ||[n] [n] */",
+    "tokenKind": "Newline",
+  },
+  Object {
+    "range": "/**[n] [n] ||[n] */",
     "tokenKind": "Newline",
   },
 ]

--- a/tsdoc/src/api/TSDocParser.ts
+++ b/tsdoc/src/api/TSDocParser.ts
@@ -1,6 +1,6 @@
 import { Character } from '../internal/Character';
 
-import { DocComment, IDocCommentParameters } from './DocComment';
+import { DocComment, IDocCommentParameters } from './nodes/DocComment';
 import { TextRange } from './TextRange';
 import { ParseError } from './ParseError';
 

--- a/tsdoc/src/api/TSDocParser.ts
+++ b/tsdoc/src/api/TSDocParser.ts
@@ -50,10 +50,16 @@ export class TSDocParser {
       parseErrors: []
     };
     this._parseLines(parameters);
+
     return new DocComment(parameters);
   }
 
-  private _parseLines(parameters: IDocCommentParameters): IDocCommentParameters {
+  /**
+   * This step parses an entire code comment from slash-star-star until star-slash,
+   * and extracts the content lines.  The lines are stored in IDocCommentParameters.lines
+   * and the overall text range is assigned to IDocCommentParameters.range.
+   */
+  private _parseLines(parameters: IDocCommentParameters): void {
     const range: TextRange = parameters.sourceRange;
     const buffer: string = range.buffer;
 
@@ -74,10 +80,10 @@ export class TSDocParser {
           case State.BeginComment1:
           case State.BeginComment2:
             TSDocParser._addError(parameters, range, 'Expecting a "/**" comment', range.pos);
-              return parameters;
+              return;
           default:
             TSDocParser._addError(parameters, range, 'Unexpected end of input', range.pos);
-            return parameters;
+            return;
         }
       }
 
@@ -94,7 +100,7 @@ export class TSDocParser {
             state = State.BeginComment2;
           } else if (!Character.isWhitespace(current)) {
             TSDocParser._addError(parameters, range, 'Expecting a leading "/**"', nextIndex);
-            return parameters;
+            return;
           }
           break;
         case State.BeginComment2:
@@ -107,7 +113,7 @@ export class TSDocParser {
             state = State.CollectingFirstLine;
           } else {
             TSDocParser._addError(parameters, range, 'Expecting a leading "/**"', nextIndex);
-            return parameters;
+            return;
           }
           break;
         case State.CollectingFirstLine:
@@ -171,7 +177,5 @@ export class TSDocParser {
     }
 
     parameters.range = range.getNewRange(commentRangeStart, commentRangeEnd);
-
-    return parameters;
   }
 }

--- a/tsdoc/src/api/TSDocParser.ts
+++ b/tsdoc/src/api/TSDocParser.ts
@@ -44,8 +44,8 @@ export class TSDocParser {
 
   public parseRange(range: TextRange): DocComment {
     const parameters: IDocCommentParameters = {
+      range: TextRange.empty,
       sourceRange: range,
-      commentRange: TextRange.empty,
       lines: [],
       parseErrors: []
     };
@@ -170,7 +170,7 @@ export class TSDocParser {
       }
     }
 
-    parameters.commentRange = range.getNewRange(commentRangeStart, commentRangeEnd);
+    parameters.range = range.getNewRange(commentRangeStart, commentRangeEnd);
 
     return parameters;
   }

--- a/tsdoc/src/api/TextRange.ts
+++ b/tsdoc/src/api/TextRange.ts
@@ -70,6 +70,20 @@ export class TextRange {
   }
 
   /**
+   * Returns a debugging dump of the range, indicated via custom delimiters.
+   * @remarks
+   * For example if the delimiters are "[" and "]", and the range is 3..5 inside "1234567",
+   * then the output would be "12[345]67".
+   */
+  public getDebugDump(posDelimiter: string, endDelimiter: string): string {
+    return this.buffer.substring(0, this.pos)
+      + posDelimiter
+      + this.buffer.substring(this.pos, this.end)
+      + endDelimiter
+      + this.buffer.substring(this.end);
+  }
+
+  /**
    * Calculates the line and column number for the specified offset into the buffer.
    *
    * @remarks

--- a/tsdoc/src/api/Tokenizer.ts
+++ b/tsdoc/src/api/Tokenizer.ts
@@ -119,10 +119,6 @@ export class Tokenizer {
    * the TokenKind.EndOfInput token.
    */
   public getToken(): Token {
-    if (this._endToken) {
-      return this._endToken;
-    }
-
     const startCharacter: ICharacter = this._getCharacter();
 
     switch (startCharacter.value) {

--- a/tsdoc/src/api/Tokenizer.ts
+++ b/tsdoc/src/api/Tokenizer.ts
@@ -1,0 +1,169 @@
+import { TextRange } from './TextRange';
+
+export enum TokenKind {
+  PlainText,
+  Newline,
+  EndOfInput
+}
+
+export class Token {
+  public readonly kind: TokenKind;
+  public readonly range: TextRange;
+
+  public constructor(kind: TokenKind, range: TextRange) {
+    this.kind = kind;
+    this.range = range;
+  }
+
+  public toString(): string {
+    return this.range.toString();
+  }
+}
+
+interface ICharacter {
+  value: string;
+  index: number;
+}
+
+export class Tokenizer {
+  /**
+   * The array of doc comment lines being tokenized.
+   * These ranges do not include doc comment delimiters such as "/*" or "*".
+   */
+  public readonly lines: TextRange[];
+
+  // The TextRange.buffer shared for the lines, which are assumed to all share
+  // a common buffer
+  private _buffer: string;
+
+  // Index into the lines array
+  private _linesIndex: number;
+
+  // This is a cached pointer to this.lines[this._linesIndex].
+  private _currentLine: TextRange | undefined;
+
+  // index into the TextRange's buffer
+  private _bufferIndex: number;
+
+  private _injectingNewline: boolean;
+
+  // If we've reached the end of the input, this is the final Token object
+  private _endToken: Token | undefined;
+
+  private _peekedCharacter: ICharacter | undefined;
+
+  public constructor(lines: TextRange[]) {
+    this.lines = lines;
+    this._linesIndex = 0;
+    if (this.lines.length === 0) {
+      this._buffer = '';
+      this._currentLine = undefined;
+      this._bufferIndex = 0;
+      this._endToken = new Token(TokenKind.EndOfInput, TextRange.empty);
+    } else {
+      this._buffer = this.lines[0].buffer;
+      this._currentLine = this.lines[0];
+      this._bufferIndex = this._currentLine.pos;
+      this._endToken = undefined;
+    }
+    this._injectingNewline = false;
+    this._peekedCharacter = undefined;
+  }
+
+  public getToken(): Token {
+    if (this._endToken) {
+      return this._endToken;
+    }
+
+    const startCharacter: ICharacter = this._getCharacter();
+
+    switch (startCharacter.value) {
+      case '':
+        return this._endToken!;
+      case '\n':
+        return new Token(TokenKind.Newline, TextRange.fromStringRange(
+          this._buffer, startCharacter.index, startCharacter.index));
+      default:
+        this._skipUntil(['\n']);
+        return new Token(TokenKind.PlainText, TextRange.fromStringRange(
+          this._buffer, startCharacter.index, this._peekCharacter().index));
+    }
+  }
+
+  private _skipUntil(endingCharacters: string[]): void {
+    while (true) {
+      const character: ICharacter = this._peekCharacter();
+
+      if (character.value === '' || endingCharacters.indexOf(character.value) >= 0) {
+        return;
+      }
+      this._getCharacter();
+    }
+  }
+
+  /**
+   * Extracts the next virtual character from the input lines.
+   * After each line, a '\n' character is returned.
+   * When the end of the input is reached, an empty string is returned.
+   * The length of the returned string will always be 0 or 1.
+   */
+  private _getCharacter(): ICharacter {
+    if (this._peekedCharacter !== undefined) {
+      const character: ICharacter = this._peekedCharacter;
+      this._peekedCharacter = undefined;
+      return character;
+    }
+
+    if (this._endToken) {
+      // already reached the end of the input
+      return { value: '', index: this._endToken.range.pos };
+    }
+    if (!this._currentLine) {
+      // Sanity check
+      throw new Error('Tokenizer._currentLine should not be undeifned');
+    }
+
+    while (true) {
+      if (this._bufferIndex < this._currentLine.end) {
+        return {
+          value: this._buffer[this._bufferIndex],
+          index: this._bufferIndex++
+        };
+      }
+
+      // When we reach the logical end of line, we inject a "\n" character (since the
+      // real EOL may be disembodied by the doc comment delimiters).
+      // Since we don't want to move _bufferIndex, we need a little bit of extra state.
+      if (!this._injectingNewline) {
+        this._injectingNewline = true;
+        return {
+          value: '\n',
+          index: this._bufferIndex
+        };
+      }
+      this._injectingNewline = false;
+
+      // Advance to the next line
+      ++this._linesIndex;
+      if (this._linesIndex >= this.lines.length) {
+        // We advanced past the final line
+        this._endToken = new Token(TokenKind.EndOfInput,
+          this._currentLine.getNewRange(this._currentLine.end, this._currentLine.end));
+        return { value: '', index: this._endToken.range.pos };
+      }
+
+      this._currentLine = this.lines[this._linesIndex];
+      this._bufferIndex = this._currentLine.pos;
+    }
+  }
+
+  /**
+   * Similar to _getCharacter(), except it does not advance the input stream pointer.
+   */
+  private _peekCharacter(): ICharacter {
+    if (this._peekedCharacter === undefined) {
+      this._peekedCharacter = this._getCharacter();
+    }
+    return this._peekedCharacter;
+  }
+}

--- a/tsdoc/src/api/nodes/DocBackslashEscape.ts
+++ b/tsdoc/src/api/nodes/DocBackslashEscape.ts
@@ -1,0 +1,24 @@
+import { DocNode, DocNodeKind, IDocNodeParameters } from './DocNode';
+
+/**
+ * Constructor parameters for {@link DocBackslashEscape}.
+ */
+export interface IDocBackslashEscapeParameters extends IDocNodeParameters {
+}
+
+/**
+ * Represents a text character that is preceded by a backslash in order to remove
+ * any special meaning that it might have as a TSDoc symbol.
+ */
+export class DocBackslashEscape extends DocNode {
+  /** {@inheritdoc} */
+  public readonly kind: DocNodeKind = DocNodeKind.HtmlTag;
+
+  /**
+   * Don't call this directly.  Instead use {@link TSDocParser}
+   * @internal
+   */
+  public constructor(parameters: IDocBackslashEscapeParameters) {
+    super(parameters);
+  }
+}

--- a/tsdoc/src/api/nodes/DocComment.ts
+++ b/tsdoc/src/api/nodes/DocComment.ts
@@ -1,28 +1,6 @@
-import { TextRange } from './TextRange';
-import { ParseError } from './ParseError';
-
-/**
- * Indicates the type of {@link DocNode}.
- */
-export enum DocNodeKind {
-  DocComment
-}
-
-/**
- * Represents a parsed documentation item.
- */
-export abstract class DocNode {
-  /**
-   * Indicates the kind of DocNode.
-   */
-  public abstract readonly kind: DocNodeKind;
-
-  public readonly range: TextRange;
-
-  public constructor(range: TextRange) {
-    this.range = range;
-  }
-}
+import { TextRange } from '../TextRange';
+import { ParseError } from '../ParseError';
+import { DocNode, DocNodeKind } from './DocNode';
 
 /**
  * Constructor parameters for {@link DocComment}.

--- a/tsdoc/src/api/nodes/DocComment.ts
+++ b/tsdoc/src/api/nodes/DocComment.ts
@@ -1,16 +1,13 @@
 import { TextRange } from '../TextRange';
 import { ParseError } from '../ParseError';
-import { DocNode, DocNodeKind } from './DocNode';
+import { DocNode, DocNodeKind, IDocNodeParameters } from './DocNode';
 
 /**
  * Constructor parameters for {@link DocComment}.
  */
-export interface IDocCommentParameters {
+export interface IDocCommentParameters extends IDocNodeParameters {
   /** {@inheritdoc DocComment.sourceRange} */
   sourceRange: TextRange;
-
-  /** {@inheritdoc DocComment.commentRange} */
-  commentRange: TextRange;
 
   /** {@inheritdoc DocComment.lines} */
   lines: TextRange[];
@@ -20,12 +17,13 @@ export interface IDocCommentParameters {
 }
 
 /**
- * Represents a parsed documentation comment.
+ * Represents an entire parsed documentation comment.  This is typically the
+ * root of the expression tree returned by the parser.
  */
 export class DocComment extends DocNode {
 
   /** {@inheritdoc} */
-  public readonly kind: DocNodeKind = DocNodeKind.DocComment;
+  public readonly kind: DocNodeKind = DocNodeKind.Comment;
 
   /**
    * Whereas {@link DocComment.range} tracks the start and end of the `/**` and `*\/` delimiters,
@@ -48,7 +46,7 @@ export class DocComment extends DocNode {
    * @internal
    */
   public constructor(parameters: IDocCommentParameters) {
-    super(parameters.commentRange);
+    super(parameters);
 
     this.sourceRange = parameters.sourceRange;
 

--- a/tsdoc/src/api/nodes/DocHtmlTag.ts
+++ b/tsdoc/src/api/nodes/DocHtmlTag.ts
@@ -1,0 +1,24 @@
+import { DocNode, DocNodeKind, IDocNodeParameters } from './DocNode';
+
+/**
+ * Constructor parameters for {@link DocHtmlTag}.
+ */
+export interface IDocHtmlTagParameters extends IDocNodeParameters {
+}
+
+/**
+ * Represents a span of comment text that contains an HTML tag
+ * conforming to CommonMark syntax rules.
+ */
+export class DocHtmlTag extends DocNode {
+  /** {@inheritdoc} */
+  public readonly kind: DocNodeKind = DocNodeKind.HtmlTag;
+
+  /**
+   * Don't call this directly.  Instead use {@link TSDocParser}
+   * @internal
+   */
+  public constructor(parameters: IDocHtmlTagParameters) {
+    super(parameters);
+  }
+}

--- a/tsdoc/src/api/nodes/DocNode.ts
+++ b/tsdoc/src/api/nodes/DocNode.ts
@@ -1,0 +1,25 @@
+import { TextRange } from '../TextRange';
+
+/**
+ * Indicates the type of {@link DocNode}.
+ */
+export enum DocNodeKind {
+  DocComment,
+  DocText
+}
+
+/**
+ * Represents a parsed documentation item.
+ */
+export abstract class DocNode {
+  /**
+   * Indicates the kind of DocNode.
+   */
+  public abstract readonly kind: DocNodeKind;
+
+  public readonly range: TextRange;
+
+  public constructor(range: TextRange) {
+    this.range = range;
+  }
+}

--- a/tsdoc/src/api/nodes/DocNode.ts
+++ b/tsdoc/src/api/nodes/DocNode.ts
@@ -4,8 +4,17 @@ import { TextRange } from '../TextRange';
  * Indicates the type of {@link DocNode}.
  */
 export enum DocNodeKind {
-  DocComment,
-  DocText
+  BackslashEscape,
+  Comment,
+  HtmlTag,
+  PlainText
+}
+
+/**
+ * Constructor parameters for DocNode.
+ */
+export interface IDocNodeParameters {
+  range: TextRange;
 }
 
 /**
@@ -17,9 +26,12 @@ export abstract class DocNode {
    */
   public abstract readonly kind: DocNodeKind;
 
+  /**
+   * The text range corresponding to this documentation node.
+   */
   public readonly range: TextRange;
 
-  public constructor(range: TextRange) {
-    this.range = range;
+  public constructor(parameters: IDocNodeParameters) {
+    this.range = parameters.range;
   }
 }

--- a/tsdoc/src/api/nodes/DocPlainText.ts
+++ b/tsdoc/src/api/nodes/DocPlainText.ts
@@ -1,0 +1,24 @@
+import { DocNode, DocNodeKind, IDocNodeParameters } from './DocNode';
+
+/**
+ * Constructor parameters for {@link DocPlainText}.
+ */
+export interface IDocPlainTextParameters extends IDocNodeParameters {
+}
+
+/**
+ * Represents a span of comment text that is considered by the parser
+ * to contain no special symbols  or meaning.
+ */
+export class DocPlainText extends DocNode {
+  /** {@inheritdoc} */
+  public readonly kind: DocNodeKind = DocNodeKind.PlainText;
+
+  /**
+   * Don't call this directly.  Instead use {@link TSDocParser}
+   * @internal
+   */
+  public constructor(parameters: IDocPlainTextParameters) {
+    super(parameters);
+  }
+}

--- a/tsdoc/src/index.ts
+++ b/tsdoc/src/index.ts
@@ -1,12 +1,6 @@
-export {
-  DocNodeKind,
-  DocComment,
-  DocNode
-} from './api/DocComment';
+
+export { DocNodeKind, DocNode } from './api/nodes/DocNode';
+export { DocComment } from './api/nodes/DocComment';
 
 export { TSDocParser } from './api/TSDocParser';
-
-export {
-  TextRange,
-  ITextLocation
-} from './api/TextRange';
+export { TextRange, ITextLocation } from './api/TextRange';

--- a/tsdoc/tslint.json
+++ b/tsdoc/tslint.json
@@ -48,7 +48,7 @@
       "timeEnd",
       "trace"
     ],
-    "no-constant-condition": true,
+    "no-constant-condition": false,
     "no-construct": true,
     "no-debugger": true,
     "no-duplicate-switch-case": true,


### PR DESCRIPTION
The Tokenizer runs after the line scanning and before the parsing stage.  It will extract tokens such as `\x` for a backslash escape, or `<!--` for an HTML comment start, `<` for an HTML tag start, etc.

This PR sets up the initial structure for the Tokenizer class.