### PR TITLE
Implement paragraph splitting

### DIFF
--- a/tsdoc/CHANGELOG.md
+++ b/tsdoc/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Change Log - @microsoft/tsdoc
 
+## (next release)
+
+- `DocSection` content is now grouped into `DocParagraph` nodes; blank lines are used to indicate paragraph boundaries
+- Rename `DocComment.deprecated` to `deprecatedBlock`
+
 ## 0.3.0
 Fri, 24 Aug 2018
 

--- a/tsdoc/src/__tests__/ParagraphSplitter.test.ts
+++ b/tsdoc/src/__tests__/ParagraphSplitter.test.ts
@@ -1,0 +1,19 @@
+import { TestHelpers } from '../parser/__tests__/TestHelpers';
+
+test('01 Basic paragraph splitting', () => {
+  TestHelpers.parseAndMatchDocCommentSnapshot([
+    '/**',
+    ' *    ',
+    ' * This is the',
+    ' * first paragraph.',
+    ' *   \t   ',
+    ' *  ',
+    ' *   \t   ',
+    ' * This is the second paragraph.',
+    ' *',
+    ' * This is the third paragraph.',
+    ' *',
+    ' *   ',
+    ' */'
+  ].join('\n'));
+});

--- a/tsdoc/src/__tests__/ParagraphSplitter.test.ts
+++ b/tsdoc/src/__tests__/ParagraphSplitter.test.ts
@@ -44,8 +44,7 @@ test('03 Degenerate manually constructed nodes', () => {
     new DocPlainText({ text: '  para 2 ' }),
     new DocSoftBreak({ }),
     new DocSoftBreak({ }),
-    // Currently newlines are allowed inside DocPlainText but are ignored by the splitter
-    new DocPlainText({ text: '  para 3\n\npara 3  ' })
+    new DocPlainText({ text: '  para 3  ' })
   ]);
 
   docSection.appendNode(docParagraph);

