### PR TITLE
Add trimSpacesInParagraphNodes() transform

### DIFF
--- a/tsdoc/CHANGELOG.md
+++ b/tsdoc/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Change Log - @microsoft/tsdoc
 
+## (next release)
+- Add DocNodeTransforms.trimSpacesInParagraphNodes() for collapsing whitespace inside DocParagraph subtrees
+
 ## 0.4.1
 Mon, 30 Aug 2018
 

--- a/tsdoc/src/__tests__/DocNodeTransforms.test.ts
+++ b/tsdoc/src/__tests__/DocNodeTransforms.test.ts
@@ -1,0 +1,27 @@
+import { ParserContext, TSDocParser } from '..';
+import { TestHelpers } from '../parser/__tests__/TestHelpers';
+import { DocParagraph, DocNode, DocNodeKind } from '../nodes';
+import { DocNodeTransforms } from '../transforms/DocNodeTransforms';
+
+test('01 trimSpacesInParagraphNodes()', () => {
+  const buffer: string = [
+    '/**',
+    ' *',
+    ' *    This \t is    the',
+    ' * first   {@mylink}paragraph.',
+    ' * ',
+    ' *         This is the second',
+    ' *    paragraph.',
+    ' */'
+  ].join('\n');
+
+  const tsdocParser: TSDocParser = new TSDocParser();
+  const parserContext: ParserContext = tsdocParser.parseString(buffer);
+  const firstNode: DocNode = parserContext.docComment.summarySection.nodes[0];
+  expect(firstNode.kind).toEqual(DocNodeKind.Paragraph);
+  const paragraph: DocParagraph = firstNode as DocParagraph;
+  const transformedNodes: DocNode[] = DocNodeTransforms.trimSpacesInParagraphNodes(paragraph);
+  expect(
+    transformedNodes.map(x => TestHelpers.getDocNodeSnapshot(x))
+  ).toMatchSnapshot();
+});

--- a/tsdoc/src/__tests__/DocNodeTransforms.test.ts
+++ b/tsdoc/src/__tests__/DocNodeTransforms.test.ts
@@ -19,8 +19,8 @@ test('01 trimSpacesInParagraphNodes()', () => {
   const firstNode: DocNode = parserContext.docComment.summarySection.nodes[0];
   expect(firstNode.kind).toEqual(DocNodeKind.Paragraph);
   const paragraph: DocParagraph = firstNode as DocParagraph;
-  const transformedNodes: DocNode[] = DocNodeTransforms.trimSpacesInParagraphNodes(paragraph);
+  const transformedParagraph: DocParagraph = DocNodeTransforms.trimSpacesInParagraph(paragraph);
   expect(
-    transformedNodes.map(x => TestHelpers.getDocNodeSnapshot(x))
+    TestHelpers.getDocNodeSnapshot(transformedParagraph)
   ).toMatchSnapshot();
 });

