### PR TITLE
PoC: Use tsutils to scan for comments

### DIFF
--- a/api-demo/assets/advanced-input.ts
+++ b/api-demo/assets/advanced-input.ts
@@ -1,3 +1,4 @@
+/** */
 export class Statistics {
   /**
    * Returns the average of two numbers.

--- a/api-demo/package.json
+++ b/api-demo/package.json
@@ -8,7 +8,8 @@
     "@microsoft/tsdoc": "../tsdoc",
     "@types/colors": "1.2.1",
     "@types/node": "10.7.1",
-    "colors": "~1.3.1"
+    "colors": "~1.3.1",
+    "tsutils": "2.29.0"
   },
   "devDependencies": {
     "rimraf": "~2.6.2",

--- a/api-demo/src/advancedDemo.ts
+++ b/api-demo/src/advancedDemo.ts
@@ -3,6 +3,7 @@ import * as os from 'os';
 import * as path from 'path';
 import * as ts from 'typescript';
 import * as tsdoc from '@microsoft/tsdoc';
+import * as tsutils from 'tsutils';
 
 /**
  * The advanced demo invokes the TypeScript compiler and extracts the comment from the AST.
@@ -52,6 +53,12 @@ export function advancedDemo(): void {
 
   if (foundComments.length === 0) {
     console.log(colors.red('Error: No code comments were found in the input file'));
+
+    const foundCommentsText: string[] = [];
+    tsutils.forEachComment(sourceFile, (_text, comment) => {
+      foundCommentsText.push(_text.substr(comment.pos, comment.end - comment.pos));
+    });
+    console.log(colors.green('...but tsutils found:\n'), foundCommentsText);
   } else {
     // For the purposes of this demo, only analyze the first comment that we found
     parseTSDoc(foundComments[0]);


### PR DESCRIPTION
Changed the advanced example as @Gerrit0 suggested which fails with the current findComments walker. Tsutils does handle this case however.

This does not include the nodes to the comments.

I tried `Symbol#getDocumentationComment` but this only returned text and stripped text, tags etc.

Adresses #56 

/cc @pgonzal 