### PR TITLE
Add support for code fences

### DIFF
--- a/tsdoc/CHANGELOG.md
+++ b/tsdoc/CHANGELOG.md
@@ -1,7 +1,10 @@
 # Change Log - @microsoft/tsdoc
 
-## (next release)
+## 0.4.0
+Mon, 27 Aug 2018
 
+- Rename `DocCodeSpan.text` to `DocCodeSpan.code` and model the delimiters using particles
+- Add support for code fences (`DocCodeFence`)
 - `DocSection` content is now grouped into `DocParagraph` nodes; blank lines are used to indicate paragraph boundaries
 - Rename `DocComment.deprecated` to `deprecatedBlock`
 

--- a/tsdoc/src/__tests__/__snapshots__/ParsingBasics.test.ts.snap
+++ b/tsdoc/src/__tests__/__snapshots__/ParsingBasics.test.ts.snap
@@ -277,7 +277,20 @@ Object {
           },
           Object {
             "kind": "CodeSpan",
-            "nodeExcerpt": "[c]x[c]",
+            "nodes": Array [
+              Object {
+                "kind": "Particle",
+                "nodeExcerpt": "[c]",
+              },
+              Object {
+                "kind": "Particle",
+                "nodeExcerpt": "x",
+              },
+              Object {
+                "kind": "Particle",
+                "nodeExcerpt": "[c]",
+              },
+            ],
           },
           Object {
             "kind": "PlainText",
@@ -285,7 +298,20 @@ Object {
           },
           Object {
             "kind": "CodeSpan",
-            "nodeExcerpt": "[c]y[c]",
+            "nodes": Array [
+              Object {
+                "kind": "Particle",
+                "nodeExcerpt": "[c]",
+              },
+              Object {
+                "kind": "Particle",
+                "nodeExcerpt": "y",
+              },
+              Object {
+                "kind": "Particle",
+                "nodeExcerpt": "[c]",
+              },
+            ],
           },
           Object {
             "kind": "SoftBreak",
@@ -407,7 +433,20 @@ Object {
           },
           Object {
             "kind": "CodeSpan",
-            "nodeExcerpt": "[c]x[c]",
+            "nodes": Array [
+              Object {
+                "kind": "Particle",
+                "nodeExcerpt": "[c]",
+              },
+              Object {
+                "kind": "Particle",
+                "nodeExcerpt": "x",
+              },
+              Object {
+                "kind": "Particle",
+                "nodeExcerpt": "[c]",
+              },
+            ],
           },
           Object {
             "kind": "PlainText",
@@ -415,7 +454,20 @@ Object {
           },
           Object {
             "kind": "CodeSpan",
-            "nodeExcerpt": "[c]y[c]",
+            "nodes": Array [
+              Object {
+                "kind": "Particle",
+                "nodeExcerpt": "[c]",
+              },
+              Object {
+                "kind": "Particle",
+                "nodeExcerpt": "y",
+              },
+              Object {
+                "kind": "Particle",
+                "nodeExcerpt": "[c]",
+              },
+            ],
           },
           Object {
             "kind": "SoftBreak",
@@ -629,7 +681,20 @@ Object {
           },
           Object {
             "kind": "CodeSpan",
-            "nodeExcerpt": "[c]x[c]",
+            "nodes": Array [
+              Object {
+                "kind": "Particle",
+                "nodeExcerpt": "[c]",
+              },
+              Object {
+                "kind": "Particle",
+                "nodeExcerpt": "x",
+              },
+              Object {
+                "kind": "Particle",
+                "nodeExcerpt": "[c]",
+              },
+            ],
           },
           Object {
             "kind": "PlainText",
@@ -637,7 +702,20 @@ Object {
           },
           Object {
             "kind": "CodeSpan",
-            "nodeExcerpt": "[c]y[c]",
+            "nodes": Array [
+              Object {
+                "kind": "Particle",
+                "nodeExcerpt": "[c]",
+              },
+              Object {
+                "kind": "Particle",
+                "nodeExcerpt": "y",
+              },
+              Object {
+                "kind": "Particle",
+                "nodeExcerpt": "[c]",
+              },
+            ],
           },
           Object {
             "kind": "SoftBreak",

--- a/tsdoc/src/nodes/DocCodeFence.ts
+++ b/tsdoc/src/nodes/DocCodeFence.ts
@@ -1,0 +1,113 @@
+import { DocNodeKind, IDocNodeParameters, DocNode } from './DocNode';
+import { Excerpt } from '../parser/Excerpt';
+import { DocParticle } from './DocParticle';
+
+/**
+ * Constructor parameters for {@link DocCodeFence}.
+ */
+export interface IDocCodeFenceParameters extends IDocNodeParameters {
+  openingDelimiterExcerpt?: Excerpt;
+
+  languageExcerpt?: Excerpt;
+  language?: string | 'ts' | undefined;
+
+  textExcerpt?: Excerpt;
+  text: string;
+
+  closingDelimiterExcerpt?: Excerpt;
+}
+
+/**
+ * Represents CommonMark-style code fence, i.e. a block of program code that
+ * starts and ends with a line comprised of three backticks.  The opening delimiter
+ * can also specify a language for a syntax highlighter.
+ */
+export class DocCodeFence extends DocNode {
+  /** {@inheritdoc} */
+  public readonly kind: DocNodeKind = DocNodeKind.CodeFence;
+
+  // The attribute name
+  private readonly _openingDelimiterParticle: DocParticle;
+
+  // The "=" delimiter
+  private readonly _languageParticle: DocParticle | undefined;
+
+  private readonly _textParticle: DocParticle;
+
+  // The attribute value including quotation marks
+  private readonly _closingDelimiterParticle: DocParticle;
+
+  /**
+   * Don't call this directly.  Instead use {@link TSDocParser}
+   * @internal
+   */
+  public constructor(parameters: IDocCodeFenceParameters) {
+    super(parameters);
+
+    this._openingDelimiterParticle = new DocParticle({
+      excerpt: parameters.openingDelimiterExcerpt,
+      content: '```'
+    });
+
+    if (parameters.language && parameters.language.length > 0) {
+      this._languageParticle = new DocParticle({
+        excerpt: parameters.languageExcerpt,
+        content: parameters.language
+      });
+    }
+
+    this._textParticle = new DocParticle({
+      excerpt: parameters.textExcerpt,
+      content: parameters.text
+    });
+
+    this._closingDelimiterParticle = new DocParticle({
+      excerpt: parameters.closingDelimiterExcerpt,
+      content: '```'
+    });
+  }
+
+  /**
+   * A name that can optionally be included after the opening code fence delimiter,
+   * on the same line as the three backticks.  This name indicates the programming language
+   * for the code, which a syntax highlighter may use to style the code block.
+   *
+   * @remarks
+   * The TSDoc standard requires that the language "ts" should be interpreted to mean TypeScript.
+   * Other languages names may be supported, but this is implementation dependent.
+   *
+   * CommonMark refers to this field as the "info string".
+   */
+  public get language(): string | 'ts' | undefined {
+    if (this._languageParticle) {
+      return this._languageParticle.content;
+    }
+    return undefined;
+  }
+
+  /**
+   * The text that should be rendered as code.
+   */
+  public get text(): string {
+    return this._textParticle.content;
+  }
+
+  /**
+   * {@inheritdoc}
+   * @override
+   */
+  public getChildNodes(): ReadonlyArray<DocNode> {
+    const result: DocNode[] = [ ];
+
+    result.push(this._openingDelimiterParticle);
+
+    if (this._languageParticle) {
+      result.push(this._languageParticle);
+    }
+
+    result.push(this._textParticle);
+    result.push(this._closingDelimiterParticle);
+
+    return result;
+  }
+}

--- a/tsdoc/src/nodes/DocCodeFence.ts
+++ b/tsdoc/src/nodes/DocCodeFence.ts
@@ -26,15 +26,16 @@ export class DocCodeFence extends DocNode {
   /** {@inheritdoc} */
   public readonly kind: DocNodeKind = DocNodeKind.CodeFence;
 
-  // The attribute name
+  // The opening ``` delimiter and padding
   private readonly _openingDelimiterParticle: DocParticle;
 
-  // The "=" delimiter
+  // The optional language string, and newline
   private readonly _languageParticle: DocParticle;
 
+  // The code content
   private readonly _codeParticle: DocParticle;
 
-  // The attribute value including quotation marks
+  // The closing ``` delimiter, spacing, and newline
   private readonly _closingDelimiterParticle: DocParticle;
 
   /**
@@ -75,6 +76,10 @@ export class DocCodeFence extends DocNode {
    * Other languages names may be supported, but this is implementation dependent.
    *
    * CommonMark refers to this field as the "info string".
+   *
+   * @privateRemarks
+   * Examples of language strings supported by GitHub flavored markdown:
+   * https://raw.githubusercontent.com/github/linguist/master/lib/linguist/languages.yml
    */
   public get language(): string | 'ts' | '' {
     return this._languageParticle.content;

--- a/tsdoc/src/nodes/DocCodeFence.ts
+++ b/tsdoc/src/nodes/DocCodeFence.ts
@@ -9,7 +9,7 @@ export interface IDocCodeFenceParameters extends IDocNodeParameters {
   openingDelimiterExcerpt?: Excerpt;
 
   languageExcerpt?: Excerpt;
-  language?: string | 'ts' | undefined;
+  language?: string | 'ts' | '';
 
   textExcerpt?: Excerpt;
   text: string;
@@ -30,7 +30,7 @@ export class DocCodeFence extends DocNode {
   private readonly _openingDelimiterParticle: DocParticle;
 
   // The "=" delimiter
-  private readonly _languageParticle: DocParticle | undefined;
+  private readonly _languageParticle: DocParticle;
 
   private readonly _textParticle: DocParticle;
 
@@ -49,12 +49,10 @@ export class DocCodeFence extends DocNode {
       content: '```'
     });
 
-    if (parameters.language && parameters.language.length > 0) {
-      this._languageParticle = new DocParticle({
-        excerpt: parameters.languageExcerpt,
-        content: parameters.language
-      });
-    }
+    this._languageParticle = new DocParticle({
+      excerpt: parameters.languageExcerpt,
+      content: parameters.language || ''
+    });
 
     this._textParticle = new DocParticle({
       excerpt: parameters.textExcerpt,
@@ -78,11 +76,8 @@ export class DocCodeFence extends DocNode {
    *
    * CommonMark refers to this field as the "info string".
    */
-  public get language(): string | 'ts' | undefined {
-    if (this._languageParticle) {
-      return this._languageParticle.content;
-    }
-    return undefined;
+  public get language(): string | 'ts' | '' {
+    return this._languageParticle.content;
   }
 
   /**
@@ -97,17 +92,11 @@ export class DocCodeFence extends DocNode {
    * @override
    */
   public getChildNodes(): ReadonlyArray<DocNode> {
-    const result: DocNode[] = [ ];
-
-    result.push(this._openingDelimiterParticle);
-
-    if (this._languageParticle) {
-      result.push(this._languageParticle);
-    }
-
-    result.push(this._textParticle);
-    result.push(this._closingDelimiterParticle);
-
-    return result;
+    return [
+      this._openingDelimiterParticle,
+      this._languageParticle,
+      this._textParticle,
+      this._closingDelimiterParticle
+    ];
   }
 }

--- a/tsdoc/src/nodes/DocCodeFence.ts
+++ b/tsdoc/src/nodes/DocCodeFence.ts
@@ -11,8 +11,8 @@ export interface IDocCodeFenceParameters extends IDocNodeParameters {
   languageExcerpt?: Excerpt;
   language?: string | 'ts' | '';
 
-  textExcerpt?: Excerpt;
-  text: string;
+  codeExcerpt?: Excerpt;
+  code: string;
 
   closingDelimiterExcerpt?: Excerpt;
 }
@@ -32,7 +32,7 @@ export class DocCodeFence extends DocNode {
   // The "=" delimiter
   private readonly _languageParticle: DocParticle;
 
-  private readonly _textParticle: DocParticle;
+  private readonly _codeParticle: DocParticle;
 
   // The attribute value including quotation marks
   private readonly _closingDelimiterParticle: DocParticle;
@@ -54,9 +54,9 @@ export class DocCodeFence extends DocNode {
       content: parameters.language || ''
     });
 
-    this._textParticle = new DocParticle({
-      excerpt: parameters.textExcerpt,
-      content: parameters.text
+    this._codeParticle = new DocParticle({
+      excerpt: parameters.codeExcerpt,
+      content: parameters.code
     });
 
     this._closingDelimiterParticle = new DocParticle({
@@ -83,8 +83,8 @@ export class DocCodeFence extends DocNode {
   /**
    * The text that should be rendered as code.
    */
-  public get text(): string {
-    return this._textParticle.content;
+  public get code(): string {
+    return this._codeParticle.content;
   }
 
   /**
@@ -95,7 +95,7 @@ export class DocCodeFence extends DocNode {
     return [
       this._openingDelimiterParticle,
       this._languageParticle,
-      this._textParticle,
+      this._codeParticle,
       this._closingDelimiterParticle
     ];
   }

--- a/tsdoc/src/nodes/DocCodeSpan.ts
+++ b/tsdoc/src/nodes/DocCodeSpan.ts
@@ -4,7 +4,7 @@ import { DocNodeKind, IDocNodeParameters, DocNode } from './DocNode';
  * Constructor parameters for {@link DocCodeSpan}.
  */
 export interface IDocCodeSpanParameters extends IDocNodeParameters {
-  text: string;
+  code: string;
 }
 
 /**
@@ -18,7 +18,7 @@ export class DocCodeSpan extends DocNode {
   /**
    * The text that should be rendered as code, excluding the backtick delimiters.
    */
-  public readonly text: string;
+  public readonly code: string;
 
   /**
    * Don't call this directly.  Instead use {@link TSDocParser}
@@ -26,6 +26,6 @@ export class DocCodeSpan extends DocNode {
    */
   public constructor(parameters: IDocCodeSpanParameters) {
     super(parameters);
-    this.text = parameters.text;
+    this.code = parameters.code;
   }
 }

--- a/tsdoc/src/nodes/DocCodeSpan.ts
+++ b/tsdoc/src/nodes/DocCodeSpan.ts
@@ -16,7 +16,7 @@ export class DocCodeSpan extends DocNode {
   public readonly kind: DocNodeKind = DocNodeKind.CodeSpan;
 
   /**
-   * The text that should be rendered as code.
+   * The text that should be rendered as code, excluding the backtick delimiters.
    */
   public readonly text: string;
 

--- a/tsdoc/src/nodes/DocCodeSpan.ts
+++ b/tsdoc/src/nodes/DocCodeSpan.ts
@@ -1,10 +1,17 @@
 import { DocNodeKind, IDocNodeParameters, DocNode } from './DocNode';
+import { DocParticle } from './DocParticle';
+import { Excerpt } from '../parser/Excerpt';
 
 /**
  * Constructor parameters for {@link DocCodeSpan}.
  */
 export interface IDocCodeSpanParameters extends IDocNodeParameters {
+  openingDelimiterExcerpt?: Excerpt;
+
+  codeExcerpt?: Excerpt;
   code: string;
+
+  closingDelimiterExcerpt?: Excerpt;
 }
 
 /**
@@ -15,10 +22,14 @@ export class DocCodeSpan extends DocNode {
   /** {@inheritdoc} */
   public readonly kind: DocNodeKind = DocNodeKind.CodeSpan;
 
-  /**
-   * The text that should be rendered as code, excluding the backtick delimiters.
-   */
-  public readonly code: string;
+  // The opening ` delimiter
+  private readonly _openingDelimiterParticle: DocParticle;
+
+  // The code content
+  private readonly _codeParticle: DocParticle;
+
+  // The closing ` delimiter
+  private readonly _closingDelimiterParticle: DocParticle;
 
   /**
    * Don't call this directly.  Instead use {@link TSDocParser}
@@ -26,6 +37,40 @@ export class DocCodeSpan extends DocNode {
    */
   public constructor(parameters: IDocCodeSpanParameters) {
     super(parameters);
-    this.code = parameters.code;
+
+    this._openingDelimiterParticle = new DocParticle({
+      excerpt: parameters.openingDelimiterExcerpt,
+      content: '`'
+    });
+
+    this._codeParticle = new DocParticle({
+      excerpt: parameters.codeExcerpt,
+      content: parameters.code
+    });
+
+    this._closingDelimiterParticle = new DocParticle({
+      excerpt: parameters.closingDelimiterExcerpt,
+      content: '`'
+    });
+
+  }
+
+  /**
+   * The text that should be rendered as code, excluding the backtick delimiters.
+   */
+  public get code(): string {
+    return this._codeParticle.content;
+  }
+
+  /**
+   * {@inheritdoc}
+   * @override
+   */
+  public getChildNodes(): ReadonlyArray<DocNode> {
+    return [
+      this._openingDelimiterParticle,
+      this._codeParticle,
+      this._closingDelimiterParticle
+    ];
   }
 }

--- a/tsdoc/src/nodes/DocComment.ts
+++ b/tsdoc/src/nodes/DocComment.ts
@@ -119,7 +119,9 @@ export class DocComment extends DocNode {
    * @override
    */
   public getChildNodes(): ReadonlyArray<DocNode> {
-    const result: DocNode[] = [ this.summarySection ];
+    const result: DocNode[] = [ ];
+
+    result.push(this.summarySection);
 
     if (this.remarksBlock) {
       result.push(this.remarksBlock);

--- a/tsdoc/src/nodes/DocNode.ts
+++ b/tsdoc/src/nodes/DocNode.ts
@@ -6,6 +6,7 @@ import { Excerpt } from '../parser/Excerpt';
 export const enum DocNodeKind {
   Block = 'Block',
   BlockTag = 'BlockTag',
+  CodeFence = 'CodeFence',
   CodeSpan = 'CodeSpan',
   Comment = 'Comment',
   ErrorText = 'ErrorText',

--- a/tsdoc/src/nodes/DocSection.ts
+++ b/tsdoc/src/nodes/DocSection.ts
@@ -31,6 +31,8 @@ export class DocSection extends DocNodeContainer {
    */
   public isAllowedChildNode(docNode: DocNode): boolean {
     switch (docNode.kind) {
+      case DocNodeKind.CodeFence:
+      case DocNodeKind.ErrorText:
       case DocNodeKind.Paragraph:
         return true;
     }

--- a/tsdoc/src/nodes/index.ts
+++ b/tsdoc/src/nodes/index.ts
@@ -1,6 +1,7 @@
 
 export * from './DocBlock';
 export * from './DocBlockTag';
+export * from './DocCodeFence';
 export * from './DocCodeSpan';
 export * from './DocComment';
 export * from './DocErrorText';

--- a/tsdoc/src/parser/NodeParser.ts
+++ b/tsdoc/src/parser/NodeParser.ts
@@ -930,7 +930,7 @@ export class NodeParser {
     // Example: "code 1\ncode 2\n   ```"
     const codeAndDelimiterSequence: TokenSequence = this._tokenReader.extractAccumulatedSequence();
 
-    const textExcerpt: Excerpt = new Excerpt({
+    const codeExcerpt: Excerpt = new Excerpt({
       content: codeAndDelimiterSequence.getNewSequence(codeAndDelimiterSequence.startIndex, codeEndMarker)
     });
 
@@ -972,8 +972,8 @@ export class NodeParser {
       languageExcerpt: languageExcerpt,
       language: languageExcerpt.content.toString(),
 
-      textExcerpt: textExcerpt,
-      text: textExcerpt.content.toString(),
+      codeExcerpt: codeExcerpt,
+      code: codeExcerpt.content.toString(),
 
       closingDelimiterExcerpt: closingDelimiterExcerpt
     });
@@ -999,7 +999,7 @@ export class NodeParser {
 
     this._tokenReader.readToken(); // read the backtick
 
-    let text: string = '';
+    let code: string = '';
     let closingBacktickMarker: number;
 
     // Parse the content backtick
@@ -1015,7 +1015,7 @@ export class NodeParser {
         return this._backtrackAndCreateError(marker,
           'The code span is missing its closing backtick');
       }
-      text += this._tokenReader.readToken().toString();
+      code += this._tokenReader.readToken().toString();
     }
 
     // Make sure there's whitespace after
@@ -1032,7 +1032,7 @@ export class NodeParser {
 
     return new DocCodeSpan({
       excerpt: new Excerpt({ content: this._tokenReader.extractAccumulatedSequence() }),
-      text
+      code
     });
   }
 

--- a/tsdoc/src/parser/TokenReader.ts
+++ b/tsdoc/src/parser/TokenReader.ts
@@ -88,7 +88,7 @@ export class TokenReader {
   }
 
   /**
-   * Show the next token that will be returned by _readToken(), without
+   * Returns the next token that would be returned by _readToken(), without
    * consuming anything.
    */
   public peekToken(): Token {
@@ -96,7 +96,7 @@ export class TokenReader {
   }
 
   /**
-   * Show the TokenKind for the next token that will be returned by _readToken(), without
+   * Returns the TokenKind for the next token that would be returned by _readToken(), without
    * consuming anything.
    */
   public peekTokenKind(): TokenKind {
@@ -104,14 +104,23 @@ export class TokenReader {
   }
 
   /**
-   * Show the TokenKind for the token after the next token that will be returned by _readToken(),
-   * without consuming anything.  In other words, look ahead two tokens.
+   * Like peekTokenKind(), but looks ahead two tokens.
    */
   public peekTokenAfterKind(): TokenKind {
     if (this._currentIndex + 1 >= this.tokens.length) {
       return TokenKind.None;
     }
     return this.tokens[this._currentIndex + 1].kind;
+  }
+
+  /**
+   * Like peekTokenKind(), but looks ahead threee tokens.
+   */
+  public peekTokenAfterAfterKind(): TokenKind {
+    if (this._currentIndex + 2 >= this.tokens.length) {
+      return TokenKind.None;
+    }
+    return this.tokens[this._currentIndex + 2].kind;
   }
 
   /**

--- a/tsdoc/src/parser/TokenSequence.ts
+++ b/tsdoc/src/parser/TokenSequence.ts
@@ -57,6 +57,18 @@ export class TokenSequence {
   }
 
   /**
+   * Constructs a TokenSequence that corresponds to a different range of tokens,
+   * e.g. a subrange.
+   */
+  public getNewSequence(startIndex: number, endIndex: number): TokenSequence {
+    return new TokenSequence({
+      parserContext: this.parserContext,
+      startIndex: startIndex,
+      endIndex: endIndex
+    });
+  }
+
+  /**
    * Returns a TextRange that includes all tokens in the sequence (including any additional
    * characters between doc comment lines).
    */

--- a/tsdoc/src/parser/__tests__/NodeParserCode.test.ts
+++ b/tsdoc/src/parser/__tests__/NodeParserCode.test.ts
@@ -23,3 +23,69 @@ test('01 Code span basic, negative', () => {
     ' */'
   ].join('\n'));
 });
+
+test('03 Code fence, positive', () => {
+  TestHelpers.parseAndMatchNodeParserSnapshot([
+    '/**',
+    ' * This is a code fence with all parts:',
+    ' * ```a language!   ',
+    ' *   some `code` here',
+    ' * ```   ',
+    ' */'
+  ].join('\n'));
+  TestHelpers.parseAndMatchNodeParserSnapshot([
+    '/**',
+    ' * This is a code fence with no language or trailing whitespace:',
+    ' * ```',
+    ' *   some `code` here',
+    ' * ```*/'
+  ].join('\n'));
+});
+
+test('04 Code fence, negative', () => {
+  TestHelpers.parseAndMatchNodeParserSnapshot([
+    '/**',
+    ' * Code fence incorrectly indented:',
+    ' *    ```',
+    ' */'
+  ].join('\n'));
+  TestHelpers.parseAndMatchNodeParserSnapshot([
+    '/**',
+    ' * Code fence not starting the line:',
+    ' *a```',
+    ' */'
+  ].join('\n'));
+  TestHelpers.parseAndMatchNodeParserSnapshot([
+    '/**',
+    ' * Code fence not being terminated 1:',
+    ' * ```*/'
+  ].join('\n'));
+  TestHelpers.parseAndMatchNodeParserSnapshot([
+    '/**',
+    ' * Code fence not being terminated 2:',
+    ' * ``` some stuff',
+    ' */'
+  ].join('\n'));
+  TestHelpers.parseAndMatchNodeParserSnapshot([
+    '/**',
+    ' * Language having backticks:',
+    ' * ``` some stuff ```',
+    ' */'
+  ].join('\n'));
+  TestHelpers.parseAndMatchNodeParserSnapshot([
+    '/**',
+    ' * Closing delimiter being indented:',
+    ' * ```',
+    ' * code',
+    ' *      ```',
+    ' */'
+  ].join('\n'));
+  TestHelpers.parseAndMatchNodeParserSnapshot([
+    '/**',
+    ' * Closing delimiter not being on a line by itself:',
+    ' * ```',
+    ' * code',
+    ' * ```  a',
+    ' */'
+  ].join('\n'));
+});

--- a/tsdoc/src/parser/__tests__/__snapshots__/NodeParserCode.test.ts.snap
+++ b/tsdoc/src/parser/__tests__/__snapshots__/NodeParserCode.test.ts.snap
@@ -147,3 +147,395 @@ Object {
   ],
 }
 `;
+
+exports[`03 Code fence, positive 1`] = `
+Object {
+  "buffer": "/**[n] * This is a code fence with all parts:[n] * [c][c][c]a language!   [n] *   some [c]code[c] here[n] * [c][c][c]   [n] */",
+  "lines": Array [
+    "This is a code fence with all parts:",
+    "[c][c][c]a language!",
+    "  some [c]code[c] here",
+    "[c][c][c]",
+  ],
+  "logMessages": Array [],
+  "verbatimNodes": Array [
+    Object {
+      "kind": "PlainText",
+      "nodeExcerpt": "This is a code fence with all parts:",
+    },
+    Object {
+      "kind": "SoftBreak",
+      "nodeExcerpt": "[n]",
+    },
+    Object {
+      "kind": "CodeFence",
+      "nodes": Array [
+        Object {
+          "kind": "Particle",
+          "nodeExcerpt": "[c][c][c]",
+        },
+        Object {
+          "kind": "Particle",
+          "nodeExcerpt": "a language!",
+          "nodeSpacing": "[n]",
+        },
+        Object {
+          "kind": "Particle",
+          "nodeExcerpt": "  some [c]code[c] here[n]",
+        },
+        Object {
+          "kind": "Particle",
+          "nodeExcerpt": "[c][c][c]",
+          "nodeSpacing": "[n]",
+        },
+      ],
+    },
+  ],
+}
+`;
+
+exports[`03 Code fence, positive 2`] = `
+Object {
+  "buffer": "/**[n] * This is a code fence with no language or trailing whitespace:[n] * [c][c][c][n] *   some [c]code[c] here[n] * [c][c][c]*/",
+  "lines": Array [
+    "This is a code fence with no language or trailing whitespace:",
+    "[c][c][c]",
+    "  some [c]code[c] here",
+    "[c][c][c]",
+  ],
+  "logMessages": Array [],
+  "verbatimNodes": Array [
+    Object {
+      "kind": "PlainText",
+      "nodeExcerpt": "This is a code fence with no language or trailing whitespace:",
+    },
+    Object {
+      "kind": "SoftBreak",
+      "nodeExcerpt": "[n]",
+    },
+    Object {
+      "kind": "CodeFence",
+      "nodes": Array [
+        Object {
+          "kind": "Particle",
+          "nodeExcerpt": "[c][c][c]",
+        },
+        Object {
+          "kind": "Particle",
+          "nodeExcerpt": "",
+          "nodeSpacing": "[n]",
+        },
+        Object {
+          "kind": "Particle",
+          "nodeExcerpt": "  some [c]code[c] here[n]",
+        },
+        Object {
+          "kind": "Particle",
+          "nodeExcerpt": "[c][c][c]",
+          "nodeSpacing": "[n]",
+        },
+      ],
+    },
+  ],
+}
+`;
+
+exports[`04 Code fence, negative 1`] = `
+Object {
+  "buffer": "/**[n] * Code fence incorrectly indented:[n] *    [c][c][c][n] */",
+  "lines": Array [
+    "Code fence incorrectly indented:",
+    "   [c][c][c]",
+  ],
+  "logMessages": Array [
+    "(3,7): The opening backtick for a code fence must appear at the start of the line",
+  ],
+  "verbatimNodes": Array [
+    Object {
+      "kind": "PlainText",
+      "nodeExcerpt": "Code fence incorrectly indented:",
+    },
+    Object {
+      "kind": "SoftBreak",
+      "nodeExcerpt": "[n]",
+    },
+    Object {
+      "kind": "PlainText",
+      "nodeExcerpt": "   ",
+    },
+    Object {
+      "errorLocation": "[c][c][c]",
+      "errorLocationPrecedingToken": "   ",
+      "errorMessage": "The opening backtick for a code fence must appear at the start of the line",
+      "kind": "ErrorText",
+      "nodeExcerpt": "[c][c][c]",
+    },
+    Object {
+      "kind": "SoftBreak",
+      "nodeExcerpt": "[n]",
+    },
+  ],
+}
+`;
+
+exports[`04 Code fence, negative 2`] = `
+Object {
+  "buffer": "/**[n] * Code fence not starting the line:[n] *a[c][c][c][n] */",
+  "lines": Array [
+    "Code fence not starting the line:",
+    "a[c][c][c]",
+  ],
+  "logMessages": Array [
+    "(3,4): The opening backtick for a code fence must appear at the start of the line",
+  ],
+  "verbatimNodes": Array [
+    Object {
+      "kind": "PlainText",
+      "nodeExcerpt": "Code fence not starting the line:",
+    },
+    Object {
+      "kind": "SoftBreak",
+      "nodeExcerpt": "[n]",
+    },
+    Object {
+      "kind": "PlainText",
+      "nodeExcerpt": "a",
+    },
+    Object {
+      "errorLocation": "[c][c][c]",
+      "errorLocationPrecedingToken": "a",
+      "errorMessage": "The opening backtick for a code fence must appear at the start of the line",
+      "kind": "ErrorText",
+      "nodeExcerpt": "[c][c][c]",
+    },
+    Object {
+      "kind": "SoftBreak",
+      "nodeExcerpt": "[n]",
+    },
+  ],
+}
+`;
+
+exports[`04 Code fence, negative 3`] = `
+Object {
+  "buffer": "/**[n] * Code fence not being terminated 1:[n] * [c][c][c]*/",
+  "lines": Array [
+    "Code fence not being terminated 1:",
+    "[c][c][c]",
+  ],
+  "logMessages": Array [
+    "(3,7): Error parsing code fence: Missing closing delimiter",
+  ],
+  "verbatimNodes": Array [
+    Object {
+      "kind": "PlainText",
+      "nodeExcerpt": "Code fence not being terminated 1:",
+    },
+    Object {
+      "kind": "SoftBreak",
+      "nodeExcerpt": "[n]",
+    },
+    Object {
+      "errorLocation": "",
+      "errorLocationPrecedingToken": "
+",
+      "errorMessage": "Error parsing code fence: Missing closing delimiter",
+      "kind": "ErrorText",
+      "nodeExcerpt": "[c][c][c]",
+    },
+    Object {
+      "kind": "SoftBreak",
+      "nodeExcerpt": "[n]",
+    },
+  ],
+}
+`;
+
+exports[`04 Code fence, negative 4`] = `
+Object {
+  "buffer": "/**[n] * Code fence not being terminated 2:[n] * [c][c][c] some stuff[n] */",
+  "lines": Array [
+    "Code fence not being terminated 2:",
+    "[c][c][c] some stuff",
+  ],
+  "logMessages": Array [
+    "(3,18): Error parsing code fence: Missing closing delimiter",
+  ],
+  "verbatimNodes": Array [
+    Object {
+      "kind": "PlainText",
+      "nodeExcerpt": "Code fence not being terminated 2:",
+    },
+    Object {
+      "kind": "SoftBreak",
+      "nodeExcerpt": "[n]",
+    },
+    Object {
+      "errorLocation": "",
+      "errorLocationPrecedingToken": "
+",
+      "errorMessage": "Error parsing code fence: Missing closing delimiter",
+      "kind": "ErrorText",
+      "nodeExcerpt": "[c][c][c]",
+    },
+    Object {
+      "kind": "PlainText",
+      "nodeExcerpt": " some stuff",
+    },
+    Object {
+      "kind": "SoftBreak",
+      "nodeExcerpt": "[n]",
+    },
+  ],
+}
+`;
+
+exports[`04 Code fence, negative 5`] = `
+Object {
+  "buffer": "/**[n] * Language having backticks:[n] * [c][c][c] some stuff [c][c][c][n] */",
+  "lines": Array [
+    "Language having backticks:",
+    "[c][c][c] some stuff [c][c][c]",
+  ],
+  "logMessages": Array [
+    "(3,19): Error parsing code fence: The language specifier cannot contain backtick characters",
+    "(3,19): The opening backtick for a code fence must appear at the start of the line",
+  ],
+  "verbatimNodes": Array [
+    Object {
+      "kind": "PlainText",
+      "nodeExcerpt": "Language having backticks:",
+    },
+    Object {
+      "kind": "SoftBreak",
+      "nodeExcerpt": "[n]",
+    },
+    Object {
+      "errorLocation": "[c]",
+      "errorLocationPrecedingToken": " ",
+      "errorMessage": "Error parsing code fence: The language specifier cannot contain backtick characters",
+      "kind": "ErrorText",
+      "nodeExcerpt": "[c][c][c]",
+    },
+    Object {
+      "kind": "PlainText",
+      "nodeExcerpt": " some stuff ",
+    },
+    Object {
+      "errorLocation": "[c][c][c]",
+      "errorLocationPrecedingToken": " ",
+      "errorMessage": "The opening backtick for a code fence must appear at the start of the line",
+      "kind": "ErrorText",
+      "nodeExcerpt": "[c][c][c]",
+    },
+    Object {
+      "kind": "SoftBreak",
+      "nodeExcerpt": "[n]",
+    },
+  ],
+}
+`;
+
+exports[`04 Code fence, negative 6`] = `
+Object {
+  "buffer": "/**[n] * Closing delimiter being indented:[n] * [c][c][c][n] * code[n] *      [c][c][c][n] */",
+  "lines": Array [
+    "Closing delimiter being indented:",
+    "[c][c][c]",
+    "code",
+    "     [c][c][c]",
+  ],
+  "logMessages": Array [
+    "(5,4): The closing delimiter for a code fence must not be indented",
+  ],
+  "verbatimNodes": Array [
+    Object {
+      "kind": "PlainText",
+      "nodeExcerpt": "Closing delimiter being indented:",
+    },
+    Object {
+      "kind": "SoftBreak",
+      "nodeExcerpt": "[n]",
+    },
+    Object {
+      "kind": "CodeFence",
+      "nodes": Array [
+        Object {
+          "kind": "Particle",
+          "nodeExcerpt": "[c][c][c]",
+        },
+        Object {
+          "kind": "Particle",
+          "nodeExcerpt": "",
+          "nodeSpacing": "[n]",
+        },
+        Object {
+          "kind": "Particle",
+          "nodeExcerpt": "code[n]",
+        },
+        Object {
+          "kind": "Particle",
+          "nodeExcerpt": "     [c][c][c]",
+          "nodeSpacing": "[n]",
+        },
+      ],
+    },
+  ],
+}
+`;
+
+exports[`04 Code fence, negative 7`] = `
+Object {
+  "buffer": "/**[n] * Closing delimiter not being on a line by itself:[n] * [c][c][c][n] * code[n] * [c][c][c]  a[n] */",
+  "lines": Array [
+    "Closing delimiter not being on a line by itself:",
+    "[c][c][c]",
+    "code",
+    "[c][c][c]  a",
+  ],
+  "logMessages": Array [
+    "(5,9): Unexpected characters after closing delimiter for code fence",
+  ],
+  "verbatimNodes": Array [
+    Object {
+      "kind": "PlainText",
+      "nodeExcerpt": "Closing delimiter not being on a line by itself:",
+    },
+    Object {
+      "kind": "SoftBreak",
+      "nodeExcerpt": "[n]",
+    },
+    Object {
+      "kind": "CodeFence",
+      "nodes": Array [
+        Object {
+          "kind": "Particle",
+          "nodeExcerpt": "[c][c][c]",
+        },
+        Object {
+          "kind": "Particle",
+          "nodeExcerpt": "",
+          "nodeSpacing": "[n]",
+        },
+        Object {
+          "kind": "Particle",
+          "nodeExcerpt": "code[n]",
+        },
+        Object {
+          "kind": "Particle",
+          "nodeExcerpt": "[c][c][c]",
+          "nodeSpacing": "  ",
+        },
+      ],
+    },
+    Object {
+      "kind": "PlainText",
+      "nodeExcerpt": "a",
+    },
+    Object {
+      "kind": "SoftBreak",
+      "nodeExcerpt": "[n]",
+    },
+  ],
+}
+`;

--- a/tsdoc/src/parser/__tests__/__snapshots__/NodeParserCode.test.ts.snap
+++ b/tsdoc/src/parser/__tests__/__snapshots__/NodeParserCode.test.ts.snap
@@ -15,7 +15,20 @@ Object {
     },
     Object {
       "kind": "CodeSpan",
-      "nodeExcerpt": "[c]1[c]",
+      "nodes": Array [
+        Object {
+          "kind": "Particle",
+          "nodeExcerpt": "[c]",
+        },
+        Object {
+          "kind": "Particle",
+          "nodeExcerpt": "1",
+        },
+        Object {
+          "kind": "Particle",
+          "nodeExcerpt": "[c]",
+        },
+      ],
     },
     Object {
       "kind": "SoftBreak",
@@ -27,7 +40,20 @@ Object {
     },
     Object {
       "kind": "CodeSpan",
-      "nodeExcerpt": "[c] 2[c]",
+      "nodes": Array [
+        Object {
+          "kind": "Particle",
+          "nodeExcerpt": "[c]",
+        },
+        Object {
+          "kind": "Particle",
+          "nodeExcerpt": " 2",
+        },
+        Object {
+          "kind": "Particle",
+          "nodeExcerpt": "[c]",
+        },
+      ],
     },
     Object {
       "kind": "PlainText",


### PR DESCRIPTION
This PR adds support for CommonMark style code fences:

```ts
/**
 * Example usage:
 * ```ts
 * console.log(average([1,2,3]));
 * ```
 */
export function average(values: number[]): number {
  if (!values.length) return 0;
  return values.reduce((a, b) => a + b) / values.length;
}
```