--- a/tsdoc/src/__tests__/DocNodeTransforms.test.ts
+++ b/tsdoc/src/__tests__/DocNodeTransforms.test.ts
@@ -8,10 +8,9 @@ test('01 trimSpacesInParagraphNodes()', () => {
     '/**',
     ' *',
     ' *    This \t is    the',
-    ' * first   {@mylink}paragraph.',
-    ' * ',
-    ' *         This is the second',
-    ' *    paragraph.',
+    ' * first   {@mylink}sentence.',
+    ' *         This is another',
+    ' *sentence.  ',
     ' */'
   ].join('\n');
 

--- a/tsdoc/src/__tests__/ParagraphSplitter.test.ts
+++ b/tsdoc/src/__tests__/ParagraphSplitter.test.ts
@@ -1,6 +1,6 @@
 import { TestHelpers } from '../parser/__tests__/TestHelpers';
 import { ParagraphSplitter } from '../parser/ParagraphSplitter';
-import { DocSection, DocPlainText, DocSoftBreak, DocParagraph, DocBlockTag } from '../nodes';
+import { DocSection, DocPlainText, DocSoftBreak, DocParagraph, DocBlockTag } from '../index';
 
 test('01 Basic paragraph splitting', () => {
   TestHelpers.parseAndMatchDocCommentSnapshot([

--- a/tsdoc/src/__tests__/ParsingBasics.test.ts
+++ b/tsdoc/src/__tests__/ParsingBasics.test.ts
@@ -1,11 +1,12 @@
 import {
   StandardModifierTagSet,
   DocComment,
-  ParserContext
+  ParserContext,
+  TSDocParserConfiguration,
+  TSDocTagDefinition,
+  TSDocTagSyntaxKind
 } from '../index';
 import { TestHelpers } from '../parser/__tests__/TestHelpers';
-import { TSDocParserConfiguration } from '../parser/TSDocParserConfiguration';
-import { TSDocTagDefinition, TSDocTagSyntaxKind } from '../parser/TSDocTagDefinition';
 
 test('01 Simple @beta and @internal extraction', () => {
   const parserContext: ParserContext = TestHelpers.parseAndMatchDocCommentSnapshot([

--- a/tsdoc/src/__tests__/__snapshots__/DocNodeTransforms.test.ts.snap
+++ b/tsdoc/src/__tests__/__snapshots__/DocNodeTransforms.test.ts.snap
@@ -1,0 +1,36 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`01 trimSpacesInParagraphNodes() 1`] = `
+Array [
+  Object {
+    "kind": "PlainText",
+    "nodeExcerpt": "   This [t] is    the",
+    "nodePlainText": "This is the first",
+  },
+  Object {
+    "kind": "InlineTag",
+    "nodes": Array [
+      Object {
+        "kind": "Particle",
+        "nodeExcerpt": "{",
+      },
+      Object {
+        "kind": "Particle",
+        "nodeExcerpt": "@mylink",
+      },
+      Object {
+        "kind": "Particle",
+      },
+      Object {
+        "kind": "Particle",
+        "nodeExcerpt": "}",
+      },
+    ],
+  },
+  Object {
+    "kind": "PlainText",
+    "nodeExcerpt": "paragraph.",
+    "nodePlainText": " paragraph.",
+  },
+]
+`;

--- a/tsdoc/src/__tests__/__snapshots__/DocNodeTransforms.test.ts.snap
+++ b/tsdoc/src/__tests__/__snapshots__/DocNodeTransforms.test.ts.snap
@@ -5,7 +5,12 @@ Array [
   Object {
     "kind": "PlainText",
     "nodeExcerpt": "   This [t] is    the",
-    "nodePlainText": "This is the first",
+    "nodePlainText": "This is the",
+  },
+  Object {
+    "kind": "PlainText",
+    "nodeExcerpt": "first   ",
+    "nodePlainText": " first",
   },
   Object {
     "kind": "InlineTag",

--- a/tsdoc/src/__tests__/__snapshots__/DocNodeTransforms.test.ts.snap
+++ b/tsdoc/src/__tests__/__snapshots__/DocNodeTransforms.test.ts.snap
@@ -1,50 +1,53 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`01 trimSpacesInParagraphNodes() 1`] = `
-Array [
-  Object {
-    "kind": "PlainText",
-    "nodeExcerpt": "   This [t] is    the",
-    "nodePlainText": "This is the",
-  },
-  Object {
-    "kind": "PlainText",
-    "nodeExcerpt": "first   ",
-    "nodePlainText": " first ",
-  },
-  Object {
-    "kind": "InlineTag",
-    "nodes": Array [
-      Object {
-        "kind": "Particle",
-        "nodeExcerpt": "{",
-      },
-      Object {
-        "kind": "Particle",
-        "nodeExcerpt": "@mylink",
-      },
-      Object {
-        "kind": "Particle",
-      },
-      Object {
-        "kind": "Particle",
-        "nodeExcerpt": "}",
-      },
-    ],
-  },
-  Object {
-    "kind": "PlainText",
-    "nodeExcerpt": "sentence.",
-  },
-  Object {
-    "kind": "PlainText",
-    "nodeExcerpt": "        This is another",
-    "nodePlainText": " This is another",
-  },
-  Object {
-    "kind": "PlainText",
-    "nodeExcerpt": "sentence.",
-    "nodePlainText": " sentence.",
-  },
-]
+Object {
+  "kind": "Paragraph",
+  "nodes": Array [
+    Object {
+      "kind": "PlainText",
+      "nodeExcerpt": "   This [t] is    the",
+      "nodePlainText": "This is the",
+    },
+    Object {
+      "kind": "PlainText",
+      "nodeExcerpt": "first   ",
+      "nodePlainText": " first ",
+    },
+    Object {
+      "kind": "InlineTag",
+      "nodes": Array [
+        Object {
+          "kind": "Particle",
+          "nodeExcerpt": "{",
+        },
+        Object {
+          "kind": "Particle",
+          "nodeExcerpt": "@mylink",
+        },
+        Object {
+          "kind": "Particle",
+        },
+        Object {
+          "kind": "Particle",
+          "nodeExcerpt": "}",
+        },
+      ],
+    },
+    Object {
+      "kind": "PlainText",
+      "nodeExcerpt": "sentence.",
+    },
+    Object {
+      "kind": "PlainText",
+      "nodeExcerpt": "        This is another",
+      "nodePlainText": " This is another",
+    },
+    Object {
+      "kind": "PlainText",
+      "nodeExcerpt": "sentence.",
+      "nodePlainText": " sentence.",
+    },
+  ],
+}
 `;

--- a/tsdoc/src/__tests__/__snapshots__/DocNodeTransforms.test.ts.snap
+++ b/tsdoc/src/__tests__/__snapshots__/DocNodeTransforms.test.ts.snap
@@ -10,7 +10,7 @@ Array [
   Object {
     "kind": "PlainText",
     "nodeExcerpt": "first   ",
-    "nodePlainText": " first",
+    "nodePlainText": " first ",
   },
   Object {
     "kind": "InlineTag",
@@ -34,8 +34,17 @@ Array [
   },
   Object {
     "kind": "PlainText",
-    "nodeExcerpt": "paragraph.",
-    "nodePlainText": " paragraph.",
+    "nodeExcerpt": "sentence.",
+  },
+  Object {
+    "kind": "PlainText",
+    "nodeExcerpt": "        This is another",
+    "nodePlainText": " This is another",
+  },
+  Object {
+    "kind": "PlainText",
+    "nodeExcerpt": "sentence.",
+    "nodePlainText": " sentence.",
   },
 ]
 `;

--- a/tsdoc/src/__tests__/__snapshots__/ParagraphSplitter.test.ts.snap
+++ b/tsdoc/src/__tests__/__snapshots__/ParagraphSplitter.test.ts.snap
@@ -182,12 +182,14 @@ Object {
       "nodes": Array [
         Object {
           "kind": "PlainText",
+          "nodePlainText": "  para 1 ",
         },
         Object {
           "kind": "SoftBreak",
         },
         Object {
           "kind": "PlainText",
+          "nodePlainText": "   ",
         },
         Object {
           "kind": "SoftBreak",
@@ -199,15 +201,18 @@ Object {
       "nodes": Array [
         Object {
           "kind": "PlainText",
+          "nodePlainText": " [t]  ",
         },
         Object {
           "kind": "PlainText",
+          "nodePlainText": "   ",
         },
         Object {
           "kind": "BlockTag",
         },
         Object {
           "kind": "PlainText",
+          "nodePlainText": "  para 2 ",
         },
         Object {
           "kind": "SoftBreak",
@@ -222,6 +227,7 @@ Object {
       "nodes": Array [
         Object {
           "kind": "PlainText",
+          "nodePlainText": "  para 3  ",
         },
       ],
     },

--- a/tsdoc/src/index.ts
+++ b/tsdoc/src/index.ts
@@ -20,3 +20,5 @@ export {
   TSDocTagSyntaxKind,
   TSDocTagDefinition
 } from './parser/TSDocTagDefinition';
+
+export { DocNodeTransforms } from './transforms/DocNodeTransforms';

--- a/tsdoc/src/parser/__tests__/TestHelpers.ts
+++ b/tsdoc/src/parser/__tests__/TestHelpers.ts
@@ -3,7 +3,8 @@ import { TextRange } from '../TextRange';
 import {
   DocErrorText,
   DocNode,
-  DocComment
+  DocComment,
+  DocPlainText
 } from '../../nodes';
 import { ParserContext } from '../ParserContext';
 import { Excerpt } from '../Excerpt';
@@ -17,6 +18,10 @@ interface ISnapshotItem {
   errorLocationPrecedingToken?: string;
   nodeExcerpt?: string;
   nodeSpacing?: string;
+
+  // If it's a DocPlainText node and the plain text is different from the excerpt,
+  // this shows the DocPlainText.text
+  nodePlainText?: string;
   nodes?: ISnapshotItem[];
 }
 
@@ -141,6 +146,14 @@ export class TestHelpers {
       item.nodeExcerpt = TestHelpers.getEscaped(excerpt.content.toString());
       if (!excerpt.spacingAfterContent.isEmpty()) {
         item.nodeSpacing = TestHelpers.getEscaped(excerpt.spacingAfterContent.toString());
+      }
+    }
+
+    if (docNode instanceof DocPlainText) {
+      const docPlainText: DocPlainText = docNode as DocPlainText;
+      const nodePlainText: string = TestHelpers.getEscaped(docPlainText.text);
+      if (nodePlainText !== item.nodeExcerpt) {
+        item.nodePlainText = nodePlainText;
       }
     }
 

--- a/tsdoc/src/transforms/DocNodeTransforms.ts
+++ b/tsdoc/src/transforms/DocNodeTransforms.ts
@@ -1,0 +1,43 @@
+import { TrimSpacesTransform } from './TrimSpacesTransform';
+import { DocParagraph, DocNode } from '../nodes';
+
+/**
+ * Helper functions that transform DocNode trees.
+ */
+export class DocNodeTransforms {
+  /**
+   * The SpaceTrimmer collapses extra spacing characters from plain text nodes.
+   *
+   * @remark
+   * This is useful when emitting HTML, where any number of spaces are equivalent
+   * to a single space.  It's also useful when emitting Markdown, where spaces
+   * can be misinterpreted as an indented code block.
+   *
+   * For example, we might transform this:
+   *
+   * nodes: [
+   *   { kind: PlainText, text: "   Here   are some   " },
+   *   { kind: SoftBreak }
+   *   { kind: PlainText, text: "   words" },
+   *   { kind: SoftBreak }
+   *   { kind: InlineTag, text: "{\@inheritDoc}" },
+   *   { kind: PlainText, text: "to process." },
+   *   { kind: PlainText, text: "  " },
+   *   { kind: PlainText, text: "  " }
+   * ]
+   *
+   * ...to this:
+   *
+   * nodes: [
+   *   { kind: PlainText, text: "Here are some words " },
+   *   { kind: InlineTag, text: "{\@inheritDoc}" },
+   *   { kind: PlainText, text: "to process." }
+   * ]
+   *
+   * @param docParagraph - a DocParagraph containing nodes to be transformed
+   * @returns The transformed child nodes.
+   */
+  public static trimSpacesInParagraphNodes(docParagraph: DocParagraph): DocNode[] {
+    return TrimSpacesTransform.transform(docParagraph);
+  }
+}

--- a/tsdoc/src/transforms/DocNodeTransforms.ts
+++ b/tsdoc/src/transforms/DocNodeTransforms.ts
@@ -1,5 +1,5 @@
 import { TrimSpacesTransform } from './TrimSpacesTransform';
-import { DocParagraph, DocNode } from '../nodes';
+import { DocParagraph } from '../nodes';
 
 /**
  * Helper functions that transform DocNode trees.
@@ -45,7 +45,7 @@ export class DocNodeTransforms {
    * @param docParagraph - a DocParagraph containing nodes to be transformed
    * @returns The transformed child nodes.
    */
-  public static trimSpacesInParagraphNodes(docParagraph: DocParagraph): DocNode[] {
+  public static trimSpacesInParagraph(docParagraph: DocParagraph): DocParagraph {
     return TrimSpacesTransform.transform(docParagraph);
   }
 }

--- a/tsdoc/src/transforms/DocNodeTransforms.ts
+++ b/tsdoc/src/transforms/DocNodeTransforms.ts
@@ -6,7 +6,7 @@ import { DocParagraph, DocNode } from '../nodes';
  */
 export class DocNodeTransforms {
   /**
-   * The SpaceTrimmer collapses extra spacing characters from plain text nodes.
+   * trimSpacesInParagraphNodes() collapses extra spacing characters from plain text nodes.
    *
    * @remark
    * This is useful when emitting HTML, where any number of spaces are equivalent
@@ -15,6 +15,7 @@ export class DocNodeTransforms {
    *
    * For example, we might transform this:
    *
+   * ```
    * nodes: [
    *   { kind: PlainText, text: "   Here   are some   " },
    *   { kind: SoftBreak }
@@ -25,14 +26,21 @@ export class DocNodeTransforms {
    *   { kind: PlainText, text: "  " },
    *   { kind: PlainText, text: "  " }
    * ]
+   * ```
    *
    * ...to this:
    *
+   * ```
    * nodes: [
-   *   { kind: PlainText, text: "Here are some words " },
+   *   { kind: PlainText, text: "Here are some " },
+   *   { kind: PlainText, text: "words " },
    *   { kind: InlineTag, text: "{\@inheritDoc}" },
    *   { kind: PlainText, text: "to process." }
    * ]
+   * ```
+   *
+   * Note that in this example, `"words "` is not merged with the preceding node because
+   * its DocPlainText.excerpt cannot span multiple lines.
    *
    * @param docParagraph - a DocParagraph containing nodes to be transformed
    * @returns The transformed child nodes.

--- a/tsdoc/src/transforms/TrimSpacesTransform.ts
+++ b/tsdoc/src/transforms/TrimSpacesTransform.ts
@@ -12,7 +12,7 @@ import { TokenSequence } from '../parser/TokenSequence';
  * Implementation of DocNodeTransforms.trimSpacesInParagraphNodes()
  */
 export class TrimSpacesTransform {
-  public static transform(docParagraph: DocParagraph): DocNode[] {
+  public static transform(docParagraph: DocParagraph): DocParagraph {
     const transformedNodes: DocNode[] = [];
 
     // Whether the next nonempty node to be added needs a space before it
@@ -107,7 +107,9 @@ export class TrimSpacesTransform {
       accumulatedPlainTextNode = undefined;
     }
 
-    return transformedNodes;
+    const transformedParagraph: DocParagraph = new DocParagraph({ });
+    transformedParagraph.appendNodes(transformedNodes);
+    return transformedParagraph;
   }
 
   private static _canMergeExcerpts(currentExcerpt: Excerpt | undefined,

--- a/tsdoc/src/transforms/TrimSpacesTransform.ts
+++ b/tsdoc/src/transforms/TrimSpacesTransform.ts
@@ -1,0 +1,94 @@
+import {
+  DocParagraph,
+  DocNode,
+  DocNodeKind,
+  DocPlainText,
+  IDocPlainTextParameters
+} from '../nodes';
+
+/**
+ * Implementation of DocNodeTransforms.trimSpacesInParagraphNodes()
+ */
+export class TrimSpacesTransform {
+  public static transform(docParagraph: DocParagraph): DocNode[] {
+    const transformedNodes: DocNode[] = [];
+
+    // Whether the next nonempty node to be added needs a space before it
+    let pendingSpace: boolean = false;
+
+    // The DocPlainText node that we're currently accumulating
+    let accumulatedPlainTextNode: IDocPlainTextParameters | undefined = undefined;
+
+    // We always trim leading whitespace for a paragraph.  This flag gets set to true
+    // as soon as nonempty content is encountered.
+    let finishedSkippingLeadingSpaces: boolean = false;
+
+    for (const node of docParagraph.nodes) {
+      switch (node.kind) {
+        case DocNodeKind.PlainText:
+          const docPlainText: DocPlainText = node as DocPlainText;
+
+          const startedWithSpace: boolean = /^\s/.test(docPlainText.text);
+          const endedWithSpace: boolean = /\s$/.test(docPlainText.text);
+          const collapsedText: string = docPlainText.text.replace(/\s+/g, ' ').trim();
+
+          if (startedWithSpace && finishedSkippingLeadingSpaces) {
+            pendingSpace = true;
+          }
+
+          if (collapsedText.length > 0) {
+            // If we haven't started an accumulatedPlainTextNode, create it now
+            if (!accumulatedPlainTextNode) {
+              accumulatedPlainTextNode = {
+                excerpt: docPlainText.excerpt,
+                text: ''
+              };
+            }
+
+            if (pendingSpace) {
+              accumulatedPlainTextNode.text += ' ';
+              pendingSpace = false;
+            }
+
+            accumulatedPlainTextNode.text += collapsedText;
+            finishedSkippingLeadingSpaces = true;
+          }
+
+          if (endedWithSpace && finishedSkippingLeadingSpaces) {
+            pendingSpace = true;
+          }
+          break;
+        case DocNodeKind.SoftBreak:
+          if (finishedSkippingLeadingSpaces) {
+            pendingSpace = true;
+          }
+          break;
+        default:
+          if (pendingSpace) {
+            if (!accumulatedPlainTextNode) {
+              accumulatedPlainTextNode = {
+                excerpt: undefined,
+                text: ' '
+              };
+              pendingSpace = false;
+            }
+          }
+
+          // Push the accumulated text
+          if (accumulatedPlainTextNode) {
+            transformedNodes.push(new DocPlainText(accumulatedPlainTextNode));
+            accumulatedPlainTextNode = undefined;
+          }
+          transformedNodes.push(node);
+          finishedSkippingLeadingSpaces = true;
+      }
+    }
+
+    // Push the accumulated text
+    if (accumulatedPlainTextNode) {
+      transformedNodes.push(new DocPlainText(accumulatedPlainTextNode));
+    }
+
+    return transformedNodes;
+  }
+}

--- a/tsdoc/src/transforms/TrimSpacesTransform.ts
+++ b/tsdoc/src/transforms/TrimSpacesTransform.ts
@@ -78,13 +78,16 @@ export class TrimSpacesTransform {
           break;
         default:
           if (pendingSpace) {
+            // If we haven't started an accumulatedPlainTextNode, create it now
             if (!accumulatedPlainTextNode) {
               accumulatedPlainTextNode = {
                 excerpt: undefined,
-                text: ' '
+                text: ''
               };
-              pendingSpace = false;
             }
+
+            accumulatedPlainTextNode.text += ' ';
+            pendingSpace = false;
           }
 
           // Push the accumulated text
@@ -92,6 +95,7 @@ export class TrimSpacesTransform {
             transformedNodes.push(new DocPlainText(accumulatedPlainTextNode));
             accumulatedPlainTextNode = undefined;
           }
+
           transformedNodes.push(node);
           finishedSkippingLeadingSpaces = true;
       }


### PR DESCRIPTION
This PR implements a helper API for collapsing redundant spaces from the DocNode tree, which is useful when emitting HTML or Markdown output.