--- a/tsdoc/src/__tests__/__snapshots__/ParagraphSplitter.test.ts.snap
+++ b/tsdoc/src/__tests__/__snapshots__/ParagraphSplitter.test.ts.snap
@@ -103,3 +103,131 @@ Object {
   "_7_logMessages": Array [],
 }
 `;
+
+exports[`02 Degenerate paragraph 1`] = `
+Object {
+  "_0_lines": Array [
+    "line 1",
+    "line 2",
+    "",
+    "  @public line 3",
+  ],
+  "_1_summarySection": Object {
+    "kind": "Section",
+    "nodes": Array [
+      Object {
+        "kind": "Paragraph",
+        "nodes": Array [
+          Object {
+            "kind": "PlainText",
+            "nodeExcerpt": "line 1",
+          },
+          Object {
+            "kind": "SoftBreak",
+            "nodeExcerpt": "[n]",
+          },
+          Object {
+            "kind": "PlainText",
+            "nodeExcerpt": "line 2",
+          },
+          Object {
+            "kind": "SoftBreak",
+            "nodeExcerpt": "[n]",
+          },
+          Object {
+            "kind": "SoftBreak",
+            "nodeExcerpt": "[n]",
+          },
+        ],
+      },
+      Object {
+        "kind": "Paragraph",
+        "nodes": Array [
+          Object {
+            "kind": "PlainText",
+            "nodeExcerpt": "  ",
+          },
+          Object {
+            "kind": "PlainText",
+            "nodeExcerpt": " line 3",
+          },
+          Object {
+            "kind": "SoftBreak",
+            "nodeExcerpt": "[n]",
+          },
+        ],
+      },
+    ],
+  },
+  "_2_remarksBlock": undefined,
+  "_3_customBlocks": Array [],
+  "_4_paramBlocks": Array [],
+  "_5_returnsBlock": undefined,
+  "_6_modifierTags": Array [
+    Object {
+      "kind": "BlockTag",
+      "nodeExcerpt": "@public",
+    },
+  ],
+  "_7_logMessages": Array [],
+}
+`;
+
+exports[`03 Degenerate manually constructed nodes 1`] = `
+Object {
+  "kind": "Section",
+  "nodes": Array [
+    Object {
+      "kind": "Paragraph",
+      "nodes": Array [
+        Object {
+          "kind": "PlainText",
+        },
+        Object {
+          "kind": "SoftBreak",
+        },
+        Object {
+          "kind": "PlainText",
+        },
+        Object {
+          "kind": "SoftBreak",
+        },
+      ],
+    },
+    Object {
+      "kind": "Paragraph",
+      "nodes": Array [
+        Object {
+          "kind": "PlainText",
+        },
+        Object {
+          "kind": "PlainText",
+        },
+        Object {
+          "kind": "BlockTag",
+        },
+        Object {
+          "kind": "PlainText",
+        },
+        Object {
+          "kind": "SoftBreak",
+        },
+        Object {
+          "kind": "SoftBreak",
+        },
+      ],
+    },
+    Object {
+      "kind": "Paragraph",
+      "nodes": Array [
+        Object {
+          "kind": "PlainText",
+        },
+      ],
+    },
+    Object {
+      "kind": "Paragraph",
+    },
+  ],
+}
+`;

--- a/tsdoc/src/__tests__/__snapshots__/ParagraphSplitter.test.ts.snap
+++ b/tsdoc/src/__tests__/__snapshots__/ParagraphSplitter.test.ts.snap
@@ -1,0 +1,105 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`01 Basic paragraph splitting 1`] = `
+Object {
+  "_0_lines": Array [
+    "",
+    "This is the",
+    "first paragraph.",
+    "",
+    "",
+    "",
+    "This is the second paragraph.",
+    "",
+    "This is the third paragraph.",
+    "",
+    "",
+  ],
+  "_1_summarySection": Object {
+    "kind": "Section",
+    "nodes": Array [
+      Object {
+        "kind": "Paragraph",
+        "nodes": Array [
+          Object {
+            "kind": "SoftBreak",
+            "nodeExcerpt": "[n]",
+          },
+          Object {
+            "kind": "PlainText",
+            "nodeExcerpt": "This is the",
+          },
+          Object {
+            "kind": "SoftBreak",
+            "nodeExcerpt": "[n]",
+          },
+          Object {
+            "kind": "PlainText",
+            "nodeExcerpt": "first paragraph.",
+          },
+          Object {
+            "kind": "SoftBreak",
+            "nodeExcerpt": "[n]",
+          },
+          Object {
+            "kind": "SoftBreak",
+            "nodeExcerpt": "[n]",
+          },
+          Object {
+            "kind": "SoftBreak",
+            "nodeExcerpt": "[n]",
+          },
+          Object {
+            "kind": "SoftBreak",
+            "nodeExcerpt": "[n]",
+          },
+        ],
+      },
+      Object {
+        "kind": "Paragraph",
+        "nodes": Array [
+          Object {
+            "kind": "PlainText",
+            "nodeExcerpt": "This is the second paragraph.",
+          },
+          Object {
+            "kind": "SoftBreak",
+            "nodeExcerpt": "[n]",
+          },
+          Object {
+            "kind": "SoftBreak",
+            "nodeExcerpt": "[n]",
+          },
+        ],
+      },
+      Object {
+        "kind": "Paragraph",
+        "nodes": Array [
+          Object {
+            "kind": "PlainText",
+            "nodeExcerpt": "This is the third paragraph.",
+          },
+          Object {
+            "kind": "SoftBreak",
+            "nodeExcerpt": "[n]",
+          },
+          Object {
+            "kind": "SoftBreak",
+            "nodeExcerpt": "[n]",
+          },
+          Object {
+            "kind": "SoftBreak",
+            "nodeExcerpt": "[n]",
+          },
+        ],
+      },
+    ],
+  },
+  "_2_remarksBlock": undefined,
+  "_3_customBlocks": Array [],
+  "_4_paramBlocks": Array [],
+  "_5_returnsBlock": undefined,
+  "_6_modifierTags": Array [],
+  "_7_logMessages": Array [],
+}
+`;

--- a/tsdoc/src/__tests__/__snapshots__/ParsingBasics.test.ts.snap
+++ b/tsdoc/src/__tests__/__snapshots__/ParsingBasics.test.ts.snap
@@ -11,32 +11,37 @@ Object {
     "kind": "Section",
     "nodes": Array [
       Object {
-        "kind": "PlainText",
-        "nodeExcerpt": "START ",
-      },
-      Object {
-        "kind": "SoftBreak",
-        "nodeExcerpt": "[n]",
-      },
-      Object {
-        "kind": "BlockTag",
-        "nodeExcerpt": "@unknownTag",
-      },
-      Object {
-        "kind": "SoftBreak",
-        "nodeExcerpt": "[n]",
-      },
-      Object {
-        "kind": "PlainText",
-        "nodeExcerpt": " ",
-      },
-      Object {
-        "kind": "PlainText",
-        "nodeExcerpt": " END",
-      },
-      Object {
-        "kind": "SoftBreak",
-        "nodeExcerpt": "[n]",
+        "kind": "Paragraph",
+        "nodes": Array [
+          Object {
+            "kind": "PlainText",
+            "nodeExcerpt": "START ",
+          },
+          Object {
+            "kind": "SoftBreak",
+            "nodeExcerpt": "[n]",
+          },
+          Object {
+            "kind": "BlockTag",
+            "nodeExcerpt": "@unknownTag",
+          },
+          Object {
+            "kind": "SoftBreak",
+            "nodeExcerpt": "[n]",
+          },
+          Object {
+            "kind": "PlainText",
+            "nodeExcerpt": " ",
+          },
+          Object {
+            "kind": "PlainText",
+            "nodeExcerpt": " END",
+          },
+          Object {
+            "kind": "SoftBreak",
+            "nodeExcerpt": "[n]",
+          },
+        ],
       },
     ],
   },
@@ -79,16 +84,21 @@ Object {
     "kind": "Section",
     "nodes": Array [
       Object {
-        "kind": "PlainText",
-        "nodeExcerpt": "Adds two numbers together.",
-      },
-      Object {
-        "kind": "SoftBreak",
-        "nodeExcerpt": "[n]",
-      },
-      Object {
-        "kind": "SoftBreak",
-        "nodeExcerpt": "[n]",
+        "kind": "Paragraph",
+        "nodes": Array [
+          Object {
+            "kind": "PlainText",
+            "nodeExcerpt": "Adds two numbers together.",
+          },
+          Object {
+            "kind": "SoftBreak",
+            "nodeExcerpt": "[n]",
+          },
+          Object {
+            "kind": "SoftBreak",
+            "nodeExcerpt": "[n]",
+          },
+        ],
       },
     ],
   },
@@ -100,45 +110,50 @@ Object {
         "nodeExcerpt": "@remarks",
       },
       Object {
-        "kind": "SoftBreak",
-        "nodeExcerpt": "[n]",
-      },
-      Object {
-        "kind": "PlainText",
-        "nodeExcerpt": "This method is part of the ",
-      },
-      Object {
-        "kind": "InlineTag",
+        "kind": "Paragraph",
         "nodes": Array [
           Object {
-            "kind": "Particle",
-            "nodeExcerpt": "{",
+            "kind": "SoftBreak",
+            "nodeExcerpt": "[n]",
           },
           Object {
-            "kind": "Particle",
-            "nodeExcerpt": "@link",
+            "kind": "PlainText",
+            "nodeExcerpt": "This method is part of the ",
           },
           Object {
-            "kind": "Particle",
-            "nodeExcerpt": " core-library/Math | Math subsystem",
+            "kind": "InlineTag",
+            "nodes": Array [
+              Object {
+                "kind": "Particle",
+                "nodeExcerpt": "{",
+              },
+              Object {
+                "kind": "Particle",
+                "nodeExcerpt": "@link",
+              },
+              Object {
+                "kind": "Particle",
+                "nodeExcerpt": " core-library/Math | Math subsystem",
+              },
+              Object {
+                "kind": "Particle",
+                "nodeExcerpt": "}",
+              },
+            ],
           },
           Object {
-            "kind": "Particle",
-            "nodeExcerpt": "}",
+            "kind": "PlainText",
+            "nodeExcerpt": ".",
+          },
+          Object {
+            "kind": "SoftBreak",
+            "nodeExcerpt": "[n]",
+          },
+          Object {
+            "kind": "SoftBreak",
+            "nodeExcerpt": "[n]",
           },
         ],
-      },
-      Object {
-        "kind": "PlainText",
-        "nodeExcerpt": ".",
-      },
-      Object {
-        "kind": "SoftBreak",
-        "nodeExcerpt": "[n]",
-      },
-      Object {
-        "kind": "SoftBreak",
-        "nodeExcerpt": "[n]",
       },
     ],
   },
@@ -151,24 +166,29 @@ Object {
           "nodeExcerpt": "@customBlock",
         },
         Object {
-          "kind": "SoftBreak",
-          "nodeExcerpt": "[n]",
-        },
-        Object {
-          "kind": "PlainText",
-          "nodeExcerpt": "This is a custom block containing an ",
-        },
-        Object {
-          "kind": "BlockTag",
-          "nodeExcerpt": "@undefinedBlockTag",
-        },
-        Object {
-          "kind": "SoftBreak",
-          "nodeExcerpt": "[n]",
-        },
-        Object {
-          "kind": "SoftBreak",
-          "nodeExcerpt": "[n]",
+          "kind": "Paragraph",
+          "nodes": Array [
+            Object {
+              "kind": "SoftBreak",
+              "nodeExcerpt": "[n]",
+            },
+            Object {
+              "kind": "PlainText",
+              "nodeExcerpt": "This is a custom block containing an ",
+            },
+            Object {
+              "kind": "BlockTag",
+              "nodeExcerpt": "@undefinedBlockTag",
+            },
+            Object {
+              "kind": "SoftBreak",
+              "nodeExcerpt": "[n]",
+            },
+            Object {
+              "kind": "SoftBreak",
+              "nodeExcerpt": "[n]",
+            },
+          ],
         },
       ],
     },
@@ -193,12 +213,17 @@ Object {
           "nodeSpacing": " ",
         },
         Object {
-          "kind": "PlainText",
-          "nodeExcerpt": "The first number to add",
-        },
-        Object {
-          "kind": "SoftBreak",
-          "nodeExcerpt": "[n]",
+          "kind": "Paragraph",
+          "nodes": Array [
+            Object {
+              "kind": "PlainText",
+              "nodeExcerpt": "The first number to add",
+            },
+            Object {
+              "kind": "SoftBreak",
+              "nodeExcerpt": "[n]",
+            },
+          ],
         },
       ],
     },
@@ -221,12 +246,17 @@ Object {
           "nodeSpacing": " ",
         },
         Object {
-          "kind": "PlainText",
-          "nodeExcerpt": "The second number to add",
-        },
-        Object {
-          "kind": "SoftBreak",
-          "nodeExcerpt": "[n]",
+          "kind": "Paragraph",
+          "nodes": Array [
+            Object {
+              "kind": "PlainText",
+              "nodeExcerpt": "The second number to add",
+            },
+            Object {
+              "kind": "SoftBreak",
+              "nodeExcerpt": "[n]",
+            },
+          ],
         },
       ],
     },
@@ -239,36 +269,41 @@ Object {
         "nodeExcerpt": "@returns",
       },
       Object {
-        "kind": "PlainText",
-        "nodeExcerpt": " The sum of ",
-      },
-      Object {
-        "kind": "CodeSpan",
-        "nodeExcerpt": "[c]x[c]",
-      },
-      Object {
-        "kind": "PlainText",
-        "nodeExcerpt": " and ",
-      },
-      Object {
-        "kind": "CodeSpan",
-        "nodeExcerpt": "[c]y[c]",
-      },
-      Object {
-        "kind": "SoftBreak",
-        "nodeExcerpt": "[n]",
-      },
-      Object {
-        "kind": "SoftBreak",
-        "nodeExcerpt": "[n]",
-      },
-      Object {
-        "kind": "PlainText",
-        "nodeExcerpt": " ",
-      },
-      Object {
-        "kind": "SoftBreak",
-        "nodeExcerpt": "[n]",
+        "kind": "Paragraph",
+        "nodes": Array [
+          Object {
+            "kind": "PlainText",
+            "nodeExcerpt": " The sum of ",
+          },
+          Object {
+            "kind": "CodeSpan",
+            "nodeExcerpt": "[c]x[c]",
+          },
+          Object {
+            "kind": "PlainText",
+            "nodeExcerpt": " and ",
+          },
+          Object {
+            "kind": "CodeSpan",
+            "nodeExcerpt": "[c]y[c]",
+          },
+          Object {
+            "kind": "SoftBreak",
+            "nodeExcerpt": "[n]",
+          },
+          Object {
+            "kind": "SoftBreak",
+            "nodeExcerpt": "[n]",
+          },
+          Object {
+            "kind": "PlainText",
+            "nodeExcerpt": " ",
+          },
+          Object {
+            "kind": "SoftBreak",
+            "nodeExcerpt": "[n]",
+          },
+        ],
       },
     ],
   },
@@ -313,12 +348,17 @@ Object {
           "kind": "Particle",
         },
         Object {
-          "kind": "PlainText",
-          "nodeExcerpt": " - The first number to add",
-        },
-        Object {
-          "kind": "SoftBreak",
-          "nodeExcerpt": "[n]",
+          "kind": "Paragraph",
+          "nodes": Array [
+            Object {
+              "kind": "PlainText",
+              "nodeExcerpt": " - The first number to add",
+            },
+            Object {
+              "kind": "SoftBreak",
+              "nodeExcerpt": "[n]",
+            },
+          ],
         },
       ],
     },
@@ -336,12 +376,17 @@ Object {
           "kind": "Particle",
         },
         Object {
-          "kind": "PlainText",
-          "nodeExcerpt": " y The first number to add",
-        },
-        Object {
-          "kind": "SoftBreak",
-          "nodeExcerpt": "[n]",
+          "kind": "Paragraph",
+          "nodes": Array [
+            Object {
+              "kind": "PlainText",
+              "nodeExcerpt": " y The first number to add",
+            },
+            Object {
+              "kind": "SoftBreak",
+              "nodeExcerpt": "[n]",
+            },
+          ],
         },
       ],
     },
@@ -354,24 +399,29 @@ Object {
         "nodeExcerpt": "@returns",
       },
       Object {
-        "kind": "PlainText",
-        "nodeExcerpt": " The sum of ",
-      },
-      Object {
-        "kind": "CodeSpan",
-        "nodeExcerpt": "[c]x[c]",
-      },
-      Object {
-        "kind": "PlainText",
-        "nodeExcerpt": " and ",
-      },
-      Object {
-        "kind": "CodeSpan",
-        "nodeExcerpt": "[c]y[c]",
-      },
-      Object {
-        "kind": "SoftBreak",
-        "nodeExcerpt": "[n]",
+        "kind": "Paragraph",
+        "nodes": Array [
+          Object {
+            "kind": "PlainText",
+            "nodeExcerpt": " The sum of ",
+          },
+          Object {
+            "kind": "CodeSpan",
+            "nodeExcerpt": "[c]x[c]",
+          },
+          Object {
+            "kind": "PlainText",
+            "nodeExcerpt": " and ",
+          },
+          Object {
+            "kind": "CodeSpan",
+            "nodeExcerpt": "[c]y[c]",
+          },
+          Object {
+            "kind": "SoftBreak",
+            "nodeExcerpt": "[n]",
+          },
+        ],
       },
     ],
   },
@@ -398,8 +448,13 @@ Object {
     "kind": "Section",
     "nodes": Array [
       Object {
-        "kind": "PlainText",
-        "nodeExcerpt": "Adds two numbers together. ",
+        "kind": "Paragraph",
+        "nodes": Array [
+          Object {
+            "kind": "PlainText",
+            "nodeExcerpt": "Adds two numbers together. ",
+          },
+        ],
       },
     ],
   },
@@ -411,49 +466,54 @@ Object {
         "nodeExcerpt": "@remarks",
       },
       Object {
-        "kind": "PlainText",
-        "nodeExcerpt": " This method is part of the",
-      },
-      Object {
-        "kind": "SoftBreak",
-        "nodeExcerpt": "[n]",
-      },
-      Object {
-        "kind": "InlineTag",
+        "kind": "Paragraph",
         "nodes": Array [
           Object {
-            "kind": "Particle",
-            "nodeExcerpt": "{",
+            "kind": "PlainText",
+            "nodeExcerpt": " This method is part of the",
           },
           Object {
-            "kind": "Particle",
-            "nodeExcerpt": "@link",
+            "kind": "SoftBreak",
+            "nodeExcerpt": "[n]",
           },
           Object {
-            "kind": "Particle",
-            "nodeExcerpt": " core-library/Math | Math subsystem",
+            "kind": "InlineTag",
+            "nodes": Array [
+              Object {
+                "kind": "Particle",
+                "nodeExcerpt": "{",
+              },
+              Object {
+                "kind": "Particle",
+                "nodeExcerpt": "@link",
+              },
+              Object {
+                "kind": "Particle",
+                "nodeExcerpt": " core-library/Math | Math subsystem",
+              },
+              Object {
+                "kind": "Particle",
+                "nodeExcerpt": "}",
+              },
+            ],
           },
           Object {
-            "kind": "Particle",
-            "nodeExcerpt": "}",
+            "kind": "PlainText",
+            "nodeExcerpt": ".",
+          },
+          Object {
+            "kind": "SoftBreak",
+            "nodeExcerpt": "[n]",
+          },
+          Object {
+            "kind": "PlainText",
+            "nodeExcerpt": " ",
+          },
+          Object {
+            "kind": "SoftBreak",
+            "nodeExcerpt": "[n]",
           },
         ],
-      },
-      Object {
-        "kind": "PlainText",
-        "nodeExcerpt": ".",
-      },
-      Object {
-        "kind": "SoftBreak",
-        "nodeExcerpt": "[n]",
-      },
-      Object {
-        "kind": "PlainText",
-        "nodeExcerpt": " ",
-      },
-      Object {
-        "kind": "SoftBreak",
-        "nodeExcerpt": "[n]",
       },
     ],
   },
@@ -466,20 +526,25 @@ Object {
           "nodeExcerpt": "@customBlock",
         },
         Object {
-          "kind": "SoftBreak",
-          "nodeExcerpt": "[n]",
-        },
-        Object {
-          "kind": "PlainText",
-          "nodeExcerpt": "This is a custom block containing an ",
-        },
-        Object {
-          "kind": "BlockTag",
-          "nodeExcerpt": "@undefinedBlockTag",
-        },
-        Object {
-          "kind": "SoftBreak",
-          "nodeExcerpt": "[n]",
+          "kind": "Paragraph",
+          "nodes": Array [
+            Object {
+              "kind": "SoftBreak",
+              "nodeExcerpt": "[n]",
+            },
+            Object {
+              "kind": "PlainText",
+              "nodeExcerpt": "This is a custom block containing an ",
+            },
+            Object {
+              "kind": "BlockTag",
+              "nodeExcerpt": "@undefinedBlockTag",
+            },
+            Object {
+              "kind": "SoftBreak",
+              "nodeExcerpt": "[n]",
+            },
+          ],
         },
       ],
     },
@@ -504,8 +569,13 @@ Object {
           "nodeSpacing": " ",
         },
         Object {
-          "kind": "PlainText",
-          "nodeExcerpt": "The first number to add ",
+          "kind": "Paragraph",
+          "nodes": Array [
+            Object {
+              "kind": "PlainText",
+              "nodeExcerpt": "The first number to add ",
+            },
+          ],
         },
       ],
     },
@@ -528,12 +598,17 @@ Object {
           "nodeSpacing": " ",
         },
         Object {
-          "kind": "PlainText",
-          "nodeExcerpt": "The second number to add",
-        },
-        Object {
-          "kind": "SoftBreak",
-          "nodeExcerpt": "[n]",
+          "kind": "Paragraph",
+          "nodes": Array [
+            Object {
+              "kind": "PlainText",
+              "nodeExcerpt": "The second number to add",
+            },
+            Object {
+              "kind": "SoftBreak",
+              "nodeExcerpt": "[n]",
+            },
+          ],
         },
       ],
     },
@@ -546,24 +621,29 @@ Object {
         "nodeExcerpt": "@returns",
       },
       Object {
-        "kind": "PlainText",
-        "nodeExcerpt": " The sum of ",
-      },
-      Object {
-        "kind": "CodeSpan",
-        "nodeExcerpt": "[c]x[c]",
-      },
-      Object {
-        "kind": "PlainText",
-        "nodeExcerpt": " and ",
-      },
-      Object {
-        "kind": "CodeSpan",
-        "nodeExcerpt": "[c]y[c]",
-      },
-      Object {
-        "kind": "SoftBreak",
-        "nodeExcerpt": "[n]",
+        "kind": "Paragraph",
+        "nodes": Array [
+          Object {
+            "kind": "PlainText",
+            "nodeExcerpt": " The sum of ",
+          },
+          Object {
+            "kind": "CodeSpan",
+            "nodeExcerpt": "[c]x[c]",
+          },
+          Object {
+            "kind": "PlainText",
+            "nodeExcerpt": " and ",
+          },
+          Object {
+            "kind": "CodeSpan",
+            "nodeExcerpt": "[c]y[c]",
+          },
+          Object {
+            "kind": "SoftBreak",
+            "nodeExcerpt": "[n]",
+          },
+        ],
       },
     ],
   },

--- a/tsdoc/src/nodes/DocComment.ts
+++ b/tsdoc/src/nodes/DocComment.ts
@@ -62,7 +62,7 @@ export class DocComment extends DocNode {
    * describing the recommended alternative.  Deprecation recursively applies to members
    * of a container.  For example, if a class is deprecated, then so are all of its members.
    */
-  public deprecated: DocBlock | undefined;
+  public deprecatedBlock: DocBlock | undefined;
 
   /**
    * The collection of parsed `@param` blocks for this doc comment.
@@ -91,6 +91,7 @@ export class DocComment extends DocNode {
     this.summarySection = new DocSection(parameters);
     this.remarksBlock = undefined;
     this.privateRemarks = undefined;
+    this.deprecatedBlock = undefined;
     this.paramBlocks = [];
     this.returnsBlock = undefined;
 
@@ -124,7 +125,13 @@ export class DocComment extends DocNode {
       result.push(this.remarksBlock);
     }
 
-    result.push(...this._customBlocks);
+    if (this.privateRemarks) {
+      result.push(this.privateRemarks);
+    }
+
+    if (this.deprecatedBlock) {
+      result.push(this.deprecatedBlock);
+    }
 
     result.push(...this.paramBlocks);
 
@@ -132,7 +139,10 @@ export class DocComment extends DocNode {
       result.push(this.returnsBlock);
     }
 
+    result.push(...this._customBlocks);
+
     result.push(...this.modifierTagSet.nodes);
+
     return result;
   }
 }

--- a/tsdoc/src/nodes/DocNodeContainer.ts
+++ b/tsdoc/src/nodes/DocNodeContainer.ts
@@ -1,0 +1,67 @@
+import { DocNode, IDocNodeParameters } from './DocNode';
+
+/**
+ * Constructor parameters for {@link DocSection}.
+ */
+export interface IDocNodeContainerParameters extends IDocNodeParameters {
+
+}
+
+/**
+ * DocNodeContainer is the base class for DocNode classes that act as a simple container
+ * for other child nodes.  The child classes are {@link DocParagraph} and {@link DocSection}.
+ */
+export abstract class DocNodeContainer extends DocNode {
+  private readonly _nodes: DocNode[] = [];
+
+  /**
+   * Don't call this directly.  Instead use {@link TSDocParser}
+   * @internal
+   */
+  public constructor(parameters: IDocNodeContainerParameters) {
+    super(parameters);
+  }
+
+  /**
+   * The child nodes.  Note that for subclasses {@link getChildNodes()} may enumerate
+   * additional nodes that are not part of this collection.
+   */
+  public get nodes(): ReadonlyArray<DocNode> {
+    return this._nodes;
+  }
+
+  /**
+   * {@inheritdoc}
+   * @override
+   */
+  public getChildNodes(): ReadonlyArray<DocNode> {
+    return this._nodes;
+  }
+
+  /**
+   * Returns true if the specified `docNode` is allowed to be added as a child node.
+   * The {@link appendNode()} and {@link appendNodes()} functions use this to validate their
+   * inputs.
+   *
+   * @virtual
+   */
+  public isAllowedChildNode(docNode: DocNode): boolean {
+    return false;
+  }
+
+  /**
+   * Append a node to the collection.
+   */
+  public appendNode(docNode: DocNode): void {
+    if (!this.isAllowedChildNode(docNode)) {
+      throw new Error(`A DocSection cannot contain nodes of type ${docNode.kind}`);
+    }
+    this._nodes.push(docNode);
+  }
+
+  public appendNodes(docNodes: ReadonlyArray<DocNode>): void {
+    for (const docNode of docNodes) {
+      this.appendNode(docNode);
+    }
+  }
+}

--- a/tsdoc/src/nodes/DocNodeContainer.ts
+++ b/tsdoc/src/nodes/DocNodeContainer.ts
@@ -59,9 +59,19 @@ export abstract class DocNodeContainer extends DocNode {
     this._nodes.push(docNode);
   }
 
+  /**
+   * Append nodes to the collection.
+   */
   public appendNodes(docNodes: ReadonlyArray<DocNode>): void {
     for (const docNode of docNodes) {
       this.appendNode(docNode);
     }
+  }
+
+  /**
+   * Remove all nodes from the collection.
+   */
+  public clearNodes(): void {
+    this._nodes.length = 0;
   }
 }

--- a/tsdoc/src/nodes/DocNodeContainer.ts
+++ b/tsdoc/src/nodes/DocNodeContainer.ts
@@ -1,7 +1,7 @@
 import { DocNode, IDocNodeParameters } from './DocNode';
 
 /**
- * Constructor parameters for {@link DocSection}.
+ * Constructor parameters for {@link DocNodeContainer}.
  */
 export interface IDocNodeContainerParameters extends IDocNodeParameters {
 
@@ -54,7 +54,7 @@ export abstract class DocNodeContainer extends DocNode {
    */
   public appendNode(docNode: DocNode): void {
     if (!this.isAllowedChildNode(docNode)) {
-      throw new Error(`A DocSection cannot contain nodes of type ${docNode.kind}`);
+      throw new Error(`A ${this.kind} cannot contain nodes of type ${docNode.kind}`);
     }
     this._nodes.push(docNode);
   }

--- a/tsdoc/src/nodes/DocParagraph.ts
+++ b/tsdoc/src/nodes/DocParagraph.ts
@@ -1,10 +1,10 @@
 import { DocNodeKind, DocNode } from './DocNode';
-import { DocSection, IDocSectionParameters } from './DocSection';
+import { DocNodeContainer, IDocNodeContainerParameters } from './DocNodeContainer';
 
 /**
  * Constructor parameters for {@link DocParagraph}.
  */
-export interface IDocParagraphParameters extends IDocSectionParameters {
+export interface IDocParagraphParameters extends IDocNodeContainerParameters {
 }
 
 /**
@@ -12,7 +12,7 @@ export interface IDocParagraphParameters extends IDocSectionParameters {
  * Like CommonMark, the TSDoc syntax uses blank lines to delineate paragraphs
  * instead of explicitly notating them.
  */
-export class DocParagraph extends DocSection {
+export class DocParagraph extends DocNodeContainer {
   /** {@inheritdoc} */
   public readonly kind: DocNodeKind = DocNodeKind.Paragraph;
 

--- a/tsdoc/src/nodes/DocParagraph.ts
+++ b/tsdoc/src/nodes/DocParagraph.ts
@@ -1,4 +1,4 @@
-import { DocNodeKind } from './DocNode';
+import { DocNodeKind, DocNode } from './DocNode';
 import { DocSection, IDocSectionParameters } from './DocSection';
 
 /**
@@ -22,5 +22,26 @@ export class DocParagraph extends DocSection {
    */
   public constructor(parameters: IDocParagraphParameters) {
     super(parameters);
+  }
+
+  /**
+   * {@inheritdoc}
+   * @override
+   */
+  public isAllowedChildNode(docNode: DocNode): boolean {
+    // NOTE: DocNodeKind.Paragraph cannot be nested
+    switch (docNode.kind) {
+      case DocNodeKind.BlockTag:
+      case DocNodeKind.CodeSpan:
+      case DocNodeKind.ErrorText:
+      case DocNodeKind.EscapedText:
+      case DocNodeKind.HtmlStartTag:
+      case DocNodeKind.HtmlEndTag:
+      case DocNodeKind.InlineTag:
+      case DocNodeKind.PlainText:
+      case DocNodeKind.SoftBreak:
+        return true;
+    }
+    return false;
   }
 }

--- a/tsdoc/src/nodes/DocPlainText.ts
+++ b/tsdoc/src/nodes/DocPlainText.ts
@@ -10,8 +10,16 @@ export interface IDocPlainTextParameters extends IDocNodeParameters {
 /**
  * Represents a span of comment text that is considered by the parser
  * to contain no special symbols or meaning.
+ *
+ * @remarks
+ * The text content must not contain newline characters.
+ * Use DocSoftBreak to represent manual line splitting.
  */
 export class DocPlainText extends DocNode {
+  // TODO: We should also prohibit "\r", but this requires updating LineExtractor
+  // to interpret a lone "\r" as a newline
+  private static readonly _newlineCharacterRegExp: RegExp = /[\n]/;
+
   /** {@inheritdoc} */
   public readonly kind: DocNodeKind = DocNodeKind.PlainText;
 
@@ -26,6 +34,10 @@ export class DocPlainText extends DocNode {
    */
   public constructor(parameters: IDocPlainTextParameters) {
     super(parameters);
+    if (DocPlainText._newlineCharacterRegExp.test(parameters.text)) {
+      // Use DocSoftBreak to represent manual line splitting
+      throw new Error('The DocPlainText content must not contain newline characters');
+    }
     this.text = parameters.text;
   }
 }

--- a/tsdoc/src/nodes/DocSection.ts
+++ b/tsdoc/src/nodes/DocSection.ts
@@ -1,4 +1,5 @@
 import { DocNode, DocNodeKind, IDocNodeParameters } from './DocNode';
+import { DocParagraph } from './DocParagraph';
 
 /**
  * Constructor parameters for {@link DocSection}.
@@ -50,16 +51,7 @@ export class DocSection extends DocNode {
    */
   public isAllowedChildNode(docNode: DocNode): boolean {
     switch (docNode.kind) {
-      case DocNodeKind.BlockTag:
-      case DocNodeKind.CodeSpan:
-      case DocNodeKind.ErrorText:
-      case DocNodeKind.EscapedText:
-      case DocNodeKind.HtmlStartTag:
-      case DocNodeKind.HtmlEndTag:
-      case DocNodeKind.InlineTag:
       case DocNodeKind.Paragraph:
-      case DocNodeKind.PlainText:
-      case DocNodeKind.SoftBreak:
         return true;
     }
     return false;
@@ -79,5 +71,26 @@ export class DocSection extends DocNode {
     for (const docNode of docNodes) {
       this.appendNode(docNode);
     }
+  }
+
+  /**
+   * If the last item in DocSection.nodes is not a DocParagraph, a new paragraph
+   * is started.  Either way, the provided docNode will be appended to the paragraph.
+   */
+  public appendNodeInParagraph(docNode: DocNode): void {
+    let paragraphNode: DocParagraph | undefined = undefined;
+
+    if (this._nodes.length > 0) {
+      const lastNode: DocNode = this._nodes[this._nodes.length - 1];
+      if (lastNode.kind === DocNodeKind.Paragraph) {
+        paragraphNode = lastNode as DocParagraph;
+      }
+    }
+    if (!paragraphNode) {
+      paragraphNode = new DocParagraph({ });
+      this.appendNode(paragraphNode);
+    }
+
+    paragraphNode.appendNode(docNode);
   }
 }

--- a/tsdoc/src/nodes/DocSection.ts
+++ b/tsdoc/src/nodes/DocSection.ts
@@ -1,10 +1,11 @@
-import { DocNode, DocNodeKind, IDocNodeParameters } from './DocNode';
+import { DocNode, DocNodeKind } from './DocNode';
 import { DocParagraph } from './DocParagraph';
+import { DocNodeContainer, IDocNodeContainerParameters } from './DocNodeContainer';
 
 /**
  * Constructor parameters for {@link DocSection}.
  */
-export interface IDocSectionParameters extends IDocNodeParameters {
+export interface IDocSectionParameters extends IDocNodeContainerParameters {
 
 }
 
@@ -12,11 +13,9 @@ export interface IDocSectionParameters extends IDocNodeParameters {
  * Represents a general block of rich text.  DocSection is the base class for DocNode classes that
  * act as a simple container for other child nodes.
  */
-export class DocSection extends DocNode {
+export class DocSection extends DocNodeContainer {
   /** {@inheritdoc} */
   public readonly kind: DocNodeKind = DocNodeKind.Section;
-
-  private readonly _nodes: DocNode[] = [];
 
   /**
    * Don't call this directly.  Instead use {@link TSDocParser}
@@ -27,27 +26,8 @@ export class DocSection extends DocNode {
   }
 
   /**
-   * The child nodes.  Note that for subclasses {@link getChildNodes()} may enumerate
-   * additional nodes that are not part of this collection.
-   */
-  public get nodes(): ReadonlyArray<DocNode> {
-    return this._nodes;
-  }
-
-  /**
    * {@inheritdoc}
    * @override
-   */
-  public getChildNodes(): ReadonlyArray<DocNode> {
-    return this._nodes;
-  }
-
-  /**
-   * Returns true if the specified `docNode` is allowed to be added as a child node.
-   * The {@link appendNode()} and {@link appendNodes()} functions use this to validate their
-   * inputs.
-   *
-   * @virtual
    */
   public isAllowedChildNode(docNode: DocNode): boolean {
     switch (docNode.kind) {
@@ -58,30 +38,14 @@ export class DocSection extends DocNode {
   }
 
   /**
-   * Append a node to the collection.
-   */
-  public appendNode(docNode: DocNode): void {
-    if (!this.isAllowedChildNode(docNode)) {
-      throw new Error(`A DocSection cannot contain nodes of type ${docNode.kind}`);
-    }
-    this._nodes.push(docNode);
-  }
-
-  public appendNodes(docNodes: ReadonlyArray<DocNode>): void {
-    for (const docNode of docNodes) {
-      this.appendNode(docNode);
-    }
-  }
-
-  /**
    * If the last item in DocSection.nodes is not a DocParagraph, a new paragraph
    * is started.  Either way, the provided docNode will be appended to the paragraph.
    */
   public appendNodeInParagraph(docNode: DocNode): void {
     let paragraphNode: DocParagraph | undefined = undefined;
 
-    if (this._nodes.length > 0) {
-      const lastNode: DocNode = this._nodes[this._nodes.length - 1];
+    if (this.nodes.length > 0) {
+      const lastNode: DocNode = this.nodes[this.nodes.length - 1];
       if (lastNode.kind === DocNodeKind.Paragraph) {
         paragraphNode = lastNode as DocParagraph;
       }

--- a/tsdoc/src/nodes/index.ts
+++ b/tsdoc/src/nodes/index.ts
@@ -10,6 +10,7 @@ export * from './DocHtmlEndTag';
 export * from './DocHtmlStartTag';
 export * from './DocInlineTag';
 export * from './DocNode';
+export * from './DocNodeContainer';
 export * from './DocParagraph';
 export * from './DocParamBlock';
 export * from './DocParticle';

--- a/tsdoc/src/parser/LineExtractor.ts
+++ b/tsdoc/src/parser/LineExtractor.ts
@@ -21,7 +21,7 @@ enum State {
  * The main API for parsing TSDoc comments.
  */
 export class LineExtractor {
-  private static readonly _whitespaceRegExp: RegExp = /^\s$/;
+  private static readonly _whitespaceCharacterRegExp: RegExp = /^\s$/;
 
   /**
    * This step parses an entire code comment from slash-star-star until star-slash,
@@ -69,7 +69,7 @@ export class LineExtractor {
             commentRangeStart = currentIndex;
             ++nextIndex; // skip the star
             state = State.BeginComment2;
-          } else if (!LineExtractor._whitespaceRegExp.test(current)) {
+          } else if (!LineExtractor._whitespaceCharacterRegExp.test(current)) {
             parserContext.log.addMessageForTextRange('Expecting a leading "/**"',
               range.getNewRange(currentIndex, currentIndex + 1));
             return false;
@@ -109,7 +109,7 @@ export class LineExtractor {
             ++nextIndex; // skip the slash
             commentRangeEnd = nextIndex;
             state = State.Done;
-          } else if (!LineExtractor._whitespaceRegExp.test(current)) {
+          } else if (!LineExtractor._whitespaceCharacterRegExp.test(current)) {
             collectingLineEnd = nextIndex;
           }
           break;
@@ -137,7 +137,7 @@ export class LineExtractor {
             // Blank line
             lines.push(range.getNewRange(currentIndex, currentIndex));
             collectingLineStart = nextIndex;
-          } else if (!LineExtractor._whitespaceRegExp.test(current)) {
+          } else if (!LineExtractor._whitespaceCharacterRegExp.test(current)) {
             // If the star is missing, then start the line here
             // Example: "/**\nL1*/"
 

--- a/tsdoc/src/parser/NodeParser.ts
+++ b/tsdoc/src/parser/NodeParser.ts
@@ -200,7 +200,7 @@ export class NodeParser {
         docComment.privateRemarks = block;
         break;
       case StandardTags.deprecated.tagNameWithUpperCase:
-        docComment.deprecated = block;
+        docComment.deprecatedBlock = block;
         break;
       case StandardTags.returns.tagNameWithUpperCase:
         docComment.returnsBlock = block;

--- a/tsdoc/src/parser/NodeParser.ts
+++ b/tsdoc/src/parser/NodeParser.ts
@@ -298,7 +298,7 @@ export class NodeParser {
   }
 
   private _pushDocNode(docNode: DocNode): void {
-    this._currentSection.appendNode(docNode);
+    this._currentSection.appendNodeInParagraph(docNode);
     this._verbatimNodes.push(docNode);
   }
 

--- a/tsdoc/src/parser/ParagraphSplitter.ts
+++ b/tsdoc/src/parser/ParagraphSplitter.ts
@@ -1,0 +1,122 @@
+import {
+  DocComment,
+  DocSection,
+  DocNode,
+  DocNodeKind,
+  DocParagraph,
+  DocPlainText
+} from '../nodes';
+
+export class ParagraphSplitter {
+  private static readonly _whitespaceRegExp: RegExp = /^\s*$/;
+
+  /**
+   * For each DocSection, split the DocParagraph into multiple paragraphs by looking
+   * for one or more blank lines that separate the paragraphs.  (These "lines" are ended
+   * by SoftBreak nodes).  The blank lines are assigned to the preceding paragraph,
+   * and referred to as the "trailer".
+   */
+  public static splitParagraphs(docComment: DocComment): void {
+    for (const node of docComment.getChildNodes()) {
+      if (node instanceof DocSection) {
+        ParagraphSplitter._splitParagraphsForSection(node);
+      }
+    }
+  }
+
+  private static _splitParagraphsForSection(docSection: DocSection): void {
+    const inputNodes: ReadonlyArray<DocNode> = docSection.nodes;
+    const outputNodes: DocNode[] = [];
+
+    for (const oldNode of inputNodes) {
+      if (oldNode.kind === DocNodeKind.Paragraph) {
+        ParagraphSplitter._splitParagraph(oldNode as DocParagraph, outputNodes);
+      } else {
+        outputNodes.push(oldNode);
+      }
+    }
+
+    // Replace the inputNodes with the outputNodes
+    docSection.clearNodes();
+    docSection.appendNodes(outputNodes);
+  }
+
+  private static _splitParagraph(oldParagraph: DocParagraph, outputNodes: DocNode[]): void {
+    const inputParagraphNodes: ReadonlyArray<DocNode> = oldParagraph.nodes;
+
+    let currentParagraph: DocParagraph = new DocParagraph({ });
+    outputNodes.push(currentParagraph);
+
+    const enum SplitterState {
+      Start,
+      AwaitingTrailer,
+      ReadingTrailer
+    }
+    let state: SplitterState = SplitterState.Start;
+
+    let currentIndex: number = 0;
+    while (currentIndex < inputParagraphNodes.length) {
+
+      // Scan forwards to the end of the line
+      let isBlankLine: boolean = true;
+      let lineEndIndex: number = currentIndex; // non-inclusive
+      do {
+        const node: DocNode = inputParagraphNodes[lineEndIndex++];
+        if (node.kind === DocNodeKind.SoftBreak) {
+          break;
+        }
+        if (isBlankLine) {
+          if (!this._isWhitespace(node)) {
+            isBlankLine = false;
+          }
+        }
+      } while (lineEndIndex < inputParagraphNodes.length);
+
+      // At this point, the line and SoftBreak will be in inputParagraphNodes.slice(currentIndex, lineEndIndex)
+
+      switch (state) {
+        case SplitterState.Start:
+          // We're skipping any blank lines that start the first paragraph
+          if (!isBlankLine) {
+            state = SplitterState.AwaitingTrailer;
+          }
+          break;
+        case SplitterState.AwaitingTrailer:
+          // We already saw some content, so now we're looking for a blank line that starts the trailer
+          // at the end of this paragraph
+          if (isBlankLine) {
+            state = SplitterState.ReadingTrailer;
+          }
+          break;
+        case SplitterState.ReadingTrailer:
+          // We already found the trailer, so now we're looking for a non-blank line that will
+          // begin a new paragraph
+          if (!isBlankLine) {
+            // Start a new paragraph
+            currentParagraph = new DocParagraph({ });
+            outputNodes.push(currentParagraph);
+
+            state = SplitterState.AwaitingTrailer;
+          }
+          break;
+      }
+
+      // Append the line onto the current paragraph
+      for (let i: number = currentIndex; i < lineEndIndex; ++i) {
+        currentParagraph.appendNode(inputParagraphNodes[i]);
+      }
+
+      currentIndex = lineEndIndex;
+    }
+  }
+
+  private static _isWhitespace(node: DocNode): boolean {
+    switch (node.kind) {
+      case DocNodeKind.PlainText:
+        const docPlainText: DocPlainText = node as DocPlainText;
+        return ParagraphSplitter._whitespaceRegExp.test(docPlainText.text);
+      default:
+        return false;
+    }
+  }
+}

--- a/tsdoc/src/parser/ParagraphSplitter.ts
+++ b/tsdoc/src/parser/ParagraphSplitter.ts
@@ -19,12 +19,19 @@ export class ParagraphSplitter {
   public static splitParagraphs(docComment: DocComment): void {
     for (const node of docComment.getChildNodes()) {
       if (node instanceof DocSection) {
-        ParagraphSplitter._splitParagraphsForSection(node);
+        ParagraphSplitter.splitParagraphsForSection(node);
       }
     }
   }
 
-  private static _splitParagraphsForSection(docSection: DocSection): void {
+  /**
+   * Split DocParagraph nodes into multiple paragraphs by looking for one or more blank lines
+   * that separate the paragraphs.  (These "lines" are ended by SoftBreak nodes).
+   * The blank lines are attached to the preceding paragraph, and referred to as the "trailer"
+   * for that paragraph.  If blank lines precede the first paragraph, they are attached to that
+   * paragraph, rather than creating a paragraph consisting entirely of whitespace.
+   */
+  public static splitParagraphsForSection(docSection: DocSection): void {
     const inputNodes: ReadonlyArray<DocNode> = docSection.nodes;
     const outputNodes: DocNode[] = [];
 

--- a/tsdoc/src/parser/ParagraphSplitter.ts
+++ b/tsdoc/src/parser/ParagraphSplitter.ts
@@ -7,14 +7,20 @@ import {
   DocPlainText
 } from '../nodes';
 
+/**
+ * The ParagraphSplitter is a secondary stage that runs after the NodeParser has constructed
+ * the DocComment.  It splits DocParagraph nodes into multiple paragraphs by looking for
+ * paragraph delimiters.  Following CommonMark conventions, paragraphs are delimited by
+ * one or more blank lines.  (These lines end with SoftBreak nodes.)  The blank lines are
+ * not discarded.  Instead, they are attached to the preceding paragraph.  If the DocParagraph
+ * starts with blank lines, they are preserved to avoid creating a paragraph containing only
+ * whitespace.
+ */
 export class ParagraphSplitter {
   private static readonly _whitespaceRegExp: RegExp = /^\s*$/;
 
   /**
-   * For each DocSection, split the DocParagraph into multiple paragraphs by looking
-   * for one or more blank lines that separate the paragraphs.  (These "lines" are ended
-   * by SoftBreak nodes).  The blank lines are assigned to the preceding paragraph,
-   * and referred to as the "trailer".
+   * Split all paragraphs belonging to the provided DocComment.
    */
   public static splitParagraphs(docComment: DocComment): void {
     for (const node of docComment.getChildNodes()) {
@@ -25,11 +31,7 @@ export class ParagraphSplitter {
   }
 
   /**
-   * Split DocParagraph nodes into multiple paragraphs by looking for one or more blank lines
-   * that separate the paragraphs.  (These "lines" are ended by SoftBreak nodes).
-   * The blank lines are attached to the preceding paragraph, and referred to as the "trailer"
-   * for that paragraph.  If blank lines precede the first paragraph, they are attached to that
-   * paragraph, rather than creating a paragraph consisting entirely of whitespace.
+   * Split all paragraphs belonging to the provided DocSection.
    */
   public static splitParagraphsForSection(docSection: DocSection): void {
     const inputNodes: ReadonlyArray<DocNode> = docSection.nodes;

--- a/tsdoc/src/parser/TSDocParser.ts
+++ b/tsdoc/src/parser/TSDocParser.ts
@@ -4,6 +4,7 @@ import { LineExtractor } from './LineExtractor';
 import { Tokenizer } from './Tokenizer';
 import { NodeParser } from './NodeParser';
 import { TSDocParserConfiguration } from './TSDocParserConfiguration';
+import { ParagraphSplitter } from './ParagraphSplitter';
 
 /**
  * The main API for parsing TSDoc comments.
@@ -31,8 +32,11 @@ export class TSDocParser {
 
     if (LineExtractor.extract(parserContext)) {
       parserContext.tokens = Tokenizer.readTokens(parserContext.lines);
+
       const nodeParser: NodeParser = new NodeParser(parserContext);
       nodeParser.parse();
+
+      ParagraphSplitter.splitParagraphs(parserContext.docComment);
     }
 
     return parserContext;

--- a/tsdoc/src/parser/__tests__/NodeParserBasics.test.ts
+++ b/tsdoc/src/parser/__tests__/NodeParserBasics.test.ts
@@ -42,21 +42,3 @@ test('03 Backslash escapes: negative examples', () => {
     ' */'
   ].join('\n'));
 });
-
-test('04 Paragraphs', () => {
-  TestHelpers.parseAndMatchNodeParserSnapshot([
-    '/**',
-    ' *    ',
-    ' * This is the',
-    ' * first paragraph.',
-    ' *   \t   ',
-    ' *  ',
-    ' *   \t   ',
-    ' * This is the second paragraph.',
-    ' *',
-    ' * This is the third paragraph.',
-    ' *',
-    ' *   ',
-    ' */'
-  ].join('\n'));
-});

--- a/tsdoc/src/parser/__tests__/NodeParserBasics.test.ts
+++ b/tsdoc/src/parser/__tests__/NodeParserBasics.test.ts
@@ -42,3 +42,21 @@ test('03 Backslash escapes: negative examples', () => {
     ' */'
   ].join('\n'));
 });
+
+test('04 Paragraphs', () => {
+  TestHelpers.parseAndMatchNodeParserSnapshot([
+    '/**',
+    ' *    ',
+    ' * This is the',
+    ' * first paragraph.',
+    ' *   \t   ',
+    ' *  ',
+    ' *   \t   ',
+    ' * This is the second paragraph.',
+    ' *',
+    ' * This is the third paragraph.',
+    ' *',
+    ' *   ',
+    ' */'
+  ].join('\n'));
+});


### PR DESCRIPTION
The `DocSection` now acts as container for `DocParagraph` nodes that behave similar to the `<p>` tag in HTML.   Following CommonMark conventions, the paragraphs are delimited by one or more blank lines (i.e. lines comprised entirely of whitespace).  In the DOM, the parser attaches the blank lines to the preceding paragraph, and any initial blank lines are attached to the first paragraph.

(Note that, as with CommonMark and HTML, the whitespace itself has no effect when rendering documentation; it is modeled by the TSDoc API merely to allow preserving/customizing line breaks when emitting a *.d.ts file.)

For example, consider this input:

```typescript
/**
 *
 * This is the
 * `first` paragraph
 *
 *
 * This is the {@second}
 *       paragraph.
 *
 * This is the third paragraph
 *
 */
```

The DOM paragraphs will look like this:
```
- DocSection
  - DocParagraph
    - DocSoftBreak
    - DocPlainText: "This is the"
    - DocSoftBreak
    - CodeSpan: "`first`"
    - DocPlainText: " paragraph"
    - DocSoftBreak
    - DocSoftBreak
    - DocSoftBreak
  - DocParagraph
    - DocPlainText: "This is the "
    - DocInlineTag: "{@second}"
    - DocSoftBreak
    - DocPlainText: "      paragraph."
    - DocSoftBreak
    - DocSoftBreak
  - DocParagraph
    - DocPlainText: "This is the third paragraph"
    - DocSoftBreak
    - DocSoftBreak
```

