### PR TITLE
Remove ParserContext.verbatimNodes and improve excerpt validation

### DIFF
--- a/tsdoc/src/__tests__/__snapshots__/ParagraphSplitter.test.ts.snap
+++ b/tsdoc/src/__tests__/__snapshots__/ParagraphSplitter.test.ts.snap
@@ -15,7 +15,8 @@ Object {
     "",
     "",
   ],
-  "_1_summarySection": Object {
+  "_1_gaps": Array [],
+  "_2_summarySection": Object {
     "kind": "Section",
     "nodes": Array [
       Object {
@@ -95,12 +96,12 @@ Object {
       },
     ],
   },
-  "_2_remarksBlock": undefined,
-  "_3_customBlocks": Array [],
-  "_4_paramBlocks": Array [],
-  "_5_returnsBlock": undefined,
-  "_6_modifierTags": Array [],
-  "_7_logMessages": Array [],
+  "_3_remarksBlock": undefined,
+  "_4_customBlocks": Array [],
+  "_5_paramBlocks": Array [],
+  "_6_returnsBlock": undefined,
+  "_7_modifierTags": Array [],
+  "_8_logMessages": Array [],
 }
 `;
 
@@ -112,7 +113,8 @@ Object {
     "",
     "  @public line 3",
   ],
-  "_1_summarySection": Object {
+  "_1_gaps": Array [],
+  "_2_summarySection": Object {
     "kind": "Section",
     "nodes": Array [
       Object {
@@ -159,17 +161,17 @@ Object {
       },
     ],
   },
-  "_2_remarksBlock": undefined,
-  "_3_customBlocks": Array [],
-  "_4_paramBlocks": Array [],
-  "_5_returnsBlock": undefined,
-  "_6_modifierTags": Array [
+  "_3_remarksBlock": undefined,
+  "_4_customBlocks": Array [],
+  "_5_paramBlocks": Array [],
+  "_6_returnsBlock": undefined,
+  "_7_modifierTags": Array [
     Object {
       "kind": "BlockTag",
       "nodeExcerpt": "@public",
     },
   ],
-  "_7_logMessages": Array [],
+  "_8_logMessages": Array [],
 }
 `;
 

--- a/tsdoc/src/__tests__/__snapshots__/ParsingBasics.test.ts.snap
+++ b/tsdoc/src/__tests__/__snapshots__/ParsingBasics.test.ts.snap
@@ -7,7 +7,10 @@ Object {
     "@unknownTag",
     "@internal @internal END",
   ],
-  "_1_summarySection": Object {
+  "_1_gaps": Array [
+    "@internal",
+  ],
+  "_2_summarySection": Object {
     "kind": "Section",
     "nodes": Array [
       Object {
@@ -45,11 +48,11 @@ Object {
       },
     ],
   },
-  "_2_remarksBlock": undefined,
-  "_3_customBlocks": Array [],
-  "_4_paramBlocks": Array [],
-  "_5_returnsBlock": undefined,
-  "_6_modifierTags": Array [
+  "_3_remarksBlock": undefined,
+  "_4_customBlocks": Array [],
+  "_5_paramBlocks": Array [],
+  "_6_returnsBlock": undefined,
+  "_7_modifierTags": Array [
     Object {
       "kind": "BlockTag",
       "nodeExcerpt": "@beta",
@@ -59,7 +62,7 @@ Object {
       "nodeExcerpt": "@internal",
     },
   ],
-  "_7_logMessages": Array [],
+  "_8_logMessages": Array [],
 }
 `;
 
@@ -80,7 +83,8 @@ Object {
     "",
     "@beta @customModifier",
   ],
-  "_1_summarySection": Object {
+  "_1_gaps": Array [],
+  "_2_summarySection": Object {
     "kind": "Section",
     "nodes": Array [
       Object {
@@ -102,7 +106,7 @@ Object {
       },
     ],
   },
-  "_2_remarksBlock": Object {
+  "_3_remarksBlock": Object {
     "kind": "Block",
     "nodes": Array [
       Object {
@@ -157,7 +161,7 @@ Object {
       },
     ],
   },
-  "_3_customBlocks": Array [
+  "_4_customBlocks": Array [
     Object {
       "kind": "Block",
       "nodes": Array [
@@ -193,7 +197,7 @@ Object {
       ],
     },
   ],
-  "_4_paramBlocks": Array [
+  "_5_paramBlocks": Array [
     Object {
       "kind": "ParamBlock",
       "nodes": Array [
@@ -261,7 +265,7 @@ Object {
       ],
     },
   ],
-  "_5_returnsBlock": Object {
+  "_6_returnsBlock": Object {
     "kind": "Block",
     "nodes": Array [
       Object {
@@ -333,7 +337,7 @@ Object {
       },
     ],
   },
-  "_6_modifierTags": Array [
+  "_7_modifierTags": Array [
     Object {
       "kind": "BlockTag",
       "nodeExcerpt": "@beta",
@@ -343,7 +347,7 @@ Object {
       "nodeExcerpt": "@customModifier",
     },
   ],
-  "_7_logMessages": Array [],
+  "_8_logMessages": Array [],
 }
 `;
 
@@ -354,12 +358,13 @@ Object {
     "@param y The second input number",
     "@returns The arithmetic mean of [c]x[c] and [c]y[c]",
   ],
-  "_1_summarySection": Object {
+  "_1_gaps": Array [],
+  "_2_summarySection": Object {
     "kind": "Section",
   },
-  "_2_remarksBlock": undefined,
-  "_3_customBlocks": Array [],
-  "_4_paramBlocks": Array [
+  "_3_remarksBlock": undefined,
+  "_4_customBlocks": Array [],
+  "_5_paramBlocks": Array [
     Object {
       "kind": "ParamBlock",
       "nodes": Array [
@@ -417,7 +422,7 @@ Object {
       ],
     },
   ],
-  "_5_returnsBlock": Object {
+  "_6_returnsBlock": Object {
     "kind": "Block",
     "nodes": Array [
       Object {
@@ -477,8 +482,8 @@ Object {
       },
     ],
   },
-  "_6_modifierTags": Array [],
-  "_7_logMessages": Array [
+  "_7_modifierTags": Array [],
+  "_8_logMessages": Array [
     "(2,4): The @param block should be followed by a parameter name",
     "(3,4): The @param block should be followed by a parameter name and then a hyphen",
   ],
@@ -496,7 +501,8 @@ Object {
     "@customBlock",
     "This is a custom block containing an @undefinedBlockTag",
   ],
-  "_1_summarySection": Object {
+  "_1_gaps": Array [],
+  "_2_summarySection": Object {
     "kind": "Section",
     "nodes": Array [
       Object {
@@ -510,7 +516,7 @@ Object {
       },
     ],
   },
-  "_2_remarksBlock": Object {
+  "_3_remarksBlock": Object {
     "kind": "Block",
     "nodes": Array [
       Object {
@@ -569,7 +575,7 @@ Object {
       },
     ],
   },
-  "_3_customBlocks": Array [
+  "_4_customBlocks": Array [
     Object {
       "kind": "Block",
       "nodes": Array [
@@ -601,7 +607,7 @@ Object {
       ],
     },
   ],
-  "_4_paramBlocks": Array [
+  "_5_paramBlocks": Array [
     Object {
       "kind": "ParamBlock",
       "nodes": Array [
@@ -665,7 +671,7 @@ Object {
       ],
     },
   ],
-  "_5_returnsBlock": Object {
+  "_6_returnsBlock": Object {
     "kind": "Block",
     "nodes": Array [
       Object {
@@ -725,7 +731,7 @@ Object {
       },
     ],
   },
-  "_6_modifierTags": Array [
+  "_7_modifierTags": Array [
     Object {
       "kind": "BlockTag",
       "nodeExcerpt": "@beta",
@@ -735,6 +741,6 @@ Object {
       "nodeExcerpt": "@customModifier",
     },
   ],
-  "_7_logMessages": Array [],
+  "_8_logMessages": Array [],
 }
 `;

--- a/tsdoc/src/parser/NodeParser.ts
+++ b/tsdoc/src/parser/NodeParser.ts
@@ -55,13 +55,11 @@ export class NodeParser {
   private static readonly htmlNameRegExp: RegExp = /^[a-z]+(\-[a-z]+)*$/i;
 
   private readonly _parserContext: ParserContext;
-  private readonly _verbatimNodes: DocNode[];
   private _currentSection: DocSection;
 
   public constructor(parserContext: ParserContext) {
     this._parserContext = parserContext;
 
-    this._verbatimNodes = parserContext.verbatimNodes;
     this._currentSection = parserContext.docComment.summarySection;
   }
 
@@ -177,10 +175,6 @@ export class NodeParser {
             this._addBlockToDocComment(newBlock);
 
             this._currentSection = newBlock;
-
-            // But for the verbatimNodes, add the DocBlockTag directly without folding it
-            // into a DocBlock
-            this._verbatimNodes.push(docBlockTag);
           }
 
           return;
@@ -188,7 +182,6 @@ export class NodeParser {
           // The block tag was recognized as a modifier, so add it to the modifier tag set
           // and do NOT call currentSection.appendNode(parsedNode)
           modifierTagSet.addTag(docBlockTag);
-          this._verbatimNodes.push(docBlockTag);
           return;
       }
     }
@@ -306,12 +299,10 @@ export class NodeParser {
 
   private _pushParagraphNode(docNode: DocNode): void {
     this._currentSection.appendNodeInParagraph(docNode);
-    this._verbatimNodes.push(docNode);
   }
 
   private _pushSectionNode(docNode: DocNode): void {
     this._currentSection.appendNode(docNode);
-    this._verbatimNodes.push(docNode);
   }
 
   private _parseBackslashEscape(tokenReader: TokenReader): DocNode {

--- a/tsdoc/src/parser/ParserContext.ts
+++ b/tsdoc/src/parser/ParserContext.ts
@@ -1,6 +1,6 @@
 import { TextRange } from './TextRange';
 import { Token } from './Token';
-import { DocComment, DocNode } from '../nodes';
+import { DocComment } from '../nodes';
 import { TSDocParserConfiguration } from './TSDocParserConfiguration';
 import { ParserMessageLog } from './ParserMessageLog';
 
@@ -36,18 +36,6 @@ export class ParserContext {
   public tokens: Token[] = [];
 
   /**
-   * A diagnostic list of all DocNode objects that were encountered during the first pass
-   * of the parser, in the order that they originally appeared in the input, with no gaps
-   * or overlap of token sequences.
-   *
-   * This linearity may be lost when the nodes are assembled into a DocComment, due to:
-   * - reordering/grouping of sections
-   * - deleting block tags that were moved to the ModifierTagSet
-   * - pruning of whitespace
-   */
-  public verbatimNodes: DocNode[];
-
-  /**
    * The parsed doc comment object.  This is the primary output of the parser.
    */
   public readonly docComment: DocComment;
@@ -60,8 +48,6 @@ export class ParserContext {
   public constructor(configuration: TSDocParserConfiguration, sourceRange: TextRange) {
     this.configuration = configuration;
     this.sourceRange = sourceRange;
-
-    this.verbatimNodes = [];
 
     this.docComment = new DocComment({ parserContext: this });
 

--- a/tsdoc/src/parser/__tests__/TestHelpers.ts
+++ b/tsdoc/src/parser/__tests__/TestHelpers.ts
@@ -94,12 +94,8 @@ export class TestHelpers {
       buffer: TestHelpers.getEscaped(buffer),
       lines: parserContext.lines.map(x => TestHelpers.getEscaped(x.toString())),
       logMessages: parserContext.log.messages.map(message => message.text),
-      verbatimNodes: parserContext.verbatimNodes.map(x => TestHelpers.getDocNodeSnapshot(x))
+      nodes: TestHelpers.getDocNodeSnapshot(parserContext.docComment)
     }).toMatchSnapshot();
-
-    expect(() => {
-      TestHelpers.validateLinearity(parserContext.verbatimNodes);
-    }).not.toThrow();
   }
 
   /**
@@ -122,10 +118,6 @@ export class TestHelpers {
       _6_modifierTags: docComment.modifierTagSet.nodes.map(x => TestHelpers.getDocNodeSnapshot(x)),
       _7_logMessages: parserContext.log.messages.map(message => message.text)
     }).toMatchSnapshot();
-
-    expect(() => {
-      TestHelpers.validateLinearity(parserContext.verbatimNodes);
-    }).not.toThrow();
 
     return parserContext;
   }

--- a/tsdoc/src/parser/__tests__/TokenCoverageChecker.ts
+++ b/tsdoc/src/parser/__tests__/TokenCoverageChecker.ts
@@ -8,6 +8,18 @@ interface ITokenAssociation {
   tokenSequence: TokenSequence;
 }
 
+/**
+ * The TokenCoverageChecker performs two diagnostics to detect parser bugs:
+ * 1. It checks for two DocNode objects whose excerpt contains overlapping tokens.
+ *    By design, a single character from the input stream should be associated with
+ *    at most one TokenSequence.
+ * 2. It checks for gaps, i.e. input tokens that were not associated with any DocNode
+ *    (that is reachable from the final DocCommon node tree).  In some cases this is
+ *    okay.  For example, if `@public` appears twice inside a comment, the second
+ *    redundant instance is ignored.  But in general we want to track the gaps in the
+ *    unit test snapshots to ensure in general that every input character is associated
+ *    with an excerpt for a DocNode.
+ */
 export class TokenCoverageChecker {
   private readonly _parserContext: ParserContext;
   private readonly _tokenAssocations: (ITokenAssociation | undefined)[];

--- a/tsdoc/src/parser/__tests__/TokenCoverageChecker.ts
+++ b/tsdoc/src/parser/__tests__/TokenCoverageChecker.ts
@@ -1,0 +1,140 @@
+import { DocNode, DocNodeLeaf } from '../../nodes';
+import { TokenSequence } from '../TokenSequence';
+import { ParserContext } from '../ParserContext';
+import { TokenKind, Token } from '../Token';
+
+interface ITokenAssociation {
+  docNode: DocNode;
+  tokenSequence: TokenSequence;
+}
+
+export class TokenCoverageChecker {
+  private readonly _parserContext: ParserContext;
+  private readonly _tokenAssocations: (ITokenAssociation | undefined)[];
+
+  public constructor(parserContext: ParserContext) {
+    this._parserContext = parserContext;
+    this._tokenAssocations = [];
+    this._tokenAssocations.length = parserContext.tokens.length;
+  }
+
+  public getGaps(rootNode: DocNode): TokenSequence[] {
+    this._addNodeTree(rootNode);
+    return this._checkForGaps(false);
+  }
+
+  public reportGaps(rootNode: DocNode): void {
+    this._addNodeTree(rootNode);
+    this._checkForGaps(true);
+  }
+
+  private _addNodeTree(node: DocNode): void {
+    if (node instanceof DocNodeLeaf) {
+      if (node.excerpt) {
+        if (node.excerpt.content) {
+          this._addSequence(node.excerpt.content, node);
+        }
+        if (node.excerpt.spacingAfterContent) {
+          this._addSequence(node.excerpt.spacingAfterContent, node);
+        }
+      }
+    }
+
+    for (const childNode of node.getChildNodes()) {
+      this._addNodeTree(childNode);
+    }
+  }
+
+  private _addSequence(tokenSequence: TokenSequence, docNode: DocNode): void {
+    const newTokenAssociation: ITokenAssociation = { docNode, tokenSequence };
+
+    for (let i: number = tokenSequence.startIndex; i < tokenSequence.endIndex; ++i) {
+      const tokenAssociation: ITokenAssociation | undefined = this._tokenAssocations[i];
+      if (tokenAssociation) {
+        throw new Error(`Overlapping content encountered between`
+          + ` ${this._formatTokenAssociation(tokenAssociation)} and`
+          + ` ${this._formatTokenAssociation(newTokenAssociation)}`);
+      }
+
+      this._tokenAssocations[i] = newTokenAssociation;
+    }
+  }
+
+  private _checkForGaps(reportGaps: boolean): TokenSequence[] {
+    const gaps: TokenSequence[] = [];
+
+    let gapStartIndex: number | undefined = undefined;
+    let tokenAssociationBeforeGap: ITokenAssociation | undefined = undefined;
+
+    const tokens: Token[] = this._parserContext.tokens;
+    if (tokens[tokens.length - 1].kind !== TokenKind.EndOfInput) {
+      throw new Error('Missing EndOfInput token');
+    }
+
+    for (let i: number = 0; i < this._parserContext.tokens.length - 1; ++i) {
+
+      const tokenAssociation: ITokenAssociation | undefined = this._tokenAssocations[i];
+
+      if (gapStartIndex === undefined) {
+        // No gap found yet
+
+        if (tokenAssociation) {
+          tokenAssociationBeforeGap = tokenAssociation;
+        } else {
+          // We found the start of a gap
+          gapStartIndex = i;
+        }
+      } else {
+        // Is this the end of the gap?
+        if (tokenAssociation) {
+          const gap: TokenSequence = new TokenSequence({
+            parserContext: this._parserContext,
+            startIndex: gapStartIndex,
+            endIndex: i
+          });
+          if (reportGaps) {
+            this._reportGap(gap, tokenAssociationBeforeGap, tokenAssociation);
+          }
+          gaps.push(gap);
+
+          gapStartIndex = undefined;
+          tokenAssociationBeforeGap = undefined;
+        }
+      }
+    }
+
+    if (gapStartIndex) {
+      const gap: TokenSequence = new TokenSequence({
+        parserContext: this._parserContext,
+        startIndex: gapStartIndex,
+        endIndex: this._parserContext.tokens.length
+      });
+      if (reportGaps) {
+        this._reportGap(gap, tokenAssociationBeforeGap, undefined);
+      }
+      gaps.push(gap);
+    }
+
+    return gaps;
+  }
+
+  private _reportGap(gap: TokenSequence, tokenAssociationBeforeGap: ITokenAssociation | undefined,
+    tokenAssociationAfterGap: ITokenAssociation | undefined): never {
+    let message: string = 'Gap encountered';
+
+    if (tokenAssociationBeforeGap) {
+      message += ' before ' + this._formatTokenAssociation(tokenAssociationBeforeGap);
+    }
+
+    if (tokenAssociationAfterGap) {
+      message += ' after ' + this._formatTokenAssociation(tokenAssociationAfterGap);
+    }
+
+    message += ': ' + JSON.stringify(gap.toString());
+    throw new Error(message);
+  }
+
+  private _formatTokenAssociation(tokenAssociation: ITokenAssociation): string {
+    return `${tokenAssociation.docNode.kind} (${JSON.stringify(tokenAssociation.tokenSequence.toString())})`;
+  }
+}

--- a/tsdoc/src/parser/__tests__/__snapshots__/NodeParserBasics.test.ts.snap
+++ b/tsdoc/src/parser/__tests__/__snapshots__/NodeParserBasics.test.ts.snap
@@ -8,24 +8,37 @@ Object {
     "line 2",
   ],
   "logMessages": Array [],
-  "verbatimNodes": Array [
-    Object {
-      "kind": "PlainText",
-      "nodeExcerpt": "line 1",
-    },
-    Object {
-      "kind": "SoftBreak",
-      "nodeExcerpt": "[n]",
-    },
-    Object {
-      "kind": "PlainText",
-      "nodeExcerpt": "line 2",
-    },
-    Object {
-      "kind": "SoftBreak",
-      "nodeExcerpt": "[n]",
-    },
-  ],
+  "nodes": Object {
+    "kind": "Comment",
+    "nodes": Array [
+      Object {
+        "kind": "Section",
+        "nodes": Array [
+          Object {
+            "kind": "Paragraph",
+            "nodes": Array [
+              Object {
+                "kind": "PlainText",
+                "nodeExcerpt": "line 1",
+              },
+              Object {
+                "kind": "SoftBreak",
+                "nodeExcerpt": "[n]",
+              },
+              Object {
+                "kind": "PlainText",
+                "nodeExcerpt": "line 2",
+              },
+              Object {
+                "kind": "SoftBreak",
+                "nodeExcerpt": "[n]",
+              },
+            ],
+          },
+        ],
+      },
+    ],
+  },
 }
 `;
 
@@ -34,7 +47,14 @@ Object {
   "buffer": "/***/",
   "lines": Array [],
   "logMessages": Array [],
-  "verbatimNodes": Array [],
+  "nodes": Object {
+    "kind": "Comment",
+    "nodes": Array [
+      Object {
+        "kind": "Section",
+      },
+    ],
+  },
 }
 `;
 
@@ -45,12 +65,25 @@ Object {
     "",
   ],
   "logMessages": Array [],
-  "verbatimNodes": Array [
-    Object {
-      "kind": "SoftBreak",
-      "nodeExcerpt": "[n]",
-    },
-  ],
+  "nodes": Object {
+    "kind": "Comment",
+    "nodes": Array [
+      Object {
+        "kind": "Section",
+        "nodes": Array [
+          Object {
+            "kind": "Paragraph",
+            "nodes": Array [
+              Object {
+                "kind": "SoftBreak",
+                "nodeExcerpt": "[n]",
+              },
+            ],
+          },
+        ],
+      },
+    ],
+  },
 }
 `;
 
@@ -62,16 +95,29 @@ Object {
     "",
   ],
   "logMessages": Array [],
-  "verbatimNodes": Array [
-    Object {
-      "kind": "SoftBreak",
-      "nodeExcerpt": "[n]",
-    },
-    Object {
-      "kind": "SoftBreak",
-      "nodeExcerpt": "[n]",
-    },
-  ],
+  "nodes": Object {
+    "kind": "Comment",
+    "nodes": Array [
+      Object {
+        "kind": "Section",
+        "nodes": Array [
+          Object {
+            "kind": "Paragraph",
+            "nodes": Array [
+              Object {
+                "kind": "SoftBreak",
+                "nodeExcerpt": "[n]",
+              },
+              Object {
+                "kind": "SoftBreak",
+                "nodeExcerpt": "[n]",
+              },
+            ],
+          },
+        ],
+      },
+    ],
+  },
 }
 `;
 
@@ -82,24 +128,37 @@ Object {
     "[b]$[b]@param",
   ],
   "logMessages": Array [],
-  "verbatimNodes": Array [
-    Object {
-      "kind": "EscapedText",
-      "nodeExcerpt": "[b]$",
-    },
-    Object {
-      "kind": "EscapedText",
-      "nodeExcerpt": "[b]@",
-    },
-    Object {
-      "kind": "PlainText",
-      "nodeExcerpt": "param",
-    },
-    Object {
-      "kind": "SoftBreak",
-      "nodeExcerpt": "[n]",
-    },
-  ],
+  "nodes": Object {
+    "kind": "Comment",
+    "nodes": Array [
+      Object {
+        "kind": "Section",
+        "nodes": Array [
+          Object {
+            "kind": "Paragraph",
+            "nodes": Array [
+              Object {
+                "kind": "EscapedText",
+                "nodeExcerpt": "[b]$",
+              },
+              Object {
+                "kind": "EscapedText",
+                "nodeExcerpt": "[b]@",
+              },
+              Object {
+                "kind": "PlainText",
+                "nodeExcerpt": "param",
+              },
+              Object {
+                "kind": "SoftBreak",
+                "nodeExcerpt": "[n]",
+              },
+            ],
+          },
+        ],
+      },
+    ],
+  },
 }
 `;
 
@@ -114,44 +173,57 @@ Object {
     "(2,22): A backslash can only be used to escape a punctuation character",
     "(2,38): A backslash can only be used to escape a punctuation character",
   ],
-  "verbatimNodes": Array [
-    Object {
-      "kind": "PlainText",
-      "nodeExcerpt": "letter: ",
-    },
-    Object {
-      "errorLocation": "[b]",
-      "errorLocationPrecedingToken": " ",
-      "errorMessage": "A backslash can only be used to escape a punctuation character",
-      "kind": "ErrorText",
-      "nodeExcerpt": "[b]",
-    },
-    Object {
-      "kind": "PlainText",
-      "nodeExcerpt": "A space: ",
-    },
-    Object {
-      "errorLocation": "[b]",
-      "errorLocationPrecedingToken": " ",
-      "errorMessage": "A backslash can only be used to escape a punctuation character",
-      "kind": "ErrorText",
-      "nodeExcerpt": "[b]",
-    },
-    Object {
-      "kind": "PlainText",
-      "nodeExcerpt": "  end of line: ",
-    },
-    Object {
-      "errorLocation": "[b]",
-      "errorLocationPrecedingToken": " ",
-      "errorMessage": "A backslash can only be used to escape a punctuation character",
-      "kind": "ErrorText",
-      "nodeExcerpt": "[b]",
-    },
-    Object {
-      "kind": "SoftBreak",
-      "nodeExcerpt": "[n]",
-    },
-  ],
+  "nodes": Object {
+    "kind": "Comment",
+    "nodes": Array [
+      Object {
+        "kind": "Section",
+        "nodes": Array [
+          Object {
+            "kind": "Paragraph",
+            "nodes": Array [
+              Object {
+                "kind": "PlainText",
+                "nodeExcerpt": "letter: ",
+              },
+              Object {
+                "errorLocation": "[b]",
+                "errorLocationPrecedingToken": " ",
+                "errorMessage": "A backslash can only be used to escape a punctuation character",
+                "kind": "ErrorText",
+                "nodeExcerpt": "[b]",
+              },
+              Object {
+                "kind": "PlainText",
+                "nodeExcerpt": "A space: ",
+              },
+              Object {
+                "errorLocation": "[b]",
+                "errorLocationPrecedingToken": " ",
+                "errorMessage": "A backslash can only be used to escape a punctuation character",
+                "kind": "ErrorText",
+                "nodeExcerpt": "[b]",
+              },
+              Object {
+                "kind": "PlainText",
+                "nodeExcerpt": "  end of line: ",
+              },
+              Object {
+                "errorLocation": "[b]",
+                "errorLocationPrecedingToken": " ",
+                "errorMessage": "A backslash can only be used to escape a punctuation character",
+                "kind": "ErrorText",
+                "nodeExcerpt": "[b]",
+              },
+              Object {
+                "kind": "SoftBreak",
+                "nodeExcerpt": "[n]",
+              },
+            ],
+          },
+        ],
+      },
+    ],
+  },
 }
 `;

--- a/tsdoc/src/parser/__tests__/__snapshots__/NodeParserBasics.test.ts.snap
+++ b/tsdoc/src/parser/__tests__/__snapshots__/NodeParserBasics.test.ts.snap
@@ -3,6 +3,7 @@
 exports[`00 Tokenizer simple case 1`] = `
 Object {
   "buffer": "/**[n] * line 1 [n] * line 2[n] */",
+  "gaps": Array [],
   "lines": Array [
     "line 1",
     "line 2",
@@ -45,6 +46,7 @@ Object {
 exports[`01 Tokenizer degenerate cases 1`] = `
 Object {
   "buffer": "/***/",
+  "gaps": Array [],
   "lines": Array [],
   "logMessages": Array [],
   "nodes": Object {
@@ -61,6 +63,7 @@ Object {
 exports[`01 Tokenizer degenerate cases 2`] = `
 Object {
   "buffer": "/**[n] *[n] */",
+  "gaps": Array [],
   "lines": Array [
     "",
   ],
@@ -90,6 +93,7 @@ Object {
 exports[`01 Tokenizer degenerate cases 3`] = `
 Object {
   "buffer": "/**[n] [n] [n] */",
+  "gaps": Array [],
   "lines": Array [
     "",
     "",
@@ -124,6 +128,7 @@ Object {
 exports[`02 Backslash escapes: positive examples 1`] = `
 Object {
   "buffer": "/**[n] * [b]$[b]@param[n] */",
+  "gaps": Array [],
   "lines": Array [
     "[b]$[b]@param",
   ],
@@ -165,6 +170,7 @@ Object {
 exports[`03 Backslash escapes: negative examples 1`] = `
 Object {
   "buffer": "/**[n] * letter: [b]A space: [b]  end of line: [b][n] */",
+  "gaps": Array [],
   "lines": Array [
     "letter: [b]A space: [b]  end of line: [b]",
   ],

--- a/tsdoc/src/parser/__tests__/__snapshots__/NodeParserCode.test.ts.snap
+++ b/tsdoc/src/parser/__tests__/__snapshots__/NodeParserCode.test.ts.snap
@@ -3,6 +3,7 @@
 exports[`00 Code span basic, positive 1`] = `
 Object {
   "buffer": "/**[n] * line [c]1[c][n] * line [c] 2[c] sdf[n] */",
+  "gaps": Array [],
   "lines": Array [
     "line [c]1[c]",
     "line [c] 2[c] sdf",
@@ -83,6 +84,7 @@ Object {
 exports[`01 Code span basic, negative 1`] = `
 Object {
   "buffer": "/**[n] * [c]multi[n] * line[c][n] */",
+  "gaps": Array [],
   "lines": Array [
     "[c]multi",
     "line[c]",
@@ -141,6 +143,7 @@ Object {
 exports[`01 Code span basic, negative 2`] = `
 Object {
   "buffer": "/**[n] * one[c]two[n] * [c]three[c]four[n] */",
+  "gaps": Array [],
   "lines": Array [
     "one[c]two",
     "[c]three[c]four",
@@ -216,6 +219,7 @@ Object {
 exports[`03 Code fence, positive 1`] = `
 Object {
   "buffer": "/**[n] * This is a code fence with all parts:[n] * [c][c][c]a language!   [n] *   some [c]code[c] here[n] * [c][c][c]   [n] */",
+  "gaps": Array [],
   "lines": Array [
     "This is a code fence with all parts:",
     "[c][c][c]a language!",
@@ -275,6 +279,7 @@ Object {
 exports[`03 Code fence, positive 2`] = `
 Object {
   "buffer": "/**[n] * This is a code fence with no language or trailing whitespace:[n] * [c][c][c][n] *   some [c]code[c] here[n] * [c][c][c]*/",
+  "gaps": Array [],
   "lines": Array [
     "This is a code fence with no language or trailing whitespace:",
     "[c][c][c]",
@@ -334,6 +339,7 @@ Object {
 exports[`04 Code fence, negative 1`] = `
 Object {
   "buffer": "/**[n] * Code fence incorrectly indented:[n] *    [c][c][c][n] */",
+  "gaps": Array [],
   "lines": Array [
     "Code fence incorrectly indented:",
     "   [c][c][c]",
@@ -390,6 +396,7 @@ Object {
 exports[`04 Code fence, negative 2`] = `
 Object {
   "buffer": "/**[n] * Code fence not starting the line:[n] *a[c][c][c][n] */",
+  "gaps": Array [],
   "lines": Array [
     "Code fence not starting the line:",
     "a[c][c][c]",
@@ -446,6 +453,7 @@ Object {
 exports[`04 Code fence, negative 3`] = `
 Object {
   "buffer": "/**[n] * Code fence not being terminated 1:[n] * [c][c][c]*/",
+  "gaps": Array [],
   "lines": Array [
     "Code fence not being terminated 1:",
     "[c][c][c]",
@@ -499,6 +507,7 @@ Object {
 exports[`04 Code fence, negative 4`] = `
 Object {
   "buffer": "/**[n] * Code fence not being terminated 2:[n] * [c][c][c] some stuff[n] */",
+  "gaps": Array [],
   "lines": Array [
     "Code fence not being terminated 2:",
     "[c][c][c] some stuff",
@@ -556,6 +565,7 @@ Object {
 exports[`04 Code fence, negative 5`] = `
 Object {
   "buffer": "/**[n] * Language having backticks:[n] * [c][c][c] some stuff [c][c][c][n] */",
+  "gaps": Array [],
   "lines": Array [
     "Language having backticks:",
     "[c][c][c] some stuff [c][c][c]",
@@ -625,6 +635,7 @@ Object {
 exports[`04 Code fence, negative 6`] = `
 Object {
   "buffer": "/**[n] * Closing delimiter being indented:[n] * [c][c][c][n] * code[n] *      [c][c][c][n] */",
+  "gaps": Array [],
   "lines": Array [
     "Closing delimiter being indented:",
     "[c][c][c]",
@@ -686,6 +697,7 @@ Object {
 exports[`04 Code fence, negative 7`] = `
 Object {
   "buffer": "/**[n] * Closing delimiter not being on a line by itself:[n] * [c][c][c][n] * code[n] * [c][c][c]  a[n] */",
+  "gaps": Array [],
   "lines": Array [
     "Closing delimiter not being on a line by itself:",
     "[c][c][c]",

--- a/tsdoc/src/parser/__tests__/__snapshots__/NodeParserCode.test.ts.snap
+++ b/tsdoc/src/parser/__tests__/__snapshots__/NodeParserCode.test.ts.snap
@@ -8,62 +8,75 @@ Object {
     "line [c] 2[c] sdf",
   ],
   "logMessages": Array [],
-  "verbatimNodes": Array [
-    Object {
-      "kind": "PlainText",
-      "nodeExcerpt": "line ",
-    },
-    Object {
-      "kind": "CodeSpan",
-      "nodes": Array [
-        Object {
-          "kind": "Particle",
-          "nodeExcerpt": "[c]",
-        },
-        Object {
-          "kind": "Particle",
-          "nodeExcerpt": "1",
-        },
-        Object {
-          "kind": "Particle",
-          "nodeExcerpt": "[c]",
-        },
-      ],
-    },
-    Object {
-      "kind": "SoftBreak",
-      "nodeExcerpt": "[n]",
-    },
-    Object {
-      "kind": "PlainText",
-      "nodeExcerpt": "line ",
-    },
-    Object {
-      "kind": "CodeSpan",
-      "nodes": Array [
-        Object {
-          "kind": "Particle",
-          "nodeExcerpt": "[c]",
-        },
-        Object {
-          "kind": "Particle",
-          "nodeExcerpt": " 2",
-        },
-        Object {
-          "kind": "Particle",
-          "nodeExcerpt": "[c]",
-        },
-      ],
-    },
-    Object {
-      "kind": "PlainText",
-      "nodeExcerpt": " sdf",
-    },
-    Object {
-      "kind": "SoftBreak",
-      "nodeExcerpt": "[n]",
-    },
-  ],
+  "nodes": Object {
+    "kind": "Comment",
+    "nodes": Array [
+      Object {
+        "kind": "Section",
+        "nodes": Array [
+          Object {
+            "kind": "Paragraph",
+            "nodes": Array [
+              Object {
+                "kind": "PlainText",
+                "nodeExcerpt": "line ",
+              },
+              Object {
+                "kind": "CodeSpan",
+                "nodes": Array [
+                  Object {
+                    "kind": "Particle",
+                    "nodeExcerpt": "[c]",
+                  },
+                  Object {
+                    "kind": "Particle",
+                    "nodeExcerpt": "1",
+                  },
+                  Object {
+                    "kind": "Particle",
+                    "nodeExcerpt": "[c]",
+                  },
+                ],
+              },
+              Object {
+                "kind": "SoftBreak",
+                "nodeExcerpt": "[n]",
+              },
+              Object {
+                "kind": "PlainText",
+                "nodeExcerpt": "line ",
+              },
+              Object {
+                "kind": "CodeSpan",
+                "nodes": Array [
+                  Object {
+                    "kind": "Particle",
+                    "nodeExcerpt": "[c]",
+                  },
+                  Object {
+                    "kind": "Particle",
+                    "nodeExcerpt": " 2",
+                  },
+                  Object {
+                    "kind": "Particle",
+                    "nodeExcerpt": "[c]",
+                  },
+                ],
+              },
+              Object {
+                "kind": "PlainText",
+                "nodeExcerpt": " sdf",
+              },
+              Object {
+                "kind": "SoftBreak",
+                "nodeExcerpt": "[n]",
+              },
+            ],
+          },
+        ],
+      },
+    ],
+  },
 }
 `;
 
@@ -78,37 +91,50 @@ Object {
     "(2,4): The code span is missing its closing backtick",
     "(3,8): The opening backtick for a code span must be preceded by whitespace",
   ],
-  "verbatimNodes": Array [
-    Object {
-      "errorLocation": "[c]",
-      "errorMessage": "The code span is missing its closing backtick",
-      "kind": "ErrorText",
-      "nodeExcerpt": "[c]",
-    },
-    Object {
-      "kind": "PlainText",
-      "nodeExcerpt": "multi",
-    },
-    Object {
-      "kind": "SoftBreak",
-      "nodeExcerpt": "[n]",
-    },
-    Object {
-      "kind": "PlainText",
-      "nodeExcerpt": "line",
-    },
-    Object {
-      "errorLocation": "[c]",
-      "errorLocationPrecedingToken": "line",
-      "errorMessage": "The opening backtick for a code span must be preceded by whitespace",
-      "kind": "ErrorText",
-      "nodeExcerpt": "[c]",
-    },
-    Object {
-      "kind": "SoftBreak",
-      "nodeExcerpt": "[n]",
-    },
-  ],
+  "nodes": Object {
+    "kind": "Comment",
+    "nodes": Array [
+      Object {
+        "kind": "Section",
+        "nodes": Array [
+          Object {
+            "kind": "Paragraph",
+            "nodes": Array [
+              Object {
+                "errorLocation": "[c]",
+                "errorMessage": "The code span is missing its closing backtick",
+                "kind": "ErrorText",
+                "nodeExcerpt": "[c]",
+              },
+              Object {
+                "kind": "PlainText",
+                "nodeExcerpt": "multi",
+              },
+              Object {
+                "kind": "SoftBreak",
+                "nodeExcerpt": "[n]",
+              },
+              Object {
+                "kind": "PlainText",
+                "nodeExcerpt": "line",
+              },
+              Object {
+                "errorLocation": "[c]",
+                "errorLocationPrecedingToken": "line",
+                "errorMessage": "The opening backtick for a code span must be preceded by whitespace",
+                "kind": "ErrorText",
+                "nodeExcerpt": "[c]",
+              },
+              Object {
+                "kind": "SoftBreak",
+                "nodeExcerpt": "[n]",
+              },
+            ],
+          },
+        ],
+      },
+    ],
+  },
 }
 `;
 
@@ -124,53 +150,66 @@ Object {
     "(3,4): Error parsing code span: The closing backtick for a code span must be followed by whitespace",
     "(3,10): The opening backtick for a code span must be preceded by whitespace",
   ],
-  "verbatimNodes": Array [
-    Object {
-      "kind": "PlainText",
-      "nodeExcerpt": "one",
-    },
-    Object {
-      "errorLocation": "[c]",
-      "errorLocationPrecedingToken": "one",
-      "errorMessage": "The opening backtick for a code span must be preceded by whitespace",
-      "kind": "ErrorText",
-      "nodeExcerpt": "[c]",
-    },
-    Object {
-      "kind": "PlainText",
-      "nodeExcerpt": "two",
-    },
-    Object {
-      "kind": "SoftBreak",
-      "nodeExcerpt": "[n]",
-    },
-    Object {
-      "errorLocation": "[c]",
-      "errorLocationPrecedingToken": "three",
-      "errorMessage": "Error parsing code span: The closing backtick for a code span must be followed by whitespace",
-      "kind": "ErrorText",
-      "nodeExcerpt": "[c]",
-    },
-    Object {
-      "kind": "PlainText",
-      "nodeExcerpt": "three",
-    },
-    Object {
-      "errorLocation": "[c]",
-      "errorLocationPrecedingToken": "three",
-      "errorMessage": "The opening backtick for a code span must be preceded by whitespace",
-      "kind": "ErrorText",
-      "nodeExcerpt": "[c]",
-    },
-    Object {
-      "kind": "PlainText",
-      "nodeExcerpt": "four",
-    },
-    Object {
-      "kind": "SoftBreak",
-      "nodeExcerpt": "[n]",
-    },
-  ],
+  "nodes": Object {
+    "kind": "Comment",
+    "nodes": Array [
+      Object {
+        "kind": "Section",
+        "nodes": Array [
+          Object {
+            "kind": "Paragraph",
+            "nodes": Array [
+              Object {
+                "kind": "PlainText",
+                "nodeExcerpt": "one",
+              },
+              Object {
+                "errorLocation": "[c]",
+                "errorLocationPrecedingToken": "one",
+                "errorMessage": "The opening backtick for a code span must be preceded by whitespace",
+                "kind": "ErrorText",
+                "nodeExcerpt": "[c]",
+              },
+              Object {
+                "kind": "PlainText",
+                "nodeExcerpt": "two",
+              },
+              Object {
+                "kind": "SoftBreak",
+                "nodeExcerpt": "[n]",
+              },
+              Object {
+                "errorLocation": "[c]",
+                "errorLocationPrecedingToken": "three",
+                "errorMessage": "Error parsing code span: The closing backtick for a code span must be followed by whitespace",
+                "kind": "ErrorText",
+                "nodeExcerpt": "[c]",
+              },
+              Object {
+                "kind": "PlainText",
+                "nodeExcerpt": "three",
+              },
+              Object {
+                "errorLocation": "[c]",
+                "errorLocationPrecedingToken": "three",
+                "errorMessage": "The opening backtick for a code span must be preceded by whitespace",
+                "kind": "ErrorText",
+                "nodeExcerpt": "[c]",
+              },
+              Object {
+                "kind": "PlainText",
+                "nodeExcerpt": "four",
+              },
+              Object {
+                "kind": "SoftBreak",
+                "nodeExcerpt": "[n]",
+              },
+            ],
+          },
+        ],
+      },
+    ],
+  },
 }
 `;
 
@@ -184,39 +223,52 @@ Object {
     "[c][c][c]",
   ],
   "logMessages": Array [],
-  "verbatimNodes": Array [
-    Object {
-      "kind": "PlainText",
-      "nodeExcerpt": "This is a code fence with all parts:",
-    },
-    Object {
-      "kind": "SoftBreak",
-      "nodeExcerpt": "[n]",
-    },
-    Object {
-      "kind": "CodeFence",
-      "nodes": Array [
-        Object {
-          "kind": "Particle",
-          "nodeExcerpt": "[c][c][c]",
-        },
-        Object {
-          "kind": "Particle",
-          "nodeExcerpt": "a language!",
-          "nodeSpacing": "[n]",
-        },
-        Object {
-          "kind": "Particle",
-          "nodeExcerpt": "  some [c]code[c] here[n]",
-        },
-        Object {
-          "kind": "Particle",
-          "nodeExcerpt": "[c][c][c]",
-          "nodeSpacing": "[n]",
-        },
-      ],
-    },
-  ],
+  "nodes": Object {
+    "kind": "Comment",
+    "nodes": Array [
+      Object {
+        "kind": "Section",
+        "nodes": Array [
+          Object {
+            "kind": "Paragraph",
+            "nodes": Array [
+              Object {
+                "kind": "PlainText",
+                "nodeExcerpt": "This is a code fence with all parts:",
+              },
+              Object {
+                "kind": "SoftBreak",
+                "nodeExcerpt": "[n]",
+              },
+            ],
+          },
+          Object {
+            "kind": "CodeFence",
+            "nodes": Array [
+              Object {
+                "kind": "Particle",
+                "nodeExcerpt": "[c][c][c]",
+              },
+              Object {
+                "kind": "Particle",
+                "nodeExcerpt": "a language!",
+                "nodeSpacing": "[n]",
+              },
+              Object {
+                "kind": "Particle",
+                "nodeExcerpt": "  some [c]code[c] here[n]",
+              },
+              Object {
+                "kind": "Particle",
+                "nodeExcerpt": "[c][c][c]",
+                "nodeSpacing": "[n]",
+              },
+            ],
+          },
+        ],
+      },
+    ],
+  },
 }
 `;
 
@@ -230,39 +282,52 @@ Object {
     "[c][c][c]",
   ],
   "logMessages": Array [],
-  "verbatimNodes": Array [
-    Object {
-      "kind": "PlainText",
-      "nodeExcerpt": "This is a code fence with no language or trailing whitespace:",
-    },
-    Object {
-      "kind": "SoftBreak",
-      "nodeExcerpt": "[n]",
-    },
-    Object {
-      "kind": "CodeFence",
-      "nodes": Array [
-        Object {
-          "kind": "Particle",
-          "nodeExcerpt": "[c][c][c]",
-        },
-        Object {
-          "kind": "Particle",
-          "nodeExcerpt": "",
-          "nodeSpacing": "[n]",
-        },
-        Object {
-          "kind": "Particle",
-          "nodeExcerpt": "  some [c]code[c] here[n]",
-        },
-        Object {
-          "kind": "Particle",
-          "nodeExcerpt": "[c][c][c]",
-          "nodeSpacing": "[n]",
-        },
-      ],
-    },
-  ],
+  "nodes": Object {
+    "kind": "Comment",
+    "nodes": Array [
+      Object {
+        "kind": "Section",
+        "nodes": Array [
+          Object {
+            "kind": "Paragraph",
+            "nodes": Array [
+              Object {
+                "kind": "PlainText",
+                "nodeExcerpt": "This is a code fence with no language or trailing whitespace:",
+              },
+              Object {
+                "kind": "SoftBreak",
+                "nodeExcerpt": "[n]",
+              },
+            ],
+          },
+          Object {
+            "kind": "CodeFence",
+            "nodes": Array [
+              Object {
+                "kind": "Particle",
+                "nodeExcerpt": "[c][c][c]",
+              },
+              Object {
+                "kind": "Particle",
+                "nodeExcerpt": "",
+                "nodeSpacing": "[n]",
+              },
+              Object {
+                "kind": "Particle",
+                "nodeExcerpt": "  some [c]code[c] here[n]",
+              },
+              Object {
+                "kind": "Particle",
+                "nodeExcerpt": "[c][c][c]",
+                "nodeSpacing": "[n]",
+              },
+            ],
+          },
+        ],
+      },
+    ],
+  },
 }
 `;
 
@@ -276,31 +341,49 @@ Object {
   "logMessages": Array [
     "(3,7): The opening backtick for a code fence must appear at the start of the line",
   ],
-  "verbatimNodes": Array [
-    Object {
-      "kind": "PlainText",
-      "nodeExcerpt": "Code fence incorrectly indented:",
-    },
-    Object {
-      "kind": "SoftBreak",
-      "nodeExcerpt": "[n]",
-    },
-    Object {
-      "kind": "PlainText",
-      "nodeExcerpt": "   ",
-    },
-    Object {
-      "errorLocation": "[c][c][c]",
-      "errorLocationPrecedingToken": "   ",
-      "errorMessage": "The opening backtick for a code fence must appear at the start of the line",
-      "kind": "ErrorText",
-      "nodeExcerpt": "[c][c][c]",
-    },
-    Object {
-      "kind": "SoftBreak",
-      "nodeExcerpt": "[n]",
-    },
-  ],
+  "nodes": Object {
+    "kind": "Comment",
+    "nodes": Array [
+      Object {
+        "kind": "Section",
+        "nodes": Array [
+          Object {
+            "kind": "Paragraph",
+            "nodes": Array [
+              Object {
+                "kind": "PlainText",
+                "nodeExcerpt": "Code fence incorrectly indented:",
+              },
+              Object {
+                "kind": "SoftBreak",
+                "nodeExcerpt": "[n]",
+              },
+              Object {
+                "kind": "PlainText",
+                "nodeExcerpt": "   ",
+              },
+            ],
+          },
+          Object {
+            "errorLocation": "[c][c][c]",
+            "errorLocationPrecedingToken": "   ",
+            "errorMessage": "The opening backtick for a code fence must appear at the start of the line",
+            "kind": "ErrorText",
+            "nodeExcerpt": "[c][c][c]",
+          },
+          Object {
+            "kind": "Paragraph",
+            "nodes": Array [
+              Object {
+                "kind": "SoftBreak",
+                "nodeExcerpt": "[n]",
+              },
+            ],
+          },
+        ],
+      },
+    ],
+  },
 }
 `;
 
@@ -314,31 +397,49 @@ Object {
   "logMessages": Array [
     "(3,4): The opening backtick for a code fence must appear at the start of the line",
   ],
-  "verbatimNodes": Array [
-    Object {
-      "kind": "PlainText",
-      "nodeExcerpt": "Code fence not starting the line:",
-    },
-    Object {
-      "kind": "SoftBreak",
-      "nodeExcerpt": "[n]",
-    },
-    Object {
-      "kind": "PlainText",
-      "nodeExcerpt": "a",
-    },
-    Object {
-      "errorLocation": "[c][c][c]",
-      "errorLocationPrecedingToken": "a",
-      "errorMessage": "The opening backtick for a code fence must appear at the start of the line",
-      "kind": "ErrorText",
-      "nodeExcerpt": "[c][c][c]",
-    },
-    Object {
-      "kind": "SoftBreak",
-      "nodeExcerpt": "[n]",
-    },
-  ],
+  "nodes": Object {
+    "kind": "Comment",
+    "nodes": Array [
+      Object {
+        "kind": "Section",
+        "nodes": Array [
+          Object {
+            "kind": "Paragraph",
+            "nodes": Array [
+              Object {
+                "kind": "PlainText",
+                "nodeExcerpt": "Code fence not starting the line:",
+              },
+              Object {
+                "kind": "SoftBreak",
+                "nodeExcerpt": "[n]",
+              },
+              Object {
+                "kind": "PlainText",
+                "nodeExcerpt": "a",
+              },
+            ],
+          },
+          Object {
+            "errorLocation": "[c][c][c]",
+            "errorLocationPrecedingToken": "a",
+            "errorMessage": "The opening backtick for a code fence must appear at the start of the line",
+            "kind": "ErrorText",
+            "nodeExcerpt": "[c][c][c]",
+          },
+          Object {
+            "kind": "Paragraph",
+            "nodes": Array [
+              Object {
+                "kind": "SoftBreak",
+                "nodeExcerpt": "[n]",
+              },
+            ],
+          },
+        ],
+      },
+    ],
+  },
 }
 `;
 
@@ -352,28 +453,46 @@ Object {
   "logMessages": Array [
     "(3,4): Error parsing code fence: Missing closing delimiter",
   ],
-  "verbatimNodes": Array [
-    Object {
-      "kind": "PlainText",
-      "nodeExcerpt": "Code fence not being terminated 1:",
-    },
-    Object {
-      "kind": "SoftBreak",
-      "nodeExcerpt": "[n]",
-    },
-    Object {
-      "errorLocation": "",
-      "errorLocationPrecedingToken": "
+  "nodes": Object {
+    "kind": "Comment",
+    "nodes": Array [
+      Object {
+        "kind": "Section",
+        "nodes": Array [
+          Object {
+            "kind": "Paragraph",
+            "nodes": Array [
+              Object {
+                "kind": "PlainText",
+                "nodeExcerpt": "Code fence not being terminated 1:",
+              },
+              Object {
+                "kind": "SoftBreak",
+                "nodeExcerpt": "[n]",
+              },
+            ],
+          },
+          Object {
+            "errorLocation": "",
+            "errorLocationPrecedingToken": "
 ",
-      "errorMessage": "Error parsing code fence: Missing closing delimiter",
-      "kind": "ErrorText",
-      "nodeExcerpt": "[c][c][c]",
-    },
-    Object {
-      "kind": "SoftBreak",
-      "nodeExcerpt": "[n]",
-    },
-  ],
+            "errorMessage": "Error parsing code fence: Missing closing delimiter",
+            "kind": "ErrorText",
+            "nodeExcerpt": "[c][c][c]",
+          },
+          Object {
+            "kind": "Paragraph",
+            "nodes": Array [
+              Object {
+                "kind": "SoftBreak",
+                "nodeExcerpt": "[n]",
+              },
+            ],
+          },
+        ],
+      },
+    ],
+  },
 }
 `;
 
@@ -387,32 +506,50 @@ Object {
   "logMessages": Array [
     "(3,4): Error parsing code fence: Missing closing delimiter",
   ],
-  "verbatimNodes": Array [
-    Object {
-      "kind": "PlainText",
-      "nodeExcerpt": "Code fence not being terminated 2:",
-    },
-    Object {
-      "kind": "SoftBreak",
-      "nodeExcerpt": "[n]",
-    },
-    Object {
-      "errorLocation": "",
-      "errorLocationPrecedingToken": "
+  "nodes": Object {
+    "kind": "Comment",
+    "nodes": Array [
+      Object {
+        "kind": "Section",
+        "nodes": Array [
+          Object {
+            "kind": "Paragraph",
+            "nodes": Array [
+              Object {
+                "kind": "PlainText",
+                "nodeExcerpt": "Code fence not being terminated 2:",
+              },
+              Object {
+                "kind": "SoftBreak",
+                "nodeExcerpt": "[n]",
+              },
+            ],
+          },
+          Object {
+            "errorLocation": "",
+            "errorLocationPrecedingToken": "
 ",
-      "errorMessage": "Error parsing code fence: Missing closing delimiter",
-      "kind": "ErrorText",
-      "nodeExcerpt": "[c][c][c]",
-    },
-    Object {
-      "kind": "PlainText",
-      "nodeExcerpt": " some stuff",
-    },
-    Object {
-      "kind": "SoftBreak",
-      "nodeExcerpt": "[n]",
-    },
-  ],
+            "errorMessage": "Error parsing code fence: Missing closing delimiter",
+            "kind": "ErrorText",
+            "nodeExcerpt": "[c][c][c]",
+          },
+          Object {
+            "kind": "Paragraph",
+            "nodes": Array [
+              Object {
+                "kind": "PlainText",
+                "nodeExcerpt": " some stuff",
+              },
+              Object {
+                "kind": "SoftBreak",
+                "nodeExcerpt": "[n]",
+              },
+            ],
+          },
+        ],
+      },
+    ],
+  },
 }
 `;
 
@@ -427,38 +564,61 @@ Object {
     "(3,4): Error parsing code fence: The language specifier cannot contain backtick characters",
     "(3,19): The opening backtick for a code fence must appear at the start of the line",
   ],
-  "verbatimNodes": Array [
-    Object {
-      "kind": "PlainText",
-      "nodeExcerpt": "Language having backticks:",
-    },
-    Object {
-      "kind": "SoftBreak",
-      "nodeExcerpt": "[n]",
-    },
-    Object {
-      "errorLocation": "[c]",
-      "errorLocationPrecedingToken": " ",
-      "errorMessage": "Error parsing code fence: The language specifier cannot contain backtick characters",
-      "kind": "ErrorText",
-      "nodeExcerpt": "[c][c][c]",
-    },
-    Object {
-      "kind": "PlainText",
-      "nodeExcerpt": " some stuff ",
-    },
-    Object {
-      "errorLocation": "[c][c][c]",
-      "errorLocationPrecedingToken": " ",
-      "errorMessage": "The opening backtick for a code fence must appear at the start of the line",
-      "kind": "ErrorText",
-      "nodeExcerpt": "[c][c][c]",
-    },
-    Object {
-      "kind": "SoftBreak",
-      "nodeExcerpt": "[n]",
-    },
-  ],
+  "nodes": Object {
+    "kind": "Comment",
+    "nodes": Array [
+      Object {
+        "kind": "Section",
+        "nodes": Array [
+          Object {
+            "kind": "Paragraph",
+            "nodes": Array [
+              Object {
+                "kind": "PlainText",
+                "nodeExcerpt": "Language having backticks:",
+              },
+              Object {
+                "kind": "SoftBreak",
+                "nodeExcerpt": "[n]",
+              },
+            ],
+          },
+          Object {
+            "errorLocation": "[c]",
+            "errorLocationPrecedingToken": " ",
+            "errorMessage": "Error parsing code fence: The language specifier cannot contain backtick characters",
+            "kind": "ErrorText",
+            "nodeExcerpt": "[c][c][c]",
+          },
+          Object {
+            "kind": "Paragraph",
+            "nodes": Array [
+              Object {
+                "kind": "PlainText",
+                "nodeExcerpt": " some stuff ",
+              },
+            ],
+          },
+          Object {
+            "errorLocation": "[c][c][c]",
+            "errorLocationPrecedingToken": " ",
+            "errorMessage": "The opening backtick for a code fence must appear at the start of the line",
+            "kind": "ErrorText",
+            "nodeExcerpt": "[c][c][c]",
+          },
+          Object {
+            "kind": "Paragraph",
+            "nodes": Array [
+              Object {
+                "kind": "SoftBreak",
+                "nodeExcerpt": "[n]",
+              },
+            ],
+          },
+        ],
+      },
+    ],
+  },
 }
 `;
 
@@ -474,39 +634,52 @@ Object {
   "logMessages": Array [
     "(5,4): The closing delimiter for a code fence must not be indented",
   ],
-  "verbatimNodes": Array [
-    Object {
-      "kind": "PlainText",
-      "nodeExcerpt": "Closing delimiter being indented:",
-    },
-    Object {
-      "kind": "SoftBreak",
-      "nodeExcerpt": "[n]",
-    },
-    Object {
-      "kind": "CodeFence",
-      "nodes": Array [
-        Object {
-          "kind": "Particle",
-          "nodeExcerpt": "[c][c][c]",
-        },
-        Object {
-          "kind": "Particle",
-          "nodeExcerpt": "",
-          "nodeSpacing": "[n]",
-        },
-        Object {
-          "kind": "Particle",
-          "nodeExcerpt": "code[n]",
-        },
-        Object {
-          "kind": "Particle",
-          "nodeExcerpt": "     [c][c][c]",
-          "nodeSpacing": "[n]",
-        },
-      ],
-    },
-  ],
+  "nodes": Object {
+    "kind": "Comment",
+    "nodes": Array [
+      Object {
+        "kind": "Section",
+        "nodes": Array [
+          Object {
+            "kind": "Paragraph",
+            "nodes": Array [
+              Object {
+                "kind": "PlainText",
+                "nodeExcerpt": "Closing delimiter being indented:",
+              },
+              Object {
+                "kind": "SoftBreak",
+                "nodeExcerpt": "[n]",
+              },
+            ],
+          },
+          Object {
+            "kind": "CodeFence",
+            "nodes": Array [
+              Object {
+                "kind": "Particle",
+                "nodeExcerpt": "[c][c][c]",
+              },
+              Object {
+                "kind": "Particle",
+                "nodeExcerpt": "",
+                "nodeSpacing": "[n]",
+              },
+              Object {
+                "kind": "Particle",
+                "nodeExcerpt": "code[n]",
+              },
+              Object {
+                "kind": "Particle",
+                "nodeExcerpt": "     [c][c][c]",
+                "nodeSpacing": "[n]",
+              },
+            ],
+          },
+        ],
+      },
+    ],
+  },
 }
 `;
 
@@ -522,46 +695,64 @@ Object {
   "logMessages": Array [
     "(5,9): Unexpected characters after closing delimiter for code fence",
   ],
-  "verbatimNodes": Array [
-    Object {
-      "kind": "PlainText",
-      "nodeExcerpt": "Closing delimiter not being on a line by itself:",
-    },
-    Object {
-      "kind": "SoftBreak",
-      "nodeExcerpt": "[n]",
-    },
-    Object {
-      "kind": "CodeFence",
-      "nodes": Array [
-        Object {
-          "kind": "Particle",
-          "nodeExcerpt": "[c][c][c]",
-        },
-        Object {
-          "kind": "Particle",
-          "nodeExcerpt": "",
-          "nodeSpacing": "[n]",
-        },
-        Object {
-          "kind": "Particle",
-          "nodeExcerpt": "code[n]",
-        },
-        Object {
-          "kind": "Particle",
-          "nodeExcerpt": "[c][c][c]",
-          "nodeSpacing": "  ",
-        },
-      ],
-    },
-    Object {
-      "kind": "PlainText",
-      "nodeExcerpt": "a",
-    },
-    Object {
-      "kind": "SoftBreak",
-      "nodeExcerpt": "[n]",
-    },
-  ],
+  "nodes": Object {
+    "kind": "Comment",
+    "nodes": Array [
+      Object {
+        "kind": "Section",
+        "nodes": Array [
+          Object {
+            "kind": "Paragraph",
+            "nodes": Array [
+              Object {
+                "kind": "PlainText",
+                "nodeExcerpt": "Closing delimiter not being on a line by itself:",
+              },
+              Object {
+                "kind": "SoftBreak",
+                "nodeExcerpt": "[n]",
+              },
+            ],
+          },
+          Object {
+            "kind": "CodeFence",
+            "nodes": Array [
+              Object {
+                "kind": "Particle",
+                "nodeExcerpt": "[c][c][c]",
+              },
+              Object {
+                "kind": "Particle",
+                "nodeExcerpt": "",
+                "nodeSpacing": "[n]",
+              },
+              Object {
+                "kind": "Particle",
+                "nodeExcerpt": "code[n]",
+              },
+              Object {
+                "kind": "Particle",
+                "nodeExcerpt": "[c][c][c]",
+                "nodeSpacing": "  ",
+              },
+            ],
+          },
+          Object {
+            "kind": "Paragraph",
+            "nodes": Array [
+              Object {
+                "kind": "PlainText",
+                "nodeExcerpt": "a",
+              },
+              Object {
+                "kind": "SoftBreak",
+                "nodeExcerpt": "[n]",
+              },
+            ],
+          },
+        ],
+      },
+    ],
+  },
 }
 `;

--- a/tsdoc/src/parser/__tests__/__snapshots__/NodeParserHtml.test.ts.snap
+++ b/tsdoc/src/parser/__tests__/__snapshots__/NodeParserHtml.test.ts.snap
@@ -13,135 +13,148 @@ Object {
     "     /[>]",
   ],
   "logMessages": Array [],
-  "verbatimNodes": Array [
-    Object {
-      "kind": "HtmlStartTag",
-      "nodes": Array [
-        Object {
-          "kind": "Particle",
-          "nodeExcerpt": "[<]",
-        },
-        Object {
-          "kind": "Particle",
-          "nodeExcerpt": "tag",
-        },
-        Object {
-          "kind": "Particle",
-          "nodeExcerpt": "/[>]",
-        },
-      ],
-    },
-    Object {
-      "kind": "SoftBreak",
-      "nodeExcerpt": "[n]",
-    },
-    Object {
-      "kind": "HtmlStartTag",
-      "nodes": Array [
-        Object {
-          "kind": "Particle",
-          "nodeExcerpt": "[<]",
-        },
-        Object {
-          "kind": "Particle",
-          "nodeExcerpt": "tag-a",
-          "nodeSpacing": " ",
-        },
-        Object {
-          "kind": "Particle",
-          "nodeExcerpt": "/[>]",
-        },
-      ],
-    },
-    Object {
-      "kind": "SoftBreak",
-      "nodeExcerpt": "[n]",
-    },
-    Object {
-      "kind": "HtmlStartTag",
-      "nodes": Array [
-        Object {
-          "kind": "Particle",
-          "nodeExcerpt": "[<]",
-        },
-        Object {
-          "kind": "Particle",
-          "nodeExcerpt": "tag-b",
-          "nodeSpacing": " ",
-        },
-        Object {
-          "kind": "Particle",
-          "nodeExcerpt": "[>]",
-        },
-      ],
-    },
-    Object {
-      "kind": "HtmlStartTag",
-      "nodes": Array [
-        Object {
-          "kind": "Particle",
-          "nodeExcerpt": "[<]",
-        },
-        Object {
-          "kind": "Particle",
-          "nodeExcerpt": "tag-c",
-          "nodeSpacing": " ",
-        },
-        Object {
-          "kind": "Particle",
-          "nodeExcerpt": "/[>]",
-        },
-      ],
-    },
-    Object {
-      "kind": "SoftBreak",
-      "nodeExcerpt": "[n]",
-    },
-    Object {
-      "kind": "HtmlStartTag",
-      "nodes": Array [
-        Object {
-          "kind": "Particle",
-          "nodeExcerpt": "[<]",
-        },
-        Object {
-          "kind": "Particle",
-          "nodeExcerpt": "tag-d",
-          "nodeSpacing": "[n]",
-        },
-        Object {
-          "kind": "Particle",
-          "nodeExcerpt": "[>]",
-        },
-      ],
-    },
-    Object {
-      "kind": "SoftBreak",
-      "nodeExcerpt": "[n]",
-    },
-    Object {
-      "kind": "HtmlStartTag",
-      "nodes": Array [
-        Object {
-          "kind": "Particle",
-          "nodeExcerpt": "[<]",
-        },
-        Object {
-          "kind": "Particle",
-          "nodeExcerpt": "tag-e",
-          "nodeSpacing": "[n]     ",
-        },
-        Object {
-          "kind": "Particle",
-          "nodeExcerpt": "/[>]",
-        },
-      ],
-    },
-    Object {
-      "kind": "SoftBreak",
-      "nodeExcerpt": "[n]",
-    },
-  ],
+  "nodes": Object {
+    "kind": "Comment",
+    "nodes": Array [
+      Object {
+        "kind": "Section",
+        "nodes": Array [
+          Object {
+            "kind": "Paragraph",
+            "nodes": Array [
+              Object {
+                "kind": "HtmlStartTag",
+                "nodes": Array [
+                  Object {
+                    "kind": "Particle",
+                    "nodeExcerpt": "[<]",
+                  },
+                  Object {
+                    "kind": "Particle",
+                    "nodeExcerpt": "tag",
+                  },
+                  Object {
+                    "kind": "Particle",
+                    "nodeExcerpt": "/[>]",
+                  },
+                ],
+              },
+              Object {
+                "kind": "SoftBreak",
+                "nodeExcerpt": "[n]",
+              },
+              Object {
+                "kind": "HtmlStartTag",
+                "nodes": Array [
+                  Object {
+                    "kind": "Particle",
+                    "nodeExcerpt": "[<]",
+                  },
+                  Object {
+                    "kind": "Particle",
+                    "nodeExcerpt": "tag-a",
+                    "nodeSpacing": " ",
+                  },
+                  Object {
+                    "kind": "Particle",
+                    "nodeExcerpt": "/[>]",
+                  },
+                ],
+              },
+              Object {
+                "kind": "SoftBreak",
+                "nodeExcerpt": "[n]",
+              },
+              Object {
+                "kind": "HtmlStartTag",
+                "nodes": Array [
+                  Object {
+                    "kind": "Particle",
+                    "nodeExcerpt": "[<]",
+                  },
+                  Object {
+                    "kind": "Particle",
+                    "nodeExcerpt": "tag-b",
+                    "nodeSpacing": " ",
+                  },
+                  Object {
+                    "kind": "Particle",
+                    "nodeExcerpt": "[>]",
+                  },
+                ],
+              },
+              Object {
+                "kind": "HtmlStartTag",
+                "nodes": Array [
+                  Object {
+                    "kind": "Particle",
+                    "nodeExcerpt": "[<]",
+                  },
+                  Object {
+                    "kind": "Particle",
+                    "nodeExcerpt": "tag-c",
+                    "nodeSpacing": " ",
+                  },
+                  Object {
+                    "kind": "Particle",
+                    "nodeExcerpt": "/[>]",
+                  },
+                ],
+              },
+              Object {
+                "kind": "SoftBreak",
+                "nodeExcerpt": "[n]",
+              },
+              Object {
+                "kind": "HtmlStartTag",
+                "nodes": Array [
+                  Object {
+                    "kind": "Particle",
+                    "nodeExcerpt": "[<]",
+                  },
+                  Object {
+                    "kind": "Particle",
+                    "nodeExcerpt": "tag-d",
+                    "nodeSpacing": "[n]",
+                  },
+                  Object {
+                    "kind": "Particle",
+                    "nodeExcerpt": "[>]",
+                  },
+                ],
+              },
+              Object {
+                "kind": "SoftBreak",
+                "nodeExcerpt": "[n]",
+              },
+              Object {
+                "kind": "HtmlStartTag",
+                "nodes": Array [
+                  Object {
+                    "kind": "Particle",
+                    "nodeExcerpt": "[<]",
+                  },
+                  Object {
+                    "kind": "Particle",
+                    "nodeExcerpt": "tag-e",
+                    "nodeSpacing": "[n]     ",
+                  },
+                  Object {
+                    "kind": "Particle",
+                    "nodeExcerpt": "/[>]",
+                  },
+                ],
+              },
+              Object {
+                "kind": "SoftBreak",
+                "nodeExcerpt": "[n]",
+              },
+            ],
+          },
+        ],
+      },
+    ],
+  },
 }
 `;
 
@@ -164,101 +177,114 @@ Object {
     "(4,21): The \\">\\" character should be escaped using a backslash to avoid confusion with an HTML tag",
     "(5,4): The HTML tag has invalid syntax: Expecting an attribute or \\">\\" or \\"/>\\"",
   ],
-  "verbatimNodes": Array [
-    Object {
-      "errorLocation": " ",
-      "errorLocationPrecedingToken": "<",
-      "errorMessage": "Invalid HTML element: A space is not allowed here",
-      "kind": "ErrorText",
-      "nodeExcerpt": "[<]",
-    },
-    Object {
-      "kind": "PlainText",
-      "nodeExcerpt": " tag/",
-    },
-    Object {
-      "errorLocation": "[>]",
-      "errorLocationPrecedingToken": "/",
-      "errorMessage": "The [q][>][q] character should be escaped using a backslash to avoid confusion with an HTML tag",
-      "kind": "ErrorText",
-      "nodeExcerpt": "[>]",
-    },
-    Object {
-      "kind": "SoftBreak",
-      "nodeExcerpt": "[n]",
-    },
-    Object {
-      "errorLocation": "-",
-      "errorLocationPrecedingToken": " ",
-      "errorMessage": "The HTML tag has invalid syntax: Expecting an attribute or [q][>][q] or [q]/[>][q]",
-      "kind": "ErrorText",
-      "nodeExcerpt": "[<]",
-    },
-    Object {
-      "kind": "PlainText",
-      "nodeExcerpt": "tag -a /",
-    },
-    Object {
-      "errorLocation": "[>]",
-      "errorLocationPrecedingToken": "/",
-      "errorMessage": "The [q][>][q] character should be escaped using a backslash to avoid confusion with an HTML tag",
-      "kind": "ErrorText",
-      "nodeExcerpt": "[>]",
-    },
-    Object {
-      "kind": "SoftBreak",
-      "nodeExcerpt": "[n]",
-    },
-    Object {
-      "errorLocation": "/",
-      "errorLocationPrecedingToken": " ",
-      "errorMessage": "The HTML tag has invalid syntax: Expecting an attribute or [q][>][q] or [q]/[>][q]",
-      "kind": "ErrorText",
-      "nodeExcerpt": "[<]",
-    },
-    Object {
-      "kind": "PlainText",
-      "nodeExcerpt": "tag-b /",
-    },
-    Object {
-      "errorLocation": "/",
-      "errorLocationPrecedingToken": " ",
-      "errorMessage": "The HTML tag has invalid syntax: Expecting an attribute or [q][>][q] or [q]/[>][q]",
-      "kind": "ErrorText",
-      "nodeExcerpt": "[<]",
-    },
-    Object {
-      "kind": "PlainText",
-      "nodeExcerpt": "tag-c / ",
-    },
-    Object {
-      "errorLocation": "[>]",
-      "errorLocationPrecedingToken": " ",
-      "errorMessage": "The [q][>][q] character should be escaped using a backslash to avoid confusion with an HTML tag",
-      "kind": "ErrorText",
-      "nodeExcerpt": "[>]",
-    },
-    Object {
-      "kind": "SoftBreak",
-      "nodeExcerpt": "[n]",
-    },
-    Object {
-      "errorLocation": "",
-      "errorLocationPrecedingToken": "
+  "nodes": Object {
+    "kind": "Comment",
+    "nodes": Array [
+      Object {
+        "kind": "Section",
+        "nodes": Array [
+          Object {
+            "kind": "Paragraph",
+            "nodes": Array [
+              Object {
+                "errorLocation": " ",
+                "errorLocationPrecedingToken": "<",
+                "errorMessage": "Invalid HTML element: A space is not allowed here",
+                "kind": "ErrorText",
+                "nodeExcerpt": "[<]",
+              },
+              Object {
+                "kind": "PlainText",
+                "nodeExcerpt": " tag/",
+              },
+              Object {
+                "errorLocation": "[>]",
+                "errorLocationPrecedingToken": "/",
+                "errorMessage": "The [q][>][q] character should be escaped using a backslash to avoid confusion with an HTML tag",
+                "kind": "ErrorText",
+                "nodeExcerpt": "[>]",
+              },
+              Object {
+                "kind": "SoftBreak",
+                "nodeExcerpt": "[n]",
+              },
+              Object {
+                "errorLocation": "-",
+                "errorLocationPrecedingToken": " ",
+                "errorMessage": "The HTML tag has invalid syntax: Expecting an attribute or [q][>][q] or [q]/[>][q]",
+                "kind": "ErrorText",
+                "nodeExcerpt": "[<]",
+              },
+              Object {
+                "kind": "PlainText",
+                "nodeExcerpt": "tag -a /",
+              },
+              Object {
+                "errorLocation": "[>]",
+                "errorLocationPrecedingToken": "/",
+                "errorMessage": "The [q][>][q] character should be escaped using a backslash to avoid confusion with an HTML tag",
+                "kind": "ErrorText",
+                "nodeExcerpt": "[>]",
+              },
+              Object {
+                "kind": "SoftBreak",
+                "nodeExcerpt": "[n]",
+              },
+              Object {
+                "errorLocation": "/",
+                "errorLocationPrecedingToken": " ",
+                "errorMessage": "The HTML tag has invalid syntax: Expecting an attribute or [q][>][q] or [q]/[>][q]",
+                "kind": "ErrorText",
+                "nodeExcerpt": "[<]",
+              },
+              Object {
+                "kind": "PlainText",
+                "nodeExcerpt": "tag-b /",
+              },
+              Object {
+                "errorLocation": "/",
+                "errorLocationPrecedingToken": " ",
+                "errorMessage": "The HTML tag has invalid syntax: Expecting an attribute or [q][>][q] or [q]/[>][q]",
+                "kind": "ErrorText",
+                "nodeExcerpt": "[<]",
+              },
+              Object {
+                "kind": "PlainText",
+                "nodeExcerpt": "tag-c / ",
+              },
+              Object {
+                "errorLocation": "[>]",
+                "errorLocationPrecedingToken": " ",
+                "errorMessage": "The [q][>][q] character should be escaped using a backslash to avoid confusion with an HTML tag",
+                "kind": "ErrorText",
+                "nodeExcerpt": "[>]",
+              },
+              Object {
+                "kind": "SoftBreak",
+                "nodeExcerpt": "[n]",
+              },
+              Object {
+                "errorLocation": "",
+                "errorLocationPrecedingToken": "
 ",
-      "errorMessage": "The HTML tag has invalid syntax: Expecting an attribute or [q][>][q] or [q]/[>][q]",
-      "kind": "ErrorText",
-      "nodeExcerpt": "[<]",
-    },
-    Object {
-      "kind": "PlainText",
-      "nodeExcerpt": "tag-d",
-    },
-    Object {
-      "kind": "SoftBreak",
-      "nodeExcerpt": "[n]",
-    },
-  ],
+                "errorMessage": "The HTML tag has invalid syntax: Expecting an attribute or [q][>][q] or [q]/[>][q]",
+                "kind": "ErrorText",
+                "nodeExcerpt": "[<]",
+              },
+              Object {
+                "kind": "PlainText",
+                "nodeExcerpt": "tag-d",
+              },
+              Object {
+                "kind": "SoftBreak",
+                "nodeExcerpt": "[n]",
+              },
+            ],
+          },
+        ],
+      },
+    ],
+  },
 }
 `;
 
@@ -273,90 +299,103 @@ Object {
     "/[>]",
   ],
   "logMessages": Array [],
-  "verbatimNodes": Array [
-    Object {
-      "kind": "HtmlStartTag",
-      "nodes": Array [
-        Object {
-          "kind": "Particle",
-          "nodeExcerpt": "[<]",
-        },
-        Object {
-          "kind": "Particle",
-          "nodeExcerpt": "tag-a",
-          "nodeSpacing": " ",
-        },
-        Object {
-          "kind": "HtmlAttribute",
-          "nodes": Array [
-            Object {
-              "kind": "Particle",
-              "nodeExcerpt": "attr-one",
-            },
-            Object {
-              "kind": "Particle",
-              "nodeExcerpt": "=",
-            },
-            Object {
-              "kind": "Particle",
-              "nodeExcerpt": "[q]one[q]",
-              "nodeSpacing": " ",
-            },
-          ],
-        },
-        Object {
-          "kind": "Particle",
-          "nodeExcerpt": "[>]",
-        },
-      ],
-    },
-    Object {
-      "kind": "SoftBreak",
-      "nodeExcerpt": "[n]",
-    },
-    Object {
-      "kind": "HtmlStartTag",
-      "nodes": Array [
-        Object {
-          "kind": "Particle",
-          "nodeExcerpt": "[<]",
-        },
-        Object {
-          "kind": "Particle",
-          "nodeExcerpt": "tag-b",
-          "nodeSpacing": "[n]  ",
-        },
-        Object {
-          "kind": "HtmlAttribute",
-          "nodes": Array [
-            Object {
-              "kind": "Particle",
-              "nodeExcerpt": "attr-two",
-              "nodeSpacing": "[n]  ",
-            },
-            Object {
-              "kind": "Particle",
-              "nodeExcerpt": "=",
-              "nodeSpacing": " ",
-            },
-            Object {
-              "kind": "Particle",
-              "nodeExcerpt": "[q]2[q]",
-              "nodeSpacing": "[n]",
-            },
-          ],
-        },
-        Object {
-          "kind": "Particle",
-          "nodeExcerpt": "/[>]",
-        },
-      ],
-    },
-    Object {
-      "kind": "SoftBreak",
-      "nodeExcerpt": "[n]",
-    },
-  ],
+  "nodes": Object {
+    "kind": "Comment",
+    "nodes": Array [
+      Object {
+        "kind": "Section",
+        "nodes": Array [
+          Object {
+            "kind": "Paragraph",
+            "nodes": Array [
+              Object {
+                "kind": "HtmlStartTag",
+                "nodes": Array [
+                  Object {
+                    "kind": "Particle",
+                    "nodeExcerpt": "[<]",
+                  },
+                  Object {
+                    "kind": "Particle",
+                    "nodeExcerpt": "tag-a",
+                    "nodeSpacing": " ",
+                  },
+                  Object {
+                    "kind": "HtmlAttribute",
+                    "nodes": Array [
+                      Object {
+                        "kind": "Particle",
+                        "nodeExcerpt": "attr-one",
+                      },
+                      Object {
+                        "kind": "Particle",
+                        "nodeExcerpt": "=",
+                      },
+                      Object {
+                        "kind": "Particle",
+                        "nodeExcerpt": "[q]one[q]",
+                        "nodeSpacing": " ",
+                      },
+                    ],
+                  },
+                  Object {
+                    "kind": "Particle",
+                    "nodeExcerpt": "[>]",
+                  },
+                ],
+              },
+              Object {
+                "kind": "SoftBreak",
+                "nodeExcerpt": "[n]",
+              },
+              Object {
+                "kind": "HtmlStartTag",
+                "nodes": Array [
+                  Object {
+                    "kind": "Particle",
+                    "nodeExcerpt": "[<]",
+                  },
+                  Object {
+                    "kind": "Particle",
+                    "nodeExcerpt": "tag-b",
+                    "nodeSpacing": "[n]  ",
+                  },
+                  Object {
+                    "kind": "HtmlAttribute",
+                    "nodes": Array [
+                      Object {
+                        "kind": "Particle",
+                        "nodeExcerpt": "attr-two",
+                        "nodeSpacing": "[n]  ",
+                      },
+                      Object {
+                        "kind": "Particle",
+                        "nodeExcerpt": "=",
+                        "nodeSpacing": " ",
+                      },
+                      Object {
+                        "kind": "Particle",
+                        "nodeExcerpt": "[q]2[q]",
+                        "nodeSpacing": "[n]",
+                      },
+                    ],
+                  },
+                  Object {
+                    "kind": "Particle",
+                    "nodeExcerpt": "/[>]",
+                  },
+                ],
+              },
+              Object {
+                "kind": "SoftBreak",
+                "nodeExcerpt": "[n]",
+              },
+            ],
+          },
+        ],
+      },
+    ],
+  },
 }
 `;
 
@@ -373,127 +412,140 @@ Object {
     "/[>]",
   ],
   "logMessages": Array [],
-  "verbatimNodes": Array [
-    Object {
-      "kind": "HtmlStartTag",
-      "nodes": Array [
-        Object {
-          "kind": "Particle",
-          "nodeExcerpt": "[<]",
-        },
-        Object {
-          "kind": "Particle",
-          "nodeExcerpt": "tag-c",
-          "nodeSpacing": " ",
-        },
-        Object {
-          "kind": "HtmlAttribute",
-          "nodes": Array [
-            Object {
-              "kind": "Particle",
-              "nodeExcerpt": "attr-three",
-            },
-            Object {
-              "kind": "Particle",
-              "nodeExcerpt": "=",
-            },
-            Object {
-              "kind": "Particle",
-              "nodeExcerpt": "[q]3[q]",
-              "nodeSpacing": " ",
-            },
-          ],
-        },
-        Object {
-          "kind": "HtmlAttribute",
-          "nodes": Array [
-            Object {
-              "kind": "Particle",
-              "nodeExcerpt": "four",
-            },
-            Object {
-              "kind": "Particle",
-              "nodeExcerpt": "=",
-            },
-            Object {
-              "kind": "Particle",
-              "nodeExcerpt": "'4'",
-            },
-          ],
-        },
-        Object {
-          "kind": "Particle",
-          "nodeExcerpt": "/[>]",
-        },
-      ],
-    },
-    Object {
-      "kind": "SoftBreak",
-      "nodeExcerpt": "[n]",
-    },
-    Object {
-      "kind": "HtmlStartTag",
-      "nodes": Array [
-        Object {
-          "kind": "Particle",
-          "nodeExcerpt": "[<]",
-        },
-        Object {
-          "kind": "Particle",
-          "nodeExcerpt": "tag-d",
-          "nodeSpacing": "[n]  ",
-        },
-        Object {
-          "kind": "HtmlAttribute",
-          "nodes": Array [
-            Object {
-              "kind": "Particle",
-              "nodeExcerpt": "attr-five",
-              "nodeSpacing": "[n]  ",
-            },
-            Object {
-              "kind": "Particle",
-              "nodeExcerpt": "=",
-              "nodeSpacing": " ",
-            },
-            Object {
-              "kind": "Particle",
-              "nodeExcerpt": "[q]5[q]",
-              "nodeSpacing": "[n]  ",
-            },
-          ],
-        },
-        Object {
-          "kind": "HtmlAttribute",
-          "nodes": Array [
-            Object {
-              "kind": "Particle",
-              "nodeExcerpt": "six",
-              "nodeSpacing": "[n]  ",
-            },
-            Object {
-              "kind": "Particle",
-              "nodeExcerpt": "=",
-              "nodeSpacing": " ",
-            },
-            Object {
-              "kind": "Particle",
-              "nodeExcerpt": "'6'",
-              "nodeSpacing": "[n]",
-            },
-          ],
-        },
-        Object {
-          "kind": "Particle",
-          "nodeExcerpt": "/[>]",
-        },
-      ],
-    },
-    Object {
-      "kind": "SoftBreak",
-      "nodeExcerpt": "[n]",
-    },
-  ],
+  "nodes": Object {
+    "kind": "Comment",
+    "nodes": Array [
+      Object {
+        "kind": "Section",
+        "nodes": Array [
+          Object {
+            "kind": "Paragraph",
+            "nodes": Array [
+              Object {
+                "kind": "HtmlStartTag",
+                "nodes": Array [
+                  Object {
+                    "kind": "Particle",
+                    "nodeExcerpt": "[<]",
+                  },
+                  Object {
+                    "kind": "Particle",
+                    "nodeExcerpt": "tag-c",
+                    "nodeSpacing": " ",
+                  },
+                  Object {
+                    "kind": "HtmlAttribute",
+                    "nodes": Array [
+                      Object {
+                        "kind": "Particle",
+                        "nodeExcerpt": "attr-three",
+                      },
+                      Object {
+                        "kind": "Particle",
+                        "nodeExcerpt": "=",
+                      },
+                      Object {
+                        "kind": "Particle",
+                        "nodeExcerpt": "[q]3[q]",
+                        "nodeSpacing": " ",
+                      },
+                    ],
+                  },
+                  Object {
+                    "kind": "HtmlAttribute",
+                    "nodes": Array [
+                      Object {
+                        "kind": "Particle",
+                        "nodeExcerpt": "four",
+                      },
+                      Object {
+                        "kind": "Particle",
+                        "nodeExcerpt": "=",
+                      },
+                      Object {
+                        "kind": "Particle",
+                        "nodeExcerpt": "'4'",
+                      },
+                    ],
+                  },
+                  Object {
+                    "kind": "Particle",
+                    "nodeExcerpt": "/[>]",
+                  },
+                ],
+              },
+              Object {
+                "kind": "SoftBreak",
+                "nodeExcerpt": "[n]",
+              },
+              Object {
+                "kind": "HtmlStartTag",
+                "nodes": Array [
+                  Object {
+                    "kind": "Particle",
+                    "nodeExcerpt": "[<]",
+                  },
+                  Object {
+                    "kind": "Particle",
+                    "nodeExcerpt": "tag-d",
+                    "nodeSpacing": "[n]  ",
+                  },
+                  Object {
+                    "kind": "HtmlAttribute",
+                    "nodes": Array [
+                      Object {
+                        "kind": "Particle",
+                        "nodeExcerpt": "attr-five",
+                        "nodeSpacing": "[n]  ",
+                      },
+                      Object {
+                        "kind": "Particle",
+                        "nodeExcerpt": "=",
+                        "nodeSpacing": " ",
+                      },
+                      Object {
+                        "kind": "Particle",
+                        "nodeExcerpt": "[q]5[q]",
+                        "nodeSpacing": "[n]  ",
+                      },
+                    ],
+                  },
+                  Object {
+                    "kind": "HtmlAttribute",
+                    "nodes": Array [
+                      Object {
+                        "kind": "Particle",
+                        "nodeExcerpt": "six",
+                        "nodeSpacing": "[n]  ",
+                      },
+                      Object {
+                        "kind": "Particle",
+                        "nodeExcerpt": "=",
+                        "nodeSpacing": " ",
+                      },
+                      Object {
+                        "kind": "Particle",
+                        "nodeExcerpt": "'6'",
+                        "nodeSpacing": "[n]",
+                      },
+                    ],
+                  },
+                  Object {
+                    "kind": "Particle",
+                    "nodeExcerpt": "/[>]",
+                  },
+                ],
+              },
+              Object {
+                "kind": "SoftBreak",
+                "nodeExcerpt": "[n]",
+              },
+            ],
+          },
+        ],
+      },
+    ],
+  },
 }
 `;
 
@@ -510,127 +562,140 @@ Object {
     "/[>]",
   ],
   "logMessages": Array [],
-  "verbatimNodes": Array [
-    Object {
-      "kind": "HtmlStartTag",
-      "nodes": Array [
-        Object {
-          "kind": "Particle",
-          "nodeExcerpt": "[<]",
-        },
-        Object {
-          "kind": "Particle",
-          "nodeExcerpt": "tag-e",
-          "nodeSpacing": " ",
-        },
-        Object {
-          "kind": "HtmlAttribute",
-          "nodes": Array [
-            Object {
-              "kind": "Particle",
-              "nodeExcerpt": "attr-one",
-            },
-            Object {
-              "kind": "Particle",
-              "nodeExcerpt": "=",
-            },
-            Object {
-              "kind": "Particle",
-              "nodeExcerpt": "[q]one[q]",
-              "nodeSpacing": " ",
-            },
-          ],
-        },
-        Object {
-          "kind": "HtmlAttribute",
-          "nodes": Array [
-            Object {
-              "kind": "Particle",
-              "nodeExcerpt": "two",
-            },
-            Object {
-              "kind": "Particle",
-              "nodeExcerpt": "=",
-            },
-            Object {
-              "kind": "Particle",
-              "nodeExcerpt": "'two'",
-            },
-          ],
-        },
-        Object {
-          "kind": "Particle",
-          "nodeExcerpt": "/[>]",
-        },
-      ],
-    },
-    Object {
-      "kind": "SoftBreak",
-      "nodeExcerpt": "[n]",
-    },
-    Object {
-      "kind": "HtmlStartTag",
-      "nodes": Array [
-        Object {
-          "kind": "Particle",
-          "nodeExcerpt": "[<]",
-        },
-        Object {
-          "kind": "Particle",
-          "nodeExcerpt": "tag-f",
-          "nodeSpacing": "[n]  ",
-        },
-        Object {
-          "kind": "HtmlAttribute",
-          "nodes": Array [
-            Object {
-              "kind": "Particle",
-              "nodeExcerpt": "attr-one",
-              "nodeSpacing": "[n]  ",
-            },
-            Object {
-              "kind": "Particle",
-              "nodeExcerpt": "=",
-              "nodeSpacing": " ",
-            },
-            Object {
-              "kind": "Particle",
-              "nodeExcerpt": "[q]one[q]",
-              "nodeSpacing": "[n]  ",
-            },
-          ],
-        },
-        Object {
-          "kind": "HtmlAttribute",
-          "nodes": Array [
-            Object {
-              "kind": "Particle",
-              "nodeExcerpt": "two",
-              "nodeSpacing": "[n]  ",
-            },
-            Object {
-              "kind": "Particle",
-              "nodeExcerpt": "=",
-              "nodeSpacing": " ",
-            },
-            Object {
-              "kind": "Particle",
-              "nodeExcerpt": "'two'",
-              "nodeSpacing": "[n]",
-            },
-          ],
-        },
-        Object {
-          "kind": "Particle",
-          "nodeExcerpt": "/[>]",
-        },
-      ],
-    },
-    Object {
-      "kind": "SoftBreak",
-      "nodeExcerpt": "[n]",
-    },
-  ],
+  "nodes": Object {
+    "kind": "Comment",
+    "nodes": Array [
+      Object {
+        "kind": "Section",
+        "nodes": Array [
+          Object {
+            "kind": "Paragraph",
+            "nodes": Array [
+              Object {
+                "kind": "HtmlStartTag",
+                "nodes": Array [
+                  Object {
+                    "kind": "Particle",
+                    "nodeExcerpt": "[<]",
+                  },
+                  Object {
+                    "kind": "Particle",
+                    "nodeExcerpt": "tag-e",
+                    "nodeSpacing": " ",
+                  },
+                  Object {
+                    "kind": "HtmlAttribute",
+                    "nodes": Array [
+                      Object {
+                        "kind": "Particle",
+                        "nodeExcerpt": "attr-one",
+                      },
+                      Object {
+                        "kind": "Particle",
+                        "nodeExcerpt": "=",
+                      },
+                      Object {
+                        "kind": "Particle",
+                        "nodeExcerpt": "[q]one[q]",
+                        "nodeSpacing": " ",
+                      },
+                    ],
+                  },
+                  Object {
+                    "kind": "HtmlAttribute",
+                    "nodes": Array [
+                      Object {
+                        "kind": "Particle",
+                        "nodeExcerpt": "two",
+                      },
+                      Object {
+                        "kind": "Particle",
+                        "nodeExcerpt": "=",
+                      },
+                      Object {
+                        "kind": "Particle",
+                        "nodeExcerpt": "'two'",
+                      },
+                    ],
+                  },
+                  Object {
+                    "kind": "Particle",
+                    "nodeExcerpt": "/[>]",
+                  },
+                ],
+              },
+              Object {
+                "kind": "SoftBreak",
+                "nodeExcerpt": "[n]",
+              },
+              Object {
+                "kind": "HtmlStartTag",
+                "nodes": Array [
+                  Object {
+                    "kind": "Particle",
+                    "nodeExcerpt": "[<]",
+                  },
+                  Object {
+                    "kind": "Particle",
+                    "nodeExcerpt": "tag-f",
+                    "nodeSpacing": "[n]  ",
+                  },
+                  Object {
+                    "kind": "HtmlAttribute",
+                    "nodes": Array [
+                      Object {
+                        "kind": "Particle",
+                        "nodeExcerpt": "attr-one",
+                        "nodeSpacing": "[n]  ",
+                      },
+                      Object {
+                        "kind": "Particle",
+                        "nodeExcerpt": "=",
+                        "nodeSpacing": " ",
+                      },
+                      Object {
+                        "kind": "Particle",
+                        "nodeExcerpt": "[q]one[q]",
+                        "nodeSpacing": "[n]  ",
+                      },
+                    ],
+                  },
+                  Object {
+                    "kind": "HtmlAttribute",
+                    "nodes": Array [
+                      Object {
+                        "kind": "Particle",
+                        "nodeExcerpt": "two",
+                        "nodeSpacing": "[n]  ",
+                      },
+                      Object {
+                        "kind": "Particle",
+                        "nodeExcerpt": "=",
+                        "nodeSpacing": " ",
+                      },
+                      Object {
+                        "kind": "Particle",
+                        "nodeExcerpt": "'two'",
+                        "nodeSpacing": "[n]",
+                      },
+                    ],
+                  },
+                  Object {
+                    "kind": "Particle",
+                    "nodeExcerpt": "/[>]",
+                  },
+                ],
+              },
+              Object {
+                "kind": "SoftBreak",
+                "nodeExcerpt": "[n]",
+              },
+            ],
+          },
+        ],
+      },
+    ],
+  },
 }
 `;
 
@@ -661,162 +726,175 @@ Object {
     "(7,4): The HTML element has an invalid attribute: The next character after a closing quote must be spacing or punctuation",
     "(7,40): The \\">\\" character should be escaped using a backslash to avoid confusion with an HTML tag",
   ],
-  "verbatimNodes": Array [
-    Object {
-      "errorLocation": "-",
-      "errorLocationPrecedingToken": " ",
-      "errorMessage": "The HTML element has an invalid attribute: Expecting [q]=[q] after HTML attribute name",
-      "kind": "ErrorText",
-      "nodeExcerpt": "[<]",
-    },
-    Object {
-      "kind": "PlainText",
-      "nodeExcerpt": "tag-a attr -one=[q]one[q] /",
-    },
-    Object {
-      "errorLocation": "[>]",
-      "errorLocationPrecedingToken": "/",
-      "errorMessage": "The [q][>][q] character should be escaped using a backslash to avoid confusion with an HTML tag",
-      "kind": "ErrorText",
-      "nodeExcerpt": "[>]",
-    },
-    Object {
-      "kind": "SoftBreak",
-      "nodeExcerpt": "[n]",
-    },
-    Object {
-      "errorLocation": "attr-",
-      "errorLocationPrecedingToken": " ",
-      "errorMessage": "The HTML element has an invalid attribute: An HTML name must be a sequence of letters separated by hyphens",
-      "kind": "ErrorText",
-      "nodeExcerpt": "[<]",
-    },
-    Object {
-      "kind": "PlainText",
-      "nodeExcerpt": "tag-b attr- two=[q]two[q] /",
-    },
-    Object {
-      "errorLocation": "[>]",
-      "errorLocationPrecedingToken": "/",
-      "errorMessage": "The [q][>][q] character should be escaped using a backslash to avoid confusion with an HTML tag",
-      "kind": "ErrorText",
-      "nodeExcerpt": "[>]",
-    },
-    Object {
-      "kind": "SoftBreak",
-      "nodeExcerpt": "[n]",
-    },
-    Object {
-      "errorLocation": "'",
-      "errorLocationPrecedingToken": "=",
-      "errorMessage": "The HTML element has an invalid attribute: The HTML string is missing its closing quote",
-      "kind": "ErrorText",
-      "nodeExcerpt": "[<]",
-    },
-    Object {
-      "kind": "PlainText",
-      "nodeExcerpt": "tag-c attr-three='three[q] /",
-    },
-    Object {
-      "errorLocation": "[>]",
-      "errorLocationPrecedingToken": "/",
-      "errorMessage": "The [q][>][q] character should be escaped using a backslash to avoid confusion with an HTML tag",
-      "kind": "ErrorText",
-      "nodeExcerpt": "[>]",
-    },
-    Object {
-      "kind": "SoftBreak",
-      "nodeExcerpt": "[n]",
-    },
-    Object {
-      "errorLocation": "@",
-      "errorLocationPrecedingToken": "=",
-      "errorMessage": "The HTML element has an invalid attribute: Expecting an HTML string starting with a single-quote or double-quote character",
-      "kind": "ErrorText",
-      "nodeExcerpt": "[<]",
-    },
-    Object {
-      "kind": "PlainText",
-      "nodeExcerpt": "tag-d attr-four=",
-    },
-    Object {
-      "errorLocation": "@",
-      "errorLocationPrecedingToken": "=",
-      "errorMessage": "A TSDoc tag must be preceded by whitespace",
-      "kind": "ErrorText",
-      "nodeExcerpt": "@",
-    },
-    Object {
-      "kind": "PlainText",
-      "nodeExcerpt": "[q]four[q] /",
-    },
-    Object {
-      "errorLocation": "[>]",
-      "errorLocationPrecedingToken": "/",
-      "errorMessage": "The [q][>][q] character should be escaped using a backslash to avoid confusion with an HTML tag",
-      "kind": "ErrorText",
-      "nodeExcerpt": "[>]",
-    },
-    Object {
-      "kind": "SoftBreak",
-      "nodeExcerpt": "[n]",
-    },
-    Object {
-      "errorLocation": "@",
-      "errorLocationPrecedingToken": "five",
-      "errorMessage": "The HTML element has an invalid attribute: Expecting [q]=[q] after HTML attribute name",
-      "kind": "ErrorText",
-      "nodeExcerpt": "[<]",
-    },
-    Object {
-      "kind": "PlainText",
-      "nodeExcerpt": "tag-e attr-five",
-    },
-    Object {
-      "errorLocation": "@",
-      "errorLocationPrecedingToken": "five",
-      "errorMessage": "A TSDoc tag must be preceded by whitespace",
-      "kind": "ErrorText",
-      "nodeExcerpt": "@",
-    },
-    Object {
-      "kind": "PlainText",
-      "nodeExcerpt": "=[q]five[q] /",
-    },
-    Object {
-      "errorLocation": "[>]",
-      "errorLocationPrecedingToken": "/",
-      "errorMessage": "The [q][>][q] character should be escaped using a backslash to avoid confusion with an HTML tag",
-      "kind": "ErrorText",
-      "nodeExcerpt": "[>]",
-    },
-    Object {
-      "kind": "SoftBreak",
-      "nodeExcerpt": "[n]",
-    },
-    Object {
-      "errorLocation": "seven",
-      "errorLocationPrecedingToken": "\\"",
-      "errorMessage": "The HTML element has an invalid attribute: The next character after a closing quote must be spacing or punctuation",
-      "kind": "ErrorText",
-      "nodeExcerpt": "[<]",
-    },
-    Object {
-      "kind": "PlainText",
-      "nodeExcerpt": "tag-f attr-six=[q]six[q]seven=[q]seven[q] /",
-    },
-    Object {
-      "errorLocation": "[>]",
-      "errorLocationPrecedingToken": "/",
-      "errorMessage": "The [q][>][q] character should be escaped using a backslash to avoid confusion with an HTML tag",
-      "kind": "ErrorText",
-      "nodeExcerpt": "[>]",
-    },
-    Object {
-      "kind": "SoftBreak",
-      "nodeExcerpt": "[n]",
-    },
-  ],
+  "nodes": Object {
+    "kind": "Comment",
+    "nodes": Array [
+      Object {
+        "kind": "Section",
+        "nodes": Array [
+          Object {
+            "kind": "Paragraph",
+            "nodes": Array [
+              Object {
+                "errorLocation": "-",
+                "errorLocationPrecedingToken": " ",
+                "errorMessage": "The HTML element has an invalid attribute: Expecting [q]=[q] after HTML attribute name",
+                "kind": "ErrorText",
+                "nodeExcerpt": "[<]",
+              },
+              Object {
+                "kind": "PlainText",
+                "nodeExcerpt": "tag-a attr -one=[q]one[q] /",
+              },
+              Object {
+                "errorLocation": "[>]",
+                "errorLocationPrecedingToken": "/",
+                "errorMessage": "The [q][>][q] character should be escaped using a backslash to avoid confusion with an HTML tag",
+                "kind": "ErrorText",
+                "nodeExcerpt": "[>]",
+              },
+              Object {
+                "kind": "SoftBreak",
+                "nodeExcerpt": "[n]",
+              },
+              Object {
+                "errorLocation": "attr-",
+                "errorLocationPrecedingToken": " ",
+                "errorMessage": "The HTML element has an invalid attribute: An HTML name must be a sequence of letters separated by hyphens",
+                "kind": "ErrorText",
+                "nodeExcerpt": "[<]",
+              },
+              Object {
+                "kind": "PlainText",
+                "nodeExcerpt": "tag-b attr- two=[q]two[q] /",
+              },
+              Object {
+                "errorLocation": "[>]",
+                "errorLocationPrecedingToken": "/",
+                "errorMessage": "The [q][>][q] character should be escaped using a backslash to avoid confusion with an HTML tag",
+                "kind": "ErrorText",
+                "nodeExcerpt": "[>]",
+              },
+              Object {
+                "kind": "SoftBreak",
+                "nodeExcerpt": "[n]",
+              },
+              Object {
+                "errorLocation": "'",
+                "errorLocationPrecedingToken": "=",
+                "errorMessage": "The HTML element has an invalid attribute: The HTML string is missing its closing quote",
+                "kind": "ErrorText",
+                "nodeExcerpt": "[<]",
+              },
+              Object {
+                "kind": "PlainText",
+                "nodeExcerpt": "tag-c attr-three='three[q] /",
+              },
+              Object {
+                "errorLocation": "[>]",
+                "errorLocationPrecedingToken": "/",
+                "errorMessage": "The [q][>][q] character should be escaped using a backslash to avoid confusion with an HTML tag",
+                "kind": "ErrorText",
+                "nodeExcerpt": "[>]",
+              },
+              Object {
+                "kind": "SoftBreak",
+                "nodeExcerpt": "[n]",
+              },
+              Object {
+                "errorLocation": "@",
+                "errorLocationPrecedingToken": "=",
+                "errorMessage": "The HTML element has an invalid attribute: Expecting an HTML string starting with a single-quote or double-quote character",
+                "kind": "ErrorText",
+                "nodeExcerpt": "[<]",
+              },
+              Object {
+                "kind": "PlainText",
+                "nodeExcerpt": "tag-d attr-four=",
+              },
+              Object {
+                "errorLocation": "@",
+                "errorLocationPrecedingToken": "=",
+                "errorMessage": "A TSDoc tag must be preceded by whitespace",
+                "kind": "ErrorText",
+                "nodeExcerpt": "@",
+              },
+              Object {
+                "kind": "PlainText",
+                "nodeExcerpt": "[q]four[q] /",
+              },
+              Object {
+                "errorLocation": "[>]",
+                "errorLocationPrecedingToken": "/",
+                "errorMessage": "The [q][>][q] character should be escaped using a backslash to avoid confusion with an HTML tag",
+                "kind": "ErrorText",
+                "nodeExcerpt": "[>]",
+              },
+              Object {
+                "kind": "SoftBreak",
+                "nodeExcerpt": "[n]",
+              },
+              Object {
+                "errorLocation": "@",
+                "errorLocationPrecedingToken": "five",
+                "errorMessage": "The HTML element has an invalid attribute: Expecting [q]=[q] after HTML attribute name",
+                "kind": "ErrorText",
+                "nodeExcerpt": "[<]",
+              },
+              Object {
+                "kind": "PlainText",
+                "nodeExcerpt": "tag-e attr-five",
+              },
+              Object {
+                "errorLocation": "@",
+                "errorLocationPrecedingToken": "five",
+                "errorMessage": "A TSDoc tag must be preceded by whitespace",
+                "kind": "ErrorText",
+                "nodeExcerpt": "@",
+              },
+              Object {
+                "kind": "PlainText",
+                "nodeExcerpt": "=[q]five[q] /",
+              },
+              Object {
+                "errorLocation": "[>]",
+                "errorLocationPrecedingToken": "/",
+                "errorMessage": "The [q][>][q] character should be escaped using a backslash to avoid confusion with an HTML tag",
+                "kind": "ErrorText",
+                "nodeExcerpt": "[>]",
+              },
+              Object {
+                "kind": "SoftBreak",
+                "nodeExcerpt": "[n]",
+              },
+              Object {
+                "errorLocation": "seven",
+                "errorLocationPrecedingToken": "\\"",
+                "errorMessage": "The HTML element has an invalid attribute: The next character after a closing quote must be spacing or punctuation",
+                "kind": "ErrorText",
+                "nodeExcerpt": "[<]",
+              },
+              Object {
+                "kind": "PlainText",
+                "nodeExcerpt": "tag-f attr-six=[q]six[q]seven=[q]seven[q] /",
+              },
+              Object {
+                "errorLocation": "[>]",
+                "errorLocationPrecedingToken": "/",
+                "errorMessage": "The [q][>][q] character should be escaped using a backslash to avoid confusion with an HTML tag",
+                "kind": "ErrorText",
+                "nodeExcerpt": "[>]",
+              },
+              Object {
+                "kind": "SoftBreak",
+                "nodeExcerpt": "[n]",
+              },
+            ],
+          },
+        ],
+      },
+    ],
+  },
 }
 `;
 
@@ -831,38 +909,51 @@ Object {
     "(2,4): The HTML element has an invalid attribute: The HTML string is missing its closing quote",
     "(3,11): The \\">\\" character should be escaped using a backslash to avoid confusion with an HTML tag",
   ],
-  "verbatimNodes": Array [
-    Object {
-      "errorLocation": "[q]",
-      "errorLocationPrecedingToken": "=",
-      "errorMessage": "The HTML element has an invalid attribute: The HTML string is missing its closing quote",
-      "kind": "ErrorText",
-      "nodeExcerpt": "[<]",
-    },
-    Object {
-      "kind": "PlainText",
-      "nodeExcerpt": "tag-g attr=[q]multi",
-    },
-    Object {
-      "kind": "SoftBreak",
-      "nodeExcerpt": "[n]",
-    },
-    Object {
-      "kind": "PlainText",
-      "nodeExcerpt": "line[q] /",
-    },
-    Object {
-      "errorLocation": "[>]",
-      "errorLocationPrecedingToken": "/",
-      "errorMessage": "The [q][>][q] character should be escaped using a backslash to avoid confusion with an HTML tag",
-      "kind": "ErrorText",
-      "nodeExcerpt": "[>]",
-    },
-    Object {
-      "kind": "SoftBreak",
-      "nodeExcerpt": "[n]",
-    },
-  ],
+  "nodes": Object {
+    "kind": "Comment",
+    "nodes": Array [
+      Object {
+        "kind": "Section",
+        "nodes": Array [
+          Object {
+            "kind": "Paragraph",
+            "nodes": Array [
+              Object {
+                "errorLocation": "[q]",
+                "errorLocationPrecedingToken": "=",
+                "errorMessage": "The HTML element has an invalid attribute: The HTML string is missing its closing quote",
+                "kind": "ErrorText",
+                "nodeExcerpt": "[<]",
+              },
+              Object {
+                "kind": "PlainText",
+                "nodeExcerpt": "tag-g attr=[q]multi",
+              },
+              Object {
+                "kind": "SoftBreak",
+                "nodeExcerpt": "[n]",
+              },
+              Object {
+                "kind": "PlainText",
+                "nodeExcerpt": "line[q] /",
+              },
+              Object {
+                "errorLocation": "[>]",
+                "errorLocationPrecedingToken": "/",
+                "errorMessage": "The [q][>][q] character should be escaped using a backslash to avoid confusion with an HTML tag",
+                "kind": "ErrorText",
+                "nodeExcerpt": "[>]",
+              },
+              Object {
+                "kind": "SoftBreak",
+                "nodeExcerpt": "[n]",
+              },
+            ],
+          },
+        ],
+      },
+    ],
+  },
 }
 `;
 
@@ -873,48 +964,61 @@ Object {
     "[<]tag attr-one=[q]@tag[q] /[>]",
   ],
   "logMessages": Array [],
-  "verbatimNodes": Array [
-    Object {
-      "kind": "HtmlStartTag",
-      "nodes": Array [
-        Object {
-          "kind": "Particle",
-          "nodeExcerpt": "[<]",
-        },
-        Object {
-          "kind": "Particle",
-          "nodeExcerpt": "tag",
-          "nodeSpacing": " ",
-        },
-        Object {
-          "kind": "HtmlAttribute",
-          "nodes": Array [
-            Object {
-              "kind": "Particle",
-              "nodeExcerpt": "attr-one",
-            },
-            Object {
-              "kind": "Particle",
-              "nodeExcerpt": "=",
-            },
-            Object {
-              "kind": "Particle",
-              "nodeExcerpt": "[q]@tag[q]",
-              "nodeSpacing": " ",
-            },
-          ],
-        },
-        Object {
-          "kind": "Particle",
-          "nodeExcerpt": "/[>]",
-        },
-      ],
-    },
-    Object {
-      "kind": "SoftBreak",
-      "nodeExcerpt": "[n]",
-    },
-  ],
+  "nodes": Object {
+    "kind": "Comment",
+    "nodes": Array [
+      Object {
+        "kind": "Section",
+        "nodes": Array [
+          Object {
+            "kind": "Paragraph",
+            "nodes": Array [
+              Object {
+                "kind": "HtmlStartTag",
+                "nodes": Array [
+                  Object {
+                    "kind": "Particle",
+                    "nodeExcerpt": "[<]",
+                  },
+                  Object {
+                    "kind": "Particle",
+                    "nodeExcerpt": "tag",
+                    "nodeSpacing": " ",
+                  },
+                  Object {
+                    "kind": "HtmlAttribute",
+                    "nodes": Array [
+                      Object {
+                        "kind": "Particle",
+                        "nodeExcerpt": "attr-one",
+                      },
+                      Object {
+                        "kind": "Particle",
+                        "nodeExcerpt": "=",
+                      },
+                      Object {
+                        "kind": "Particle",
+                        "nodeExcerpt": "[q]@tag[q]",
+                        "nodeSpacing": " ",
+                      },
+                    ],
+                  },
+                  Object {
+                    "kind": "Particle",
+                    "nodeExcerpt": "/[>]",
+                  },
+                ],
+              },
+              Object {
+                "kind": "SoftBreak",
+                "nodeExcerpt": "[n]",
+              },
+            ],
+          },
+        ],
+      },
+    ],
+  },
 }
 `;
 
@@ -928,73 +1032,86 @@ Object {
     "  [>]",
   ],
   "logMessages": Array [],
-  "verbatimNodes": Array [
-    Object {
-      "kind": "HtmlEndTag",
-      "nodes": Array [
-        Object {
-          "kind": "Particle",
-          "nodeExcerpt": "[<]/",
-        },
-        Object {
-          "kind": "Particle",
-          "nodeExcerpt": "tag-a",
-        },
-        Object {
-          "kind": "Particle",
-          "nodeExcerpt": "[>]",
-        },
-      ],
-    },
-    Object {
-      "kind": "SoftBreak",
-      "nodeExcerpt": "[n]",
-    },
-    Object {
-      "kind": "HtmlEndTag",
-      "nodes": Array [
-        Object {
-          "kind": "Particle",
-          "nodeExcerpt": "[<]/",
-        },
-        Object {
-          "kind": "Particle",
-          "nodeExcerpt": "tag-b",
-          "nodeSpacing": "  ",
-        },
-        Object {
-          "kind": "Particle",
-          "nodeExcerpt": "[>]",
-        },
-      ],
-    },
-    Object {
-      "kind": "SoftBreak",
-      "nodeExcerpt": "[n]",
-    },
-    Object {
-      "kind": "HtmlEndTag",
-      "nodes": Array [
-        Object {
-          "kind": "Particle",
-          "nodeExcerpt": "[<]/",
-        },
-        Object {
-          "kind": "Particle",
-          "nodeExcerpt": "tag-c",
-          "nodeSpacing": "[n]  ",
-        },
-        Object {
-          "kind": "Particle",
-          "nodeExcerpt": "[>]",
-        },
-      ],
-    },
-    Object {
-      "kind": "SoftBreak",
-      "nodeExcerpt": "[n]",
-    },
-  ],
+  "nodes": Object {
+    "kind": "Comment",
+    "nodes": Array [
+      Object {
+        "kind": "Section",
+        "nodes": Array [
+          Object {
+            "kind": "Paragraph",
+            "nodes": Array [
+              Object {
+                "kind": "HtmlEndTag",
+                "nodes": Array [
+                  Object {
+                    "kind": "Particle",
+                    "nodeExcerpt": "[<]/",
+                  },
+                  Object {
+                    "kind": "Particle",
+                    "nodeExcerpt": "tag-a",
+                  },
+                  Object {
+                    "kind": "Particle",
+                    "nodeExcerpt": "[>]",
+                  },
+                ],
+              },
+              Object {
+                "kind": "SoftBreak",
+                "nodeExcerpt": "[n]",
+              },
+              Object {
+                "kind": "HtmlEndTag",
+                "nodes": Array [
+                  Object {
+                    "kind": "Particle",
+                    "nodeExcerpt": "[<]/",
+                  },
+                  Object {
+                    "kind": "Particle",
+                    "nodeExcerpt": "tag-b",
+                    "nodeSpacing": "  ",
+                  },
+                  Object {
+                    "kind": "Particle",
+                    "nodeExcerpt": "[>]",
+                  },
+                ],
+              },
+              Object {
+                "kind": "SoftBreak",
+                "nodeExcerpt": "[n]",
+              },
+              Object {
+                "kind": "HtmlEndTag",
+                "nodes": Array [
+                  Object {
+                    "kind": "Particle",
+                    "nodeExcerpt": "[<]/",
+                  },
+                  Object {
+                    "kind": "Particle",
+                    "nodeExcerpt": "tag-c",
+                    "nodeSpacing": "[n]  ",
+                  },
+                  Object {
+                    "kind": "Particle",
+                    "nodeExcerpt": "[>]",
+                  },
+                ],
+              },
+              Object {
+                "kind": "SoftBreak",
+                "nodeExcerpt": "[n]",
+              },
+            ],
+          },
+        ],
+      },
+    ],
+  },
 }
 `;
 
@@ -1013,67 +1130,80 @@ Object {
     "(3,12): The \\">\\" character should be escaped using a backslash to avoid confusion with an HTML tag",
     "(4,4): Expecting a closing \\">\\" for the HTML tag",
   ],
-  "verbatimNodes": Array [
-    Object {
-      "errorLocation": "/",
-      "errorLocationPrecedingToken": "a",
-      "errorMessage": "Expecting a closing [q][>][q] for the HTML tag",
-      "kind": "ErrorText",
-      "nodeExcerpt": "[<]",
-    },
-    Object {
-      "kind": "PlainText",
-      "nodeExcerpt": "/tag-a/",
-    },
-    Object {
-      "errorLocation": "[>]",
-      "errorLocationPrecedingToken": "/",
-      "errorMessage": "The [q][>][q] character should be escaped using a backslash to avoid confusion with an HTML tag",
-      "kind": "ErrorText",
-      "nodeExcerpt": "[>]",
-    },
-    Object {
-      "kind": "SoftBreak",
-      "nodeExcerpt": "[n]",
-    },
-    Object {
-      "errorLocation": " ",
-      "errorLocationPrecedingToken": "/",
-      "errorMessage": "Expecting an HTML element name: A space is not allowed here",
-      "kind": "ErrorText",
-      "nodeExcerpt": "[<]",
-    },
-    Object {
-      "kind": "PlainText",
-      "nodeExcerpt": "/ tag-b",
-    },
-    Object {
-      "errorLocation": "[>]",
-      "errorLocationPrecedingToken": "b",
-      "errorMessage": "The [q][>][q] character should be escaped using a backslash to avoid confusion with an HTML tag",
-      "kind": "ErrorText",
-      "nodeExcerpt": "[>]",
-    },
-    Object {
-      "kind": "SoftBreak",
-      "nodeExcerpt": "[n]",
-    },
-    Object {
-      "errorLocation": "",
-      "errorLocationPrecedingToken": "
+  "nodes": Object {
+    "kind": "Comment",
+    "nodes": Array [
+      Object {
+        "kind": "Section",
+        "nodes": Array [
+          Object {
+            "kind": "Paragraph",
+            "nodes": Array [
+              Object {
+                "errorLocation": "/",
+                "errorLocationPrecedingToken": "a",
+                "errorMessage": "Expecting a closing [q][>][q] for the HTML tag",
+                "kind": "ErrorText",
+                "nodeExcerpt": "[<]",
+              },
+              Object {
+                "kind": "PlainText",
+                "nodeExcerpt": "/tag-a/",
+              },
+              Object {
+                "errorLocation": "[>]",
+                "errorLocationPrecedingToken": "/",
+                "errorMessage": "The [q][>][q] character should be escaped using a backslash to avoid confusion with an HTML tag",
+                "kind": "ErrorText",
+                "nodeExcerpt": "[>]",
+              },
+              Object {
+                "kind": "SoftBreak",
+                "nodeExcerpt": "[n]",
+              },
+              Object {
+                "errorLocation": " ",
+                "errorLocationPrecedingToken": "/",
+                "errorMessage": "Expecting an HTML element name: A space is not allowed here",
+                "kind": "ErrorText",
+                "nodeExcerpt": "[<]",
+              },
+              Object {
+                "kind": "PlainText",
+                "nodeExcerpt": "/ tag-b",
+              },
+              Object {
+                "errorLocation": "[>]",
+                "errorLocationPrecedingToken": "b",
+                "errorMessage": "The [q][>][q] character should be escaped using a backslash to avoid confusion with an HTML tag",
+                "kind": "ErrorText",
+                "nodeExcerpt": "[>]",
+              },
+              Object {
+                "kind": "SoftBreak",
+                "nodeExcerpt": "[n]",
+              },
+              Object {
+                "errorLocation": "",
+                "errorLocationPrecedingToken": "
 ",
-      "errorMessage": "Expecting a closing [q][>][q] for the HTML tag",
-      "kind": "ErrorText",
-      "nodeExcerpt": "[<]",
-    },
-    Object {
-      "kind": "PlainText",
-      "nodeExcerpt": "/tag-c",
-    },
-    Object {
-      "kind": "SoftBreak",
-      "nodeExcerpt": "[n]",
-    },
-  ],
+                "errorMessage": "Expecting a closing [q][>][q] for the HTML tag",
+                "kind": "ErrorText",
+                "nodeExcerpt": "[<]",
+              },
+              Object {
+                "kind": "PlainText",
+                "nodeExcerpt": "/tag-c",
+              },
+              Object {
+                "kind": "SoftBreak",
+                "nodeExcerpt": "[n]",
+              },
+            ],
+          },
+        ],
+      },
+    ],
+  },
 }
 `;

--- a/tsdoc/src/parser/__tests__/__snapshots__/NodeParserHtml.test.ts.snap
+++ b/tsdoc/src/parser/__tests__/__snapshots__/NodeParserHtml.test.ts.snap
@@ -3,6 +3,7 @@
 exports[`01 HTML start tags: simple, positive 1`] = `
 Object {
   "buffer": "/**[n] * [<]tag/[>][n] * [<]tag-a /[>][n] * [<]tag-b [>][<]tag-c /[>][n] * [<]tag-d[n] * [>][n] * [<]tag-e[n] *      /[>]  [n] */",
+  "gaps": Array [],
   "lines": Array [
     "[<]tag/[>]",
     "[<]tag-a /[>]",
@@ -161,6 +162,7 @@ Object {
 exports[`02 HTML start tags: simple, negative 1`] = `
 Object {
   "buffer": "/**[n] * [<] tag/[>][n] * [<]tag -a /[>][n] * [<]tag-b /[<]tag-c / [>][n] * [<]tag-d[n] */",
+  "gaps": Array [],
   "lines": Array [
     "[<] tag/[>]",
     "[<]tag -a /[>]",
@@ -291,6 +293,7 @@ Object {
 exports[`03 HTML start tags: with attributes, positive 1`] = `
 Object {
   "buffer": "/**[n] * [<]tag-a attr-one=[q]one[q] [>][n] * [<]tag-b[n] *   attr-two[n] *   = [q]2[q][n] * /[>][n] */",
+  "gaps": Array [],
   "lines": Array [
     "[<]tag-a attr-one=[q]one[q] [>]",
     "[<]tag-b",
@@ -402,6 +405,7 @@ Object {
 exports[`03 HTML start tags: with attributes, positive 2`] = `
 Object {
   "buffer": "/**[n] * [<]tag-c attr-three=[q]3[q] four='4'/[>][n] * [<]tag-d[n] *   attr-five[n] *   = [q]5[q][n] *   six[n] *   = '6'[n] * /[>][n] */",
+  "gaps": Array [],
   "lines": Array [
     "[<]tag-c attr-three=[q]3[q] four='4'/[>]",
     "[<]tag-d",
@@ -552,6 +556,7 @@ Object {
 exports[`03 HTML start tags: with attributes, positive 3`] = `
 Object {
   "buffer": "/**[n] * [<]tag-e attr-one=[q]one[q] two='two'/[>][n] * [<]tag-f[n] *   attr-one[n] *   = [q]one[q][n] *   two[n] *   = 'two'[n] * /[>][n] */",
+  "gaps": Array [],
   "lines": Array [
     "[<]tag-e attr-one=[q]one[q] two='two'/[>]",
     "[<]tag-f",
@@ -702,6 +707,7 @@ Object {
 exports[`04 HTML start tags: with attributes, negative 1`] = `
 Object {
   "buffer": "/**[n] * [<]tag-a attr -one=[q]one[q] /[>][n] * [<]tag-b attr- two=[q]two[q] /[>][n] * [<]tag-c attr-three='three[q] /[>][n] * [<]tag-d attr-four=@[q]four[q] /[>][n] * [<]tag-e attr-five@=[q]five[q] /[>][n] * [<]tag-f attr-six=[q]six[q]seven=[q]seven[q] /[>][n] */",
+  "gaps": Array [],
   "lines": Array [
     "[<]tag-a attr -one=[q]one[q] /[>]",
     "[<]tag-b attr- two=[q]two[q] /[>]",
@@ -901,6 +907,7 @@ Object {
 exports[`04 HTML start tags: with attributes, negative 2`] = `
 Object {
   "buffer": "/**[n] * [<]tag-g attr=[q]multi[n] * line[q] /[>][n] */",
+  "gaps": Array [],
   "lines": Array [
     "[<]tag-g attr=[q]multi",
     "line[q] /[>]",
@@ -960,6 +967,7 @@ Object {
 exports[`05 Eclipsed TSDoc 1`] = `
 Object {
   "buffer": "/**[n] * [<]tag attr-one=[q]@tag[q] /[>][n] */",
+  "gaps": Array [],
   "lines": Array [
     "[<]tag attr-one=[q]@tag[q] /[>]",
   ],
@@ -1025,6 +1033,7 @@ Object {
 exports[`06 Closing tags, positive 1`] = `
 Object {
   "buffer": "/**[n] * [<]/tag-a[>][n] * [<]/tag-b  [>][n] * [<]/tag-c[n] *   [>][n] */",
+  "gaps": Array [],
   "lines": Array [
     "[<]/tag-a[>]",
     "[<]/tag-b  [>]",
@@ -1118,6 +1127,7 @@ Object {
 exports[`07 Closing tags, negative 1`] = `
 Object {
   "buffer": "/**[n] * [<]/tag-a/[>][n] * [<]/ tag-b[>][n] * [<]/tag-c[n] */",
+  "gaps": Array [],
   "lines": Array [
     "[<]/tag-a/[>]",
     "[<]/ tag-b[>]",

--- a/tsdoc/src/parser/__tests__/__snapshots__/NodeParserTags.test.ts.snap
+++ b/tsdoc/src/parser/__tests__/__snapshots__/NodeParserTags.test.ts.snap
@@ -3,6 +3,7 @@
 exports[`00 Block tags: positive examples 1`] = `
 Object {
   "buffer": "/**[n] * @one [n] * @two[n] */",
+  "gaps": Array [],
   "lines": Array [
     "@one",
     "@two",
@@ -45,6 +46,7 @@ Object {
 exports[`01 Block tags: negative examples 1`] = `
 Object {
   "buffer": "/**[n] * @ one [n] * +@two [n] * @two+ [n] */",
+  "gaps": Array [],
   "lines": Array [
     "@ one",
     "+@two",
@@ -125,6 +127,7 @@ Object {
 exports[`02 Inline tags: simple, positive 1`] = `
 Object {
   "buffer": "/**[n] * {@one} [n] * {@two } [n] * {@three}{@four} [n] * {@five [n] *   } [n] */",
+  "gaps": Array [],
   "lines": Array [
     "{@one}",
     "{@two }",
@@ -272,6 +275,7 @@ Object {
 exports[`03 Inline tags: simple, negative 1`] = `
 Object {
   "buffer": "/**[n] * {@ one} [n] * {@two~} [n] * { @three} [n] * {@four[n] */",
+  "gaps": Array [],
   "lines": Array [
     "{@ one}",
     "{@two~}",
@@ -403,6 +407,7 @@ Object {
 exports[`04 Inline tags: complex, positive 1`] = `
 Object {
   "buffer": "/**[n] * {@one some content}[n] * {@two multi[n] * line}[n] */",
+  "gaps": Array [],
   "lines": Array [
     "{@one some content}",
     "{@two multi",
@@ -480,6 +485,7 @@ Object {
 exports[`04 Inline tags: complex, positive 2`] = `
 Object {
   "buffer": "/**[n] * {@three @taglike}[n] */",
+  "gaps": Array [],
   "lines": Array [
     "{@three @taglike}",
   ],
@@ -530,6 +536,7 @@ Object {
 exports[`05 Inline tags: escaping, positive 1`] = `
 Object {
   "buffer": "/**[n] * {@one left [b]{ right [b]} backslash [b][b] }[n] */",
+  "gaps": Array [],
   "lines": Array [
     "{@one left [b]{ right [b]} backslash [b][b] }",
   ],
@@ -580,6 +587,7 @@ Object {
 exports[`06 Inline tags: escaping, negative 1`] = `
 Object {
   "buffer": "/**[n] * {@one curly[b]}[n] */",
+  "gaps": Array [],
   "lines": Array [
     "{@one curly[b]}",
   ],
@@ -625,6 +633,7 @@ Object {
 exports[`06 Inline tags: escaping, negative 2`] = `
 Object {
   "buffer": "/**[n] * {@two curly{}}[n] */",
+  "gaps": Array [],
   "lines": Array [
     "{@two curly{}}",
   ],
@@ -691,6 +700,7 @@ Object {
 exports[`06 Inline tags: escaping, negative 3`] = `
 Object {
   "buffer": "/**[n] * three: }[n] */",
+  "gaps": Array [],
   "lines": Array [
     "three: }",
   ],

--- a/tsdoc/src/parser/__tests__/__snapshots__/NodeParserTags.test.ts.snap
+++ b/tsdoc/src/parser/__tests__/__snapshots__/NodeParserTags.test.ts.snap
@@ -8,24 +8,37 @@ Object {
     "@two",
   ],
   "logMessages": Array [],
-  "verbatimNodes": Array [
-    Object {
-      "kind": "BlockTag",
-      "nodeExcerpt": "@one",
-    },
-    Object {
-      "kind": "SoftBreak",
-      "nodeExcerpt": "[n]",
-    },
-    Object {
-      "kind": "BlockTag",
-      "nodeExcerpt": "@two",
-    },
-    Object {
-      "kind": "SoftBreak",
-      "nodeExcerpt": "[n]",
-    },
-  ],
+  "nodes": Object {
+    "kind": "Comment",
+    "nodes": Array [
+      Object {
+        "kind": "Section",
+        "nodes": Array [
+          Object {
+            "kind": "Paragraph",
+            "nodes": Array [
+              Object {
+                "kind": "BlockTag",
+                "nodeExcerpt": "@one",
+              },
+              Object {
+                "kind": "SoftBreak",
+                "nodeExcerpt": "[n]",
+              },
+              Object {
+                "kind": "BlockTag",
+                "nodeExcerpt": "@two",
+              },
+              Object {
+                "kind": "SoftBreak",
+                "nodeExcerpt": "[n]",
+              },
+            ],
+          },
+        ],
+      },
+    ],
+  },
 }
 `;
 
@@ -42,57 +55,70 @@ Object {
     "(3,5): A TSDoc tag must be preceded by whitespace",
     "(4,4): A TSDoc tag must be followed by whitespace",
   ],
-  "verbatimNodes": Array [
-    Object {
-      "errorLocation": "@",
-      "errorMessage": "Expecting a TSDoc tag name after the [q]@[q] character (or use a backslash to escape this character)",
-      "kind": "ErrorText",
-      "nodeExcerpt": "@",
-    },
-    Object {
-      "kind": "PlainText",
-      "nodeExcerpt": " one",
-    },
-    Object {
-      "kind": "SoftBreak",
-      "nodeExcerpt": "[n]",
-    },
-    Object {
-      "kind": "PlainText",
-      "nodeExcerpt": "+",
-    },
-    Object {
-      "errorLocation": "@",
-      "errorLocationPrecedingToken": "+",
-      "errorMessage": "A TSDoc tag must be preceded by whitespace",
-      "kind": "ErrorText",
-      "nodeExcerpt": "@",
-    },
-    Object {
-      "kind": "PlainText",
-      "nodeExcerpt": "two",
-    },
-    Object {
-      "kind": "SoftBreak",
-      "nodeExcerpt": "[n]",
-    },
-    Object {
-      "errorLocation": "@",
-      "errorLocationPrecedingToken": "
+  "nodes": Object {
+    "kind": "Comment",
+    "nodes": Array [
+      Object {
+        "kind": "Section",
+        "nodes": Array [
+          Object {
+            "kind": "Paragraph",
+            "nodes": Array [
+              Object {
+                "errorLocation": "@",
+                "errorMessage": "Expecting a TSDoc tag name after the [q]@[q] character (or use a backslash to escape this character)",
+                "kind": "ErrorText",
+                "nodeExcerpt": "@",
+              },
+              Object {
+                "kind": "PlainText",
+                "nodeExcerpt": " one",
+              },
+              Object {
+                "kind": "SoftBreak",
+                "nodeExcerpt": "[n]",
+              },
+              Object {
+                "kind": "PlainText",
+                "nodeExcerpt": "+",
+              },
+              Object {
+                "errorLocation": "@",
+                "errorLocationPrecedingToken": "+",
+                "errorMessage": "A TSDoc tag must be preceded by whitespace",
+                "kind": "ErrorText",
+                "nodeExcerpt": "@",
+              },
+              Object {
+                "kind": "PlainText",
+                "nodeExcerpt": "two",
+              },
+              Object {
+                "kind": "SoftBreak",
+                "nodeExcerpt": "[n]",
+              },
+              Object {
+                "errorLocation": "@",
+                "errorLocationPrecedingToken": "
 ",
-      "errorMessage": "A TSDoc tag must be followed by whitespace",
-      "kind": "ErrorText",
-      "nodeExcerpt": "@",
-    },
-    Object {
-      "kind": "PlainText",
-      "nodeExcerpt": "two+",
-    },
-    Object {
-      "kind": "SoftBreak",
-      "nodeExcerpt": "[n]",
-    },
-  ],
+                "errorMessage": "A TSDoc tag must be followed by whitespace",
+                "kind": "ErrorText",
+                "nodeExcerpt": "@",
+              },
+              Object {
+                "kind": "PlainText",
+                "nodeExcerpt": "two+",
+              },
+              Object {
+                "kind": "SoftBreak",
+                "nodeExcerpt": "[n]",
+              },
+            ],
+          },
+        ],
+      },
+    ],
+  },
 }
 `;
 
@@ -107,126 +133,139 @@ Object {
     "  }",
   ],
   "logMessages": Array [],
-  "verbatimNodes": Array [
-    Object {
-      "kind": "InlineTag",
-      "nodes": Array [
-        Object {
-          "kind": "Particle",
-          "nodeExcerpt": "{",
-        },
-        Object {
-          "kind": "Particle",
-          "nodeExcerpt": "@one",
-        },
-        Object {
-          "kind": "Particle",
-        },
-        Object {
-          "kind": "Particle",
-          "nodeExcerpt": "}",
-        },
-      ],
-    },
-    Object {
-      "kind": "SoftBreak",
-      "nodeExcerpt": "[n]",
-    },
-    Object {
-      "kind": "InlineTag",
-      "nodes": Array [
-        Object {
-          "kind": "Particle",
-          "nodeExcerpt": "{",
-        },
-        Object {
-          "kind": "Particle",
-          "nodeExcerpt": "@two",
-        },
-        Object {
-          "kind": "Particle",
-          "nodeExcerpt": " ",
-        },
-        Object {
-          "kind": "Particle",
-          "nodeExcerpt": "}",
-        },
-      ],
-    },
-    Object {
-      "kind": "SoftBreak",
-      "nodeExcerpt": "[n]",
-    },
-    Object {
-      "kind": "InlineTag",
-      "nodes": Array [
-        Object {
-          "kind": "Particle",
-          "nodeExcerpt": "{",
-        },
-        Object {
-          "kind": "Particle",
-          "nodeExcerpt": "@three",
-        },
-        Object {
-          "kind": "Particle",
-        },
-        Object {
-          "kind": "Particle",
-          "nodeExcerpt": "}",
-        },
-      ],
-    },
-    Object {
-      "kind": "InlineTag",
-      "nodes": Array [
-        Object {
-          "kind": "Particle",
-          "nodeExcerpt": "{",
-        },
-        Object {
-          "kind": "Particle",
-          "nodeExcerpt": "@four",
-        },
-        Object {
-          "kind": "Particle",
-        },
-        Object {
-          "kind": "Particle",
-          "nodeExcerpt": "}",
-        },
-      ],
-    },
-    Object {
-      "kind": "SoftBreak",
-      "nodeExcerpt": "[n]",
-    },
-    Object {
-      "kind": "InlineTag",
-      "nodes": Array [
-        Object {
-          "kind": "Particle",
-          "nodeExcerpt": "{",
-        },
-        Object {
-          "kind": "Particle",
-          "nodeExcerpt": "@five",
-        },
-        Object {
-          "kind": "Particle",
-          "nodeExcerpt": "[n]  ",
-        },
-        Object {
-          "kind": "Particle",
-          "nodeExcerpt": "}",
-        },
-      ],
-    },
-    Object {
-      "kind": "SoftBreak",
-      "nodeExcerpt": "[n]",
-    },
-  ],
+  "nodes": Object {
+    "kind": "Comment",
+    "nodes": Array [
+      Object {
+        "kind": "Section",
+        "nodes": Array [
+          Object {
+            "kind": "Paragraph",
+            "nodes": Array [
+              Object {
+                "kind": "InlineTag",
+                "nodes": Array [
+                  Object {
+                    "kind": "Particle",
+                    "nodeExcerpt": "{",
+                  },
+                  Object {
+                    "kind": "Particle",
+                    "nodeExcerpt": "@one",
+                  },
+                  Object {
+                    "kind": "Particle",
+                  },
+                  Object {
+                    "kind": "Particle",
+                    "nodeExcerpt": "}",
+                  },
+                ],
+              },
+              Object {
+                "kind": "SoftBreak",
+                "nodeExcerpt": "[n]",
+              },
+              Object {
+                "kind": "InlineTag",
+                "nodes": Array [
+                  Object {
+                    "kind": "Particle",
+                    "nodeExcerpt": "{",
+                  },
+                  Object {
+                    "kind": "Particle",
+                    "nodeExcerpt": "@two",
+                  },
+                  Object {
+                    "kind": "Particle",
+                    "nodeExcerpt": " ",
+                  },
+                  Object {
+                    "kind": "Particle",
+                    "nodeExcerpt": "}",
+                  },
+                ],
+              },
+              Object {
+                "kind": "SoftBreak",
+                "nodeExcerpt": "[n]",
+              },
+              Object {
+                "kind": "InlineTag",
+                "nodes": Array [
+                  Object {
+                    "kind": "Particle",
+                    "nodeExcerpt": "{",
+                  },
+                  Object {
+                    "kind": "Particle",
+                    "nodeExcerpt": "@three",
+                  },
+                  Object {
+                    "kind": "Particle",
+                  },
+                  Object {
+                    "kind": "Particle",
+                    "nodeExcerpt": "}",
+                  },
+                ],
+              },
+              Object {
+                "kind": "InlineTag",
+                "nodes": Array [
+                  Object {
+                    "kind": "Particle",
+                    "nodeExcerpt": "{",
+                  },
+                  Object {
+                    "kind": "Particle",
+                    "nodeExcerpt": "@four",
+                  },
+                  Object {
+                    "kind": "Particle",
+                  },
+                  Object {
+                    "kind": "Particle",
+                    "nodeExcerpt": "}",
+                  },
+                ],
+              },
+              Object {
+                "kind": "SoftBreak",
+                "nodeExcerpt": "[n]",
+              },
+              Object {
+                "kind": "InlineTag",
+                "nodes": Array [
+                  Object {
+                    "kind": "Particle",
+                    "nodeExcerpt": "{",
+                  },
+                  Object {
+                    "kind": "Particle",
+                    "nodeExcerpt": "@five",
+                  },
+                  Object {
+                    "kind": "Particle",
+                    "nodeExcerpt": "[n]  ",
+                  },
+                  Object {
+                    "kind": "Particle",
+                    "nodeExcerpt": "}",
+                  },
+                ],
+              },
+              Object {
+                "kind": "SoftBreak",
+                "nodeExcerpt": "[n]",
+              },
+            ],
+          },
+        ],
+      },
+    ],
+  },
 }
 `;
 
@@ -249,102 +288,115 @@ Object {
     "(4,12): The \\"}\\" character should be escaped using a backslash to avoid confusion with a TSDoc inline tag",
     "(5,4): The TSDoc inline tag name is missing its closing \\"}\\"",
   ],
-  "verbatimNodes": Array [
-    Object {
-      "errorLocation": "@",
-      "errorLocationPrecedingToken": "{",
-      "errorMessage": "Expecting a TSDoc inline tag name after the [q]{@[q] characters",
-      "kind": "ErrorText",
-      "nodeExcerpt": "{@",
-    },
-    Object {
-      "kind": "PlainText",
-      "nodeExcerpt": " one",
-    },
-    Object {
-      "errorLocation": "}",
-      "errorLocationPrecedingToken": "one",
-      "errorMessage": "The [q]}[q] character should be escaped using a backslash to avoid confusion with a TSDoc inline tag",
-      "kind": "ErrorText",
-      "nodeExcerpt": "}",
-    },
-    Object {
-      "kind": "SoftBreak",
-      "nodeExcerpt": "[n]",
-    },
-    Object {
-      "errorLocation": "~",
-      "errorLocationPrecedingToken": "two",
-      "errorMessage": "Expecting a space after the TSDoc inline tag name",
-      "kind": "ErrorText",
-      "nodeExcerpt": "{@",
-    },
-    Object {
-      "kind": "PlainText",
-      "nodeExcerpt": "two~",
-    },
-    Object {
-      "errorLocation": "}",
-      "errorLocationPrecedingToken": "~",
-      "errorMessage": "The [q]}[q] character should be escaped using a backslash to avoid confusion with a TSDoc inline tag",
-      "kind": "ErrorText",
-      "nodeExcerpt": "}",
-    },
-    Object {
-      "kind": "SoftBreak",
-      "nodeExcerpt": "[n]",
-    },
-    Object {
-      "errorLocation": "{",
-      "errorLocationPrecedingToken": "
+  "nodes": Object {
+    "kind": "Comment",
+    "nodes": Array [
+      Object {
+        "kind": "Section",
+        "nodes": Array [
+          Object {
+            "kind": "Paragraph",
+            "nodes": Array [
+              Object {
+                "errorLocation": "@",
+                "errorLocationPrecedingToken": "{",
+                "errorMessage": "Expecting a TSDoc inline tag name after the [q]{@[q] characters",
+                "kind": "ErrorText",
+                "nodeExcerpt": "{@",
+              },
+              Object {
+                "kind": "PlainText",
+                "nodeExcerpt": " one",
+              },
+              Object {
+                "errorLocation": "}",
+                "errorLocationPrecedingToken": "one",
+                "errorMessage": "The [q]}[q] character should be escaped using a backslash to avoid confusion with a TSDoc inline tag",
+                "kind": "ErrorText",
+                "nodeExcerpt": "}",
+              },
+              Object {
+                "kind": "SoftBreak",
+                "nodeExcerpt": "[n]",
+              },
+              Object {
+                "errorLocation": "~",
+                "errorLocationPrecedingToken": "two",
+                "errorMessage": "Expecting a space after the TSDoc inline tag name",
+                "kind": "ErrorText",
+                "nodeExcerpt": "{@",
+              },
+              Object {
+                "kind": "PlainText",
+                "nodeExcerpt": "two~",
+              },
+              Object {
+                "errorLocation": "}",
+                "errorLocationPrecedingToken": "~",
+                "errorMessage": "The [q]}[q] character should be escaped using a backslash to avoid confusion with a TSDoc inline tag",
+                "kind": "ErrorText",
+                "nodeExcerpt": "}",
+              },
+              Object {
+                "kind": "SoftBreak",
+                "nodeExcerpt": "[n]",
+              },
+              Object {
+                "errorLocation": "{",
+                "errorLocationPrecedingToken": "
 ",
-      "errorMessage": "Expecting a TSDoc tag starting with [q]{@[q]",
-      "kind": "ErrorText",
-      "nodeExcerpt": "{",
-    },
-    Object {
-      "kind": "PlainText",
-      "nodeExcerpt": " ",
-    },
-    Object {
-      "errorLocation": "@",
-      "errorLocationPrecedingToken": " ",
-      "errorMessage": "A TSDoc tag must be followed by whitespace",
-      "kind": "ErrorText",
-      "nodeExcerpt": "@",
-    },
-    Object {
-      "kind": "PlainText",
-      "nodeExcerpt": "three",
-    },
-    Object {
-      "errorLocation": "}",
-      "errorLocationPrecedingToken": "three",
-      "errorMessage": "The [q]}[q] character should be escaped using a backslash to avoid confusion with a TSDoc inline tag",
-      "kind": "ErrorText",
-      "nodeExcerpt": "}",
-    },
-    Object {
-      "kind": "SoftBreak",
-      "nodeExcerpt": "[n]",
-    },
-    Object {
-      "errorLocation": "{@",
-      "errorLocationPrecedingToken": "
+                "errorMessage": "Expecting a TSDoc tag starting with [q]{@[q]",
+                "kind": "ErrorText",
+                "nodeExcerpt": "{",
+              },
+              Object {
+                "kind": "PlainText",
+                "nodeExcerpt": " ",
+              },
+              Object {
+                "errorLocation": "@",
+                "errorLocationPrecedingToken": " ",
+                "errorMessage": "A TSDoc tag must be followed by whitespace",
+                "kind": "ErrorText",
+                "nodeExcerpt": "@",
+              },
+              Object {
+                "kind": "PlainText",
+                "nodeExcerpt": "three",
+              },
+              Object {
+                "errorLocation": "}",
+                "errorLocationPrecedingToken": "three",
+                "errorMessage": "The [q]}[q] character should be escaped using a backslash to avoid confusion with a TSDoc inline tag",
+                "kind": "ErrorText",
+                "nodeExcerpt": "}",
+              },
+              Object {
+                "kind": "SoftBreak",
+                "nodeExcerpt": "[n]",
+              },
+              Object {
+                "errorLocation": "{@",
+                "errorLocationPrecedingToken": "
 ",
-      "errorMessage": "The TSDoc inline tag name is missing its closing [q]}[q]",
-      "kind": "ErrorText",
-      "nodeExcerpt": "{@",
-    },
-    Object {
-      "kind": "PlainText",
-      "nodeExcerpt": "four",
-    },
-    Object {
-      "kind": "SoftBreak",
-      "nodeExcerpt": "[n]",
-    },
-  ],
+                "errorMessage": "The TSDoc inline tag name is missing its closing [q]}[q]",
+                "kind": "ErrorText",
+                "nodeExcerpt": "{@",
+              },
+              Object {
+                "kind": "PlainText",
+                "nodeExcerpt": "four",
+              },
+              Object {
+                "kind": "SoftBreak",
+                "nodeExcerpt": "[n]",
+              },
+            ],
+          },
+        ],
+      },
+    ],
+  },
 }
 `;
 
@@ -357,58 +409,71 @@ Object {
     "line}",
   ],
   "logMessages": Array [],
-  "verbatimNodes": Array [
-    Object {
-      "kind": "InlineTag",
-      "nodes": Array [
-        Object {
-          "kind": "Particle",
-          "nodeExcerpt": "{",
-        },
-        Object {
-          "kind": "Particle",
-          "nodeExcerpt": "@one",
-        },
-        Object {
-          "kind": "Particle",
-          "nodeExcerpt": " some content",
-        },
-        Object {
-          "kind": "Particle",
-          "nodeExcerpt": "}",
-        },
-      ],
-    },
-    Object {
-      "kind": "SoftBreak",
-      "nodeExcerpt": "[n]",
-    },
-    Object {
-      "kind": "InlineTag",
-      "nodes": Array [
-        Object {
-          "kind": "Particle",
-          "nodeExcerpt": "{",
-        },
-        Object {
-          "kind": "Particle",
-          "nodeExcerpt": "@two",
-        },
-        Object {
-          "kind": "Particle",
-          "nodeExcerpt": " multi[n]line",
-        },
-        Object {
-          "kind": "Particle",
-          "nodeExcerpt": "}",
-        },
-      ],
-    },
-    Object {
-      "kind": "SoftBreak",
-      "nodeExcerpt": "[n]",
-    },
-  ],
+  "nodes": Object {
+    "kind": "Comment",
+    "nodes": Array [
+      Object {
+        "kind": "Section",
+        "nodes": Array [
+          Object {
+            "kind": "Paragraph",
+            "nodes": Array [
+              Object {
+                "kind": "InlineTag",
+                "nodes": Array [
+                  Object {
+                    "kind": "Particle",
+                    "nodeExcerpt": "{",
+                  },
+                  Object {
+                    "kind": "Particle",
+                    "nodeExcerpt": "@one",
+                  },
+                  Object {
+                    "kind": "Particle",
+                    "nodeExcerpt": " some content",
+                  },
+                  Object {
+                    "kind": "Particle",
+                    "nodeExcerpt": "}",
+                  },
+                ],
+              },
+              Object {
+                "kind": "SoftBreak",
+                "nodeExcerpt": "[n]",
+              },
+              Object {
+                "kind": "InlineTag",
+                "nodes": Array [
+                  Object {
+                    "kind": "Particle",
+                    "nodeExcerpt": "{",
+                  },
+                  Object {
+                    "kind": "Particle",
+                    "nodeExcerpt": "@two",
+                  },
+                  Object {
+                    "kind": "Particle",
+                    "nodeExcerpt": " multi[n]line",
+                  },
+                  Object {
+                    "kind": "Particle",
+                    "nodeExcerpt": "}",
+                  },
+                ],
+              },
+              Object {
+                "kind": "SoftBreak",
+                "nodeExcerpt": "[n]",
+              },
+            ],
+          },
+        ],
+      },
+    ],
+  },
 }
 `;
 
@@ -419,33 +484,46 @@ Object {
     "{@three @taglike}",
   ],
   "logMessages": Array [],
-  "verbatimNodes": Array [
-    Object {
-      "kind": "InlineTag",
-      "nodes": Array [
-        Object {
-          "kind": "Particle",
-          "nodeExcerpt": "{",
-        },
-        Object {
-          "kind": "Particle",
-          "nodeExcerpt": "@three",
-        },
-        Object {
-          "kind": "Particle",
-          "nodeExcerpt": " @taglike",
-        },
-        Object {
-          "kind": "Particle",
-          "nodeExcerpt": "}",
-        },
-      ],
-    },
-    Object {
-      "kind": "SoftBreak",
-      "nodeExcerpt": "[n]",
-    },
-  ],
+  "nodes": Object {
+    "kind": "Comment",
+    "nodes": Array [
+      Object {
+        "kind": "Section",
+        "nodes": Array [
+          Object {
+            "kind": "Paragraph",
+            "nodes": Array [
+              Object {
+                "kind": "InlineTag",
+                "nodes": Array [
+                  Object {
+                    "kind": "Particle",
+                    "nodeExcerpt": "{",
+                  },
+                  Object {
+                    "kind": "Particle",
+                    "nodeExcerpt": "@three",
+                  },
+                  Object {
+                    "kind": "Particle",
+                    "nodeExcerpt": " @taglike",
+                  },
+                  Object {
+                    "kind": "Particle",
+                    "nodeExcerpt": "}",
+                  },
+                ],
+              },
+              Object {
+                "kind": "SoftBreak",
+                "nodeExcerpt": "[n]",
+              },
+            ],
+          },
+        ],
+      },
+    ],
+  },
 }
 `;
 
@@ -456,33 +534,46 @@ Object {
     "{@one left [b]{ right [b]} backslash [b][b] }",
   ],
   "logMessages": Array [],
-  "verbatimNodes": Array [
-    Object {
-      "kind": "InlineTag",
-      "nodes": Array [
-        Object {
-          "kind": "Particle",
-          "nodeExcerpt": "{",
-        },
-        Object {
-          "kind": "Particle",
-          "nodeExcerpt": "@one",
-        },
-        Object {
-          "kind": "Particle",
-          "nodeExcerpt": " left [b]{ right [b]} backslash [b][b] ",
-        },
-        Object {
-          "kind": "Particle",
-          "nodeExcerpt": "}",
-        },
-      ],
-    },
-    Object {
-      "kind": "SoftBreak",
-      "nodeExcerpt": "[n]",
-    },
-  ],
+  "nodes": Object {
+    "kind": "Comment",
+    "nodes": Array [
+      Object {
+        "kind": "Section",
+        "nodes": Array [
+          Object {
+            "kind": "Paragraph",
+            "nodes": Array [
+              Object {
+                "kind": "InlineTag",
+                "nodes": Array [
+                  Object {
+                    "kind": "Particle",
+                    "nodeExcerpt": "{",
+                  },
+                  Object {
+                    "kind": "Particle",
+                    "nodeExcerpt": "@one",
+                  },
+                  Object {
+                    "kind": "Particle",
+                    "nodeExcerpt": " left [b]{ right [b]} backslash [b][b] ",
+                  },
+                  Object {
+                    "kind": "Particle",
+                    "nodeExcerpt": "}",
+                  },
+                ],
+              },
+              Object {
+                "kind": "SoftBreak",
+                "nodeExcerpt": "[n]",
+              },
+            ],
+          },
+        ],
+      },
+    ],
+  },
 }
 `;
 
@@ -495,26 +586,39 @@ Object {
   "logMessages": Array [
     "(2,4): The TSDoc inline tag name is missing its closing \\"}\\"",
   ],
-  "verbatimNodes": Array [
-    Object {
-      "errorLocation": "{@",
-      "errorMessage": "The TSDoc inline tag name is missing its closing [q]}[q]",
-      "kind": "ErrorText",
-      "nodeExcerpt": "{@",
-    },
-    Object {
-      "kind": "PlainText",
-      "nodeExcerpt": "one curly",
-    },
-    Object {
-      "kind": "EscapedText",
-      "nodeExcerpt": "[b]}",
-    },
-    Object {
-      "kind": "SoftBreak",
-      "nodeExcerpt": "[n]",
-    },
-  ],
+  "nodes": Object {
+    "kind": "Comment",
+    "nodes": Array [
+      Object {
+        "kind": "Section",
+        "nodes": Array [
+          Object {
+            "kind": "Paragraph",
+            "nodes": Array [
+              Object {
+                "errorLocation": "{@",
+                "errorMessage": "The TSDoc inline tag name is missing its closing [q]}[q]",
+                "kind": "ErrorText",
+                "nodeExcerpt": "{@",
+              },
+              Object {
+                "kind": "PlainText",
+                "nodeExcerpt": "one curly",
+              },
+              Object {
+                "kind": "EscapedText",
+                "nodeExcerpt": "[b]}",
+              },
+              Object {
+                "kind": "SoftBreak",
+                "nodeExcerpt": "[n]",
+              },
+            ],
+          },
+        ],
+      },
+    ],
+  },
 }
 `;
 
@@ -530,44 +634,57 @@ Object {
     "(2,16): The \\"}\\" character should be escaped using a backslash to avoid confusion with a TSDoc inline tag",
     "(2,17): The \\"}\\" character should be escaped using a backslash to avoid confusion with a TSDoc inline tag",
   ],
-  "verbatimNodes": Array [
-    Object {
-      "errorLocation": "{",
-      "errorLocationPrecedingToken": "curly",
-      "errorMessage": "The [q]{[q] character must be escaped with a backslash when used inside a TSDoc inline tag",
-      "kind": "ErrorText",
-      "nodeExcerpt": "{@",
-    },
-    Object {
-      "kind": "PlainText",
-      "nodeExcerpt": "two curly",
-    },
-    Object {
-      "errorLocation": "{",
-      "errorLocationPrecedingToken": "curly",
-      "errorMessage": "Expecting a TSDoc tag starting with [q]{@[q]",
-      "kind": "ErrorText",
-      "nodeExcerpt": "{",
-    },
-    Object {
-      "errorLocation": "}",
-      "errorLocationPrecedingToken": "{",
-      "errorMessage": "The [q]}[q] character should be escaped using a backslash to avoid confusion with a TSDoc inline tag",
-      "kind": "ErrorText",
-      "nodeExcerpt": "}",
-    },
-    Object {
-      "errorLocation": "}",
-      "errorLocationPrecedingToken": "}",
-      "errorMessage": "The [q]}[q] character should be escaped using a backslash to avoid confusion with a TSDoc inline tag",
-      "kind": "ErrorText",
-      "nodeExcerpt": "}",
-    },
-    Object {
-      "kind": "SoftBreak",
-      "nodeExcerpt": "[n]",
-    },
-  ],
+  "nodes": Object {
+    "kind": "Comment",
+    "nodes": Array [
+      Object {
+        "kind": "Section",
+        "nodes": Array [
+          Object {
+            "kind": "Paragraph",
+            "nodes": Array [
+              Object {
+                "errorLocation": "{",
+                "errorLocationPrecedingToken": "curly",
+                "errorMessage": "The [q]{[q] character must be escaped with a backslash when used inside a TSDoc inline tag",
+                "kind": "ErrorText",
+                "nodeExcerpt": "{@",
+              },
+              Object {
+                "kind": "PlainText",
+                "nodeExcerpt": "two curly",
+              },
+              Object {
+                "errorLocation": "{",
+                "errorLocationPrecedingToken": "curly",
+                "errorMessage": "Expecting a TSDoc tag starting with [q]{@[q]",
+                "kind": "ErrorText",
+                "nodeExcerpt": "{",
+              },
+              Object {
+                "errorLocation": "}",
+                "errorLocationPrecedingToken": "{",
+                "errorMessage": "The [q]}[q] character should be escaped using a backslash to avoid confusion with a TSDoc inline tag",
+                "kind": "ErrorText",
+                "nodeExcerpt": "}",
+              },
+              Object {
+                "errorLocation": "}",
+                "errorLocationPrecedingToken": "}",
+                "errorMessage": "The [q]}[q] character should be escaped using a backslash to avoid confusion with a TSDoc inline tag",
+                "kind": "ErrorText",
+                "nodeExcerpt": "}",
+              },
+              Object {
+                "kind": "SoftBreak",
+                "nodeExcerpt": "[n]",
+              },
+            ],
+          },
+        ],
+      },
+    ],
+  },
 }
 `;
 
@@ -580,22 +697,35 @@ Object {
   "logMessages": Array [
     "(2,11): The \\"}\\" character should be escaped using a backslash to avoid confusion with a TSDoc inline tag",
   ],
-  "verbatimNodes": Array [
-    Object {
-      "kind": "PlainText",
-      "nodeExcerpt": "three: ",
-    },
-    Object {
-      "errorLocation": "}",
-      "errorLocationPrecedingToken": " ",
-      "errorMessage": "The [q]}[q] character should be escaped using a backslash to avoid confusion with a TSDoc inline tag",
-      "kind": "ErrorText",
-      "nodeExcerpt": "}",
-    },
-    Object {
-      "kind": "SoftBreak",
-      "nodeExcerpt": "[n]",
-    },
-  ],
+  "nodes": Object {
+    "kind": "Comment",
+    "nodes": Array [
+      Object {
+        "kind": "Section",
+        "nodes": Array [
+          Object {
+            "kind": "Paragraph",
+            "nodes": Array [
+              Object {
+                "kind": "PlainText",
+                "nodeExcerpt": "three: ",
+              },
+              Object {
+                "errorLocation": "}",
+                "errorLocationPrecedingToken": " ",
+                "errorMessage": "The [q]}[q] character should be escaped using a backslash to avoid confusion with a TSDoc inline tag",
+                "kind": "ErrorText",
+                "nodeExcerpt": "}",
+              },
+              Object {
+                "kind": "SoftBreak",
+                "nodeExcerpt": "[n]",
+              },
+            ],
+          },
+        ],
+      },
+    ],
+  },
 }
 `;


### PR DESCRIPTION
This PR improves the unit testing strategy to be more flexible.  The only production change is to remove the `ParserContext.verbatimNodes` property.

The `ParserContext.verbatimNodes` property was originally introduced to support `TestHelpers.validateLinearity()`, which tried to ensure that the parser associated every input character with an excerpt for a DocNode object.  However this approach naively assumed that the tree will be mostly linear (i.e. arranged in order of appearance).

The new approach relaxes the validation to allow arbitrary ordering, while still ensuring that (1) excerpts never overlap, and (2) gaps are allowed but tracked in Jest snapshots.