### PR TITLE
Fix missing space for DocFx under "Who's involved"

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ The collaborators currently driving the TSDoc standard are:
 - [TypeScript](http://www.typescriptlang.org) compiler group at Microsoft
 - [API Extractor](https://aka.ms/extractor) project owners
 - [TypeDoc](http://typedoc.org) maintainers
-- [DocFX](https://dotnet.github.io/docfx/)pipeline owners
+- [DocFX](https://dotnet.github.io/docfx/) pipeline owners
 - [SimplrJS](https://simplrjs.com/) developers, who maintain the [ts-docs-gen](https://github.com/SimplrJS/ts-docs-gen) tool
 - [Tom Dale](https://github.com/tomdale), who's working on the documentation engine for [Ember.js](https://www.emberjs.com), [Glimmer.js](https://glimmerjs.com), and other projects
 - [Rob Eisenberg](https://github.com/EisenbergEffect), who's working on the documentation engine for [Aurelia](http://aurelia.io/).


### PR DESCRIPTION
Super nit, but it caught my eye while reading the docs today.