### PR TITLE
Parsing of @link tags: URL destinations (part 1 of 2)

### DIFF
--- a/tsdoc/src/__tests__/__snapshots__/DocNodeTransforms.test.ts.snap
+++ b/tsdoc/src/__tests__/__snapshots__/DocNodeTransforms.test.ts.snap
@@ -18,18 +18,18 @@ Object {
       "kind": "InlineTag",
       "nodes": Array [
         Object {
-          "kind": "Particle",
+          "kind": "Particle: openingDelimiter",
           "nodeExcerpt": "{",
         },
         Object {
-          "kind": "Particle",
+          "kind": "Particle: tagName",
           "nodeExcerpt": "@mylink",
         },
         Object {
-          "kind": "Particle",
+          "kind": "Particle: tagContent",
         },
         Object {
-          "kind": "Particle",
+          "kind": "Particle: closingDelimiter",
           "nodeExcerpt": "}",
         },
       ],

--- a/tsdoc/src/__tests__/__snapshots__/ParsingBasics.test.ts.snap
+++ b/tsdoc/src/__tests__/__snapshots__/ParsingBasics.test.ts.snap
@@ -134,10 +134,11 @@ Object {
               Object {
                 "kind": "Particle",
                 "nodeExcerpt": "@link",
+                "nodeSpacing": " ",
               },
               Object {
                 "kind": "Particle",
-                "nodeExcerpt": " core-library#Statistics | Statistics subsystem",
+                "nodeExcerpt": "core-library#Statistics | Statistics subsystem",
               },
               Object {
                 "kind": "Particle",
@@ -544,10 +545,11 @@ Object {
               Object {
                 "kind": "Particle",
                 "nodeExcerpt": "@link",
+                "nodeSpacing": " ",
               },
               Object {
                 "kind": "Particle",
-                "nodeExcerpt": " core-library#Statistics | Statistics subsystem",
+                "nodeExcerpt": "core-library#Statistics | Statistics subsystem",
               },
               Object {
                 "kind": "Particle",

--- a/tsdoc/src/__tests__/__snapshots__/ParsingBasics.test.ts.snap
+++ b/tsdoc/src/__tests__/__snapshots__/ParsingBasics.test.ts.snap
@@ -128,20 +128,20 @@ Object {
             "kind": "InlineTag",
             "nodes": Array [
               Object {
-                "kind": "Particle",
+                "kind": "Particle: openingDelimiter",
                 "nodeExcerpt": "{",
               },
               Object {
-                "kind": "Particle",
+                "kind": "Particle: tagName",
                 "nodeExcerpt": "@link",
                 "nodeSpacing": " ",
               },
               Object {
-                "kind": "Particle",
+                "kind": "Particle: tagContent",
                 "nodeExcerpt": "core-library#Statistics | Statistics subsystem",
               },
               Object {
-                "kind": "Particle",
+                "kind": "Particle: closingDelimiter",
                 "nodeExcerpt": "}",
               },
             ],
@@ -208,12 +208,12 @@ Object {
           "nodeSpacing": " ",
         },
         Object {
-          "kind": "Particle",
+          "kind": "Particle: parameterName",
           "nodeExcerpt": "x",
           "nodeSpacing": " ",
         },
         Object {
-          "kind": "Particle",
+          "kind": "Particle: hyphen",
           "nodeExcerpt": "-",
           "nodeSpacing": " ",
         },
@@ -241,12 +241,12 @@ Object {
           "nodeSpacing": " ",
         },
         Object {
-          "kind": "Particle",
+          "kind": "Particle: parameterName",
           "nodeExcerpt": "y",
           "nodeSpacing": " ",
         },
         Object {
-          "kind": "Particle",
+          "kind": "Particle: hyphen",
           "nodeExcerpt": "-",
           "nodeSpacing": " ",
         },
@@ -284,15 +284,15 @@ Object {
             "kind": "CodeSpan",
             "nodes": Array [
               Object {
-                "kind": "Particle",
+                "kind": "Particle: openingDelimiter",
                 "nodeExcerpt": "[c]",
               },
               Object {
-                "kind": "Particle",
+                "kind": "Particle: code",
                 "nodeExcerpt": "x",
               },
               Object {
-                "kind": "Particle",
+                "kind": "Particle: closingDelimiter",
                 "nodeExcerpt": "[c]",
               },
             ],
@@ -305,15 +305,15 @@ Object {
             "kind": "CodeSpan",
             "nodes": Array [
               Object {
-                "kind": "Particle",
+                "kind": "Particle: openingDelimiter",
                 "nodeExcerpt": "[c]",
               },
               Object {
-                "kind": "Particle",
+                "kind": "Particle: code",
                 "nodeExcerpt": "y",
               },
               Object {
-                "kind": "Particle",
+                "kind": "Particle: closingDelimiter",
                 "nodeExcerpt": "[c]",
               },
             ],
@@ -374,10 +374,10 @@ Object {
           "nodeExcerpt": "@param",
         },
         Object {
-          "kind": "Particle",
+          "kind": "Particle: parameterName",
         },
         Object {
-          "kind": "Particle",
+          "kind": "Particle: hyphen",
         },
         Object {
           "kind": "Paragraph",
@@ -402,10 +402,10 @@ Object {
           "nodeExcerpt": "@param",
         },
         Object {
-          "kind": "Particle",
+          "kind": "Particle: parameterName",
         },
         Object {
-          "kind": "Particle",
+          "kind": "Particle: hyphen",
         },
         Object {
           "kind": "Paragraph",
@@ -441,15 +441,15 @@ Object {
             "kind": "CodeSpan",
             "nodes": Array [
               Object {
-                "kind": "Particle",
+                "kind": "Particle: openingDelimiter",
                 "nodeExcerpt": "[c]",
               },
               Object {
-                "kind": "Particle",
+                "kind": "Particle: code",
                 "nodeExcerpt": "x",
               },
               Object {
-                "kind": "Particle",
+                "kind": "Particle: closingDelimiter",
                 "nodeExcerpt": "[c]",
               },
             ],
@@ -462,15 +462,15 @@ Object {
             "kind": "CodeSpan",
             "nodes": Array [
               Object {
-                "kind": "Particle",
+                "kind": "Particle: openingDelimiter",
                 "nodeExcerpt": "[c]",
               },
               Object {
-                "kind": "Particle",
+                "kind": "Particle: code",
                 "nodeExcerpt": "y",
               },
               Object {
-                "kind": "Particle",
+                "kind": "Particle: closingDelimiter",
                 "nodeExcerpt": "[c]",
               },
             ],
@@ -539,20 +539,20 @@ Object {
             "kind": "InlineTag",
             "nodes": Array [
               Object {
-                "kind": "Particle",
+                "kind": "Particle: openingDelimiter",
                 "nodeExcerpt": "{",
               },
               Object {
-                "kind": "Particle",
+                "kind": "Particle: tagName",
                 "nodeExcerpt": "@link",
                 "nodeSpacing": " ",
               },
               Object {
-                "kind": "Particle",
+                "kind": "Particle: tagContent",
                 "nodeExcerpt": "core-library#Statistics | Statistics subsystem",
               },
               Object {
-                "kind": "Particle",
+                "kind": "Particle: closingDelimiter",
                 "nodeExcerpt": "}",
               },
             ],
@@ -619,12 +619,12 @@ Object {
           "nodeSpacing": " ",
         },
         Object {
-          "kind": "Particle",
+          "kind": "Particle: parameterName",
           "nodeExcerpt": "x",
           "nodeSpacing": " ",
         },
         Object {
-          "kind": "Particle",
+          "kind": "Particle: hyphen",
           "nodeExcerpt": "-",
           "nodeSpacing": " ",
         },
@@ -648,12 +648,12 @@ Object {
           "nodeSpacing": " ",
         },
         Object {
-          "kind": "Particle",
+          "kind": "Particle: parameterName",
           "nodeExcerpt": "y",
           "nodeSpacing": " ",
         },
         Object {
-          "kind": "Particle",
+          "kind": "Particle: hyphen",
           "nodeExcerpt": "-",
           "nodeSpacing": " ",
         },
@@ -691,15 +691,15 @@ Object {
             "kind": "CodeSpan",
             "nodes": Array [
               Object {
-                "kind": "Particle",
+                "kind": "Particle: openingDelimiter",
                 "nodeExcerpt": "[c]",
               },
               Object {
-                "kind": "Particle",
+                "kind": "Particle: code",
                 "nodeExcerpt": "x",
               },
               Object {
-                "kind": "Particle",
+                "kind": "Particle: closingDelimiter",
                 "nodeExcerpt": "[c]",
               },
             ],
@@ -712,15 +712,15 @@ Object {
             "kind": "CodeSpan",
             "nodes": Array [
               Object {
-                "kind": "Particle",
+                "kind": "Particle: openingDelimiter",
                 "nodeExcerpt": "[c]",
               },
               Object {
-                "kind": "Particle",
+                "kind": "Particle: code",
                 "nodeExcerpt": "y",
               },
               Object {
-                "kind": "Particle",
+                "kind": "Particle: closingDelimiter",
                 "nodeExcerpt": "[c]",
               },
             ],

--- a/tsdoc/src/nodes/DocCodeFence.ts
+++ b/tsdoc/src/nodes/DocCodeFence.ts
@@ -77,21 +77,25 @@ export class DocCodeFence extends DocNode {
     super.updateParameters(parameters);
 
     this._openingDelimiterParticle = new DocParticle({
+      particleId: 'openingDelimiter',
       excerpt: parameters.openingDelimiterExcerpt,
       content: '```'
     });
 
     this._languageParticle = new DocParticle({
+      particleId: 'language',
       excerpt: parameters.languageExcerpt,
       content: parameters.language || ''
     });
 
     this._codeParticle = new DocParticle({
+      particleId: 'code',
       excerpt: parameters.codeExcerpt,
       content: parameters.code
     });
 
     this._closingDelimiterParticle = new DocParticle({
+      particleId: 'closingDelimiter',
       excerpt: parameters.closingDelimiterExcerpt,
       content: '```'
     });

--- a/tsdoc/src/nodes/DocCodeSpan.ts
+++ b/tsdoc/src/nodes/DocCodeSpan.ts
@@ -51,16 +51,19 @@ export class DocCodeSpan extends DocNode {
     super.updateParameters(parameters);
 
     this._openingDelimiterParticle = new DocParticle({
+      particleId: 'openingDelimiter',
       excerpt: parameters.openingDelimiterExcerpt,
       content: '`'
     });
 
     this._codeParticle = new DocParticle({
+      particleId: 'code',
       excerpt: parameters.codeExcerpt,
       content: parameters.code
     });
 
     this._closingDelimiterParticle = new DocParticle({
+      particleId: 'closingDelimiter',
       excerpt: parameters.closingDelimiterExcerpt,
       content: '`'
     });

--- a/tsdoc/src/nodes/DocHtmlAttribute.ts
+++ b/tsdoc/src/nodes/DocHtmlAttribute.ts
@@ -87,18 +87,21 @@ export class DocHtmlAttribute extends DocNode {
     super.updateParameters(parameters);
 
     this._attributeNameParticle = new DocParticle({
+      particleId: 'attributeName',
       excerpt: parameters.attributeNameExcerpt,
       content: parameters.attributeName,
       spacingAfterContent: parameters.spacingAfterAttributeName
     });
 
     this._equalsParticle = new DocParticle({
+      particleId: 'equals',
       excerpt: parameters.equalsExcerpt,
       content: '=',
       spacingAfterContent: parameters.spacingAfterEquals
     });
 
     this._attributeValueParticle = new DocParticle({
+      particleId: 'attributeValue',
       excerpt: parameters.attributeValueExcerpt,
       content: parameters.attributeValue,
       spacingAfterContent: parameters.spacingAfterAttributeValue

--- a/tsdoc/src/nodes/DocHtmlEndTag.ts
+++ b/tsdoc/src/nodes/DocHtmlEndTag.ts
@@ -50,16 +50,19 @@ export class DocHtmlEndTag extends DocNode {
     super.updateParameters(parameters);
 
     this._openingDelimiterParticle = new DocParticle({
+      particleId: 'openingDelimiter',
       excerpt: parameters.openingDelimiterExcerpt,
       content: '</'
     });
 
     this._elementNameParticle = new DocParticle({
+      particleId: 'elementName',
       excerpt: parameters.elementNameExcerpt,
       content: parameters.elementName
     });
 
     this._closingDelimiterParticle = new DocParticle({
+      particleId: 'closingDelimiter',
       excerpt: parameters.closingDelimiterExcerpt,
       content: '>'
     });

--- a/tsdoc/src/nodes/DocHtmlStartTag.ts
+++ b/tsdoc/src/nodes/DocHtmlStartTag.ts
@@ -83,11 +83,13 @@ export class DocHtmlStartTag extends DocNode {
     super.updateParameters(parameters);
 
     this._openingDelimiterParticle = new DocParticle({
+      particleId: 'openingDelimiter',
       excerpt: parameters.openingDelimiterExcerpt,
       content: '<'
     });
 
     this._elementNameParticle = new DocParticle({
+      particleId: 'elementName',
       excerpt: parameters.elementNameExcerpt,
       content: parameters.elementName,
       spacingAfterContent: parameters.spacingAfterElementName
@@ -98,6 +100,7 @@ export class DocHtmlStartTag extends DocNode {
     this._selfClosingTag = parameters.selfClosingTag;
 
     this._closingDelimiterParticle = new DocParticle({
+      particleId: 'closingDelimiter',
       excerpt: parameters.closingDelimiterExcerpt,
       content: parameters.selfClosingTag ? '/>' : '>'
     });

--- a/tsdoc/src/nodes/DocInlineTag.ts
+++ b/tsdoc/src/nodes/DocInlineTag.ts
@@ -89,30 +89,29 @@ export class DocInlineTag extends DocNode {
 
   /**
    * {@inheritdoc}
-   * @override
+   * @override @sealed
    */
   public getChildNodes(): ReadonlyArray<DocNode> {
     return [
       this._openingDelimiterParticle!,
       this._tagNameParticle!,
-      this._tagContentParticle!,
+      ...this.getChildNodesForContent(),
       this._closingDelimiterParticle!
     ];
   }
 
-  protected get openingDelimiterParticle(): DocParticle {
-    return this._openingDelimiterParticle!;
-  }
-
-  protected get tagNameParticle(): DocParticle {
-    return this._tagNameParticle!;
+  /**
+   * Allows child classes to replace the tagContentParticle with a more detailed
+   * set of nodes.
+   * @virtual
+   */
+  protected getChildNodesForContent(): ReadonlyArray<DocNode> {
+    return [
+      this._tagContentParticle!
+    ];
   }
 
   protected get tagContentParticle(): DocParticle {
     return this._tagContentParticle!;
-  }
-
-  protected get closingDelimiterParticle(): DocParticle {
-    return this._closingDelimiterParticle!;
   }
 }

--- a/tsdoc/src/nodes/DocInlineTag.ts
+++ b/tsdoc/src/nodes/DocInlineTag.ts
@@ -63,21 +63,25 @@ export class DocInlineTag extends DocNode {
     super.updateParameters(parameters);
 
     this._openingDelimiterParticle = new DocParticle({
+      particleId: 'openingDelimiter',
       excerpt: parameters.openingDelimiterExcerpt,
       content: '{'
     });
 
     this._tagNameParticle = new DocParticle({
+      particleId: 'tagName',
       excerpt: parameters.tagNameExcerpt,
       content: parameters.tagName
     });
 
     this._tagContentParticle = new DocParticle({
+      particleId: 'tagContent',
       excerpt: parameters.tagContentExcerpt,
       content: parameters.tagContent
     });
 
     this._closingDelimiterParticle = new DocParticle({
+      particleId: 'closingDelimiter',
       excerpt: parameters.closingDelimiterExcerpt,
       content: '}'
     });

--- a/tsdoc/src/nodes/DocInlineTag.ts
+++ b/tsdoc/src/nodes/DocInlineTag.ts
@@ -95,4 +95,20 @@ export class DocInlineTag extends DocNode {
       this._closingDelimiterParticle!
     ];
   }
+
+  protected get openingDelimiterParticle(): DocParticle {
+    return this._openingDelimiterParticle!;
+  }
+
+  protected get tagNameParticle(): DocParticle {
+    return this._tagNameParticle!;
+  }
+
+  protected get tagContentParticle(): DocParticle {
+    return this._tagContentParticle!;
+  }
+
+  protected get closingDelimiterParticle(): DocParticle {
+    return this._closingDelimiterParticle!;
+  }
 }

--- a/tsdoc/src/nodes/DocLinkTag.ts
+++ b/tsdoc/src/nodes/DocLinkTag.ts
@@ -87,7 +87,7 @@ export class DocLinkTag extends DocInlineTag {
       });
     }
 
-    if (parameters.linkTextExcerpt || parameters.linkText) {
+    if (parameters.linkTextExcerpt || parameters.linkText || parameters.pipeExcerpt) {
       this._pipeParticle = new DocParticle({
         excerpt: parameters.pipeExcerpt,
         content: '|'

--- a/tsdoc/src/nodes/DocLinkTag.ts
+++ b/tsdoc/src/nodes/DocLinkTag.ts
@@ -82,6 +82,7 @@ export class DocLinkTag extends DocInlineTag {
 
     if (parameters.urlDestination !== undefined) {
       this._urlDestinationParticle = new DocParticle({
+        particleId: 'urlDestination',
         excerpt: parameters.urlDestinationExcerpt,
         content: parameters.urlDestination
       });
@@ -89,6 +90,7 @@ export class DocLinkTag extends DocInlineTag {
 
     if (parameters.linkTextExcerpt || parameters.linkText || parameters.pipeExcerpt) {
       this._pipeParticle = new DocParticle({
+        particleId: 'pipe',
         excerpt: parameters.pipeExcerpt,
         content: '|'
       });
@@ -96,6 +98,7 @@ export class DocLinkTag extends DocInlineTag {
 
     if (parameters.linkText !== undefined) {
       this._linkTextParticle = new DocParticle({
+        particleId: 'linkText',
         excerpt: parameters.linkTextExcerpt,
         content: parameters.linkText
       });

--- a/tsdoc/src/nodes/DocLinkTag.ts
+++ b/tsdoc/src/nodes/DocLinkTag.ts
@@ -109,7 +109,7 @@ export class DocLinkTag extends DocInlineTag {
    * {@inheritdoc}
    * @override
    */
-  public getChildNodes(): ReadonlyArray<DocNode> {
+  protected getChildNodesForContent(): ReadonlyArray<DocNode> {
     if (this.tagContentParticle.excerpt) {
       // If the parser associated the inline tag input with the tagContentExcerpt (e.g. because
       // second stage parsing encountered an error), then fall back to the base class's representation
@@ -117,14 +117,9 @@ export class DocLinkTag extends DocInlineTag {
     } else {
       // Otherwise return the detailed structure
       return DocNode.trimUndefinedNodes([
-        this.openingDelimiterParticle,  // from base class
-        this.tagNameParticle,           // from base class
-
         this._urlDestinationParticle,
         this._pipeParticle,
-        this._linkTextParticle,
-
-        this.closingDelimiterParticle   // from base class
+        this._linkTextParticle
       ]);
     }
 

--- a/tsdoc/src/nodes/DocLinkTag.ts
+++ b/tsdoc/src/nodes/DocLinkTag.ts
@@ -1,0 +1,105 @@
+import { DocNodeKind, DocNode } from './DocNode';
+import { DocInlineTag, IDocInlineTagParameters } from './DocInlineTag';
+import { DocParticle } from './DocParticle';
+import { Excerpt } from '../parser/Excerpt';
+
+/**
+ * Constructor parameters for {@link DocLinkTag}.
+ */
+export interface IDocLinkTagParameters extends IDocInlineTagParameters {
+  documentLinkExcerpt?: Excerpt;
+  documentLink?: string;
+
+  pipeExcerpt?: Excerpt;
+
+  linkTextExcerpt?: Excerpt;
+  linkText?: string;
+}
+
+/**
+ * Represents an `{@link}` tag.
+ */
+export class DocLinkTag extends DocInlineTag {
+
+  /** {@inheritdoc} */
+  public readonly kind: DocNodeKind = DocNodeKind.LinkTag;
+
+  private _documentLinkParticle: DocParticle | undefined;
+
+  private _pipeParticle: DocParticle | undefined;
+
+  private _linkTextParticle: DocParticle | undefined;
+
+  /**
+   * Don't call this directly.  Instead use {@link TSDocParser}
+   * @internal
+   */
+  public constructor(parameters: IDocLinkTagParameters) {
+    super(parameters);
+  }
+
+  /**
+   * If the link tag was an ordinary URI, this returns the URL string;
+   * otherwise this property is undefined.
+   * @remarks
+   * Either the `codeLink` or the `documentLink` property will be defined, but never both.
+   */
+  public get documentLink(): string | undefined {
+    return this._documentLinkParticle ? this._documentLinkParticle.content : undefined;
+  }
+
+  /**
+   * An optional text string that is the hyperlink text.  If omitted, the documentation
+   * renderer will use a default string based on the link itself (e.g. the URL text
+   * or the declaration identifier).
+   */
+  public get linkText(): string | undefined {
+    if (this._linkTextParticle) {
+      return this._linkTextParticle.content;
+    } else {
+      return undefined;
+    }
+  }
+
+  /** @override */
+  public updateParameters(parameters: IDocLinkTagParameters): void {
+    if (parameters.tagName.toUpperCase() !== '@LINK') {
+      throw new Error('DocLinkTag requires the tag name to be "{@link}"');
+    }
+
+    super.updateParameters(parameters);
+
+    this._documentLinkParticle = undefined;
+
+    if (parameters.documentLink !== undefined) {
+      this._documentLinkParticle = new DocParticle({
+        excerpt: parameters.documentLinkExcerpt,
+        content: parameters.documentLink
+      });
+    }
+
+    this._pipeParticle = new DocParticle({
+      excerpt: parameters.pipeExcerpt,
+      content: '|'
+    });
+
+    if (parameters.linkText !== undefined) {
+      this._linkTextParticle = new DocParticle({
+        excerpt: parameters.linkTextExcerpt,
+        content: parameters.linkText
+      });
+    }
+  }
+
+  /**
+   * {@inheritdoc}
+   * @override
+   */
+  public getChildNodes(): ReadonlyArray<DocNode> {
+    return DocNode.trimUndefinedNodes([
+      this._documentLinkParticle,
+      this._pipeParticle,
+      this._linkTextParticle
+    ]);
+  }
+}

--- a/tsdoc/src/nodes/DocNode.ts
+++ b/tsdoc/src/nodes/DocNode.ts
@@ -13,6 +13,7 @@ export const enum DocNodeKind {
   HtmlEndTag = 'HtmlEndTag',
   HtmlStartTag = 'HtmlStartTag',
   InlineTag = 'InlineTag',
+  LinkTag = 'LinkTag',
   Particle = 'Particle',
   Paragraph = 'Paragraph',
   ParamBlock = 'ParamBlock',

--- a/tsdoc/src/nodes/DocParagraph.ts
+++ b/tsdoc/src/nodes/DocParagraph.ts
@@ -38,6 +38,7 @@ export class DocParagraph extends DocNodeContainer {
       case DocNodeKind.HtmlStartTag:
       case DocNodeKind.HtmlEndTag:
       case DocNodeKind.InlineTag:
+      case DocNodeKind.LinkTag:
       case DocNodeKind.PlainText:
       case DocNodeKind.SoftBreak:
         return true;

--- a/tsdoc/src/nodes/DocParamBlock.ts
+++ b/tsdoc/src/nodes/DocParamBlock.ts
@@ -45,11 +45,13 @@ export class DocParamBlock extends DocBlock {
     super.updateParameters(parameters);
 
     this._parameterNameParticle = new DocParticle({
+      particleId: 'parameterName',
       excerpt: parameters.parameterNameExcerpt,
       content: parameters.parameterName
     });
 
     this._hyphenParticle = new DocParticle({
+      particleId: 'hyphen',
       excerpt: parameters.hyphenExcerpt,
       content: '-'
     });

--- a/tsdoc/src/nodes/DocParticle.ts
+++ b/tsdoc/src/nodes/DocParticle.ts
@@ -5,6 +5,7 @@ import { DocNodeLeaf, IDocNodeLeafParameters } from './DocNodeLeaf';
  * Constructor parameters for {@link DocParticle}.
  */
 export interface IDocParticleParameters extends IDocNodeLeafParameters {
+  particleId: string;
   content: string;
   spacingAfterContent?: string | undefined;
 }
@@ -27,6 +28,7 @@ export class DocParticle extends DocNodeLeaf {
   /** {@inheritdoc} */
   public readonly kind: DocNodeKind = DocNodeKind.Particle;
 
+  private _particleId: string | undefined;
   private _content: string | undefined;
   private _spacingAfterContent: string | undefined;
 
@@ -36,6 +38,15 @@ export class DocParticle extends DocNodeLeaf {
    */
   public constructor(parameters: IDocParticleParameters) {
     super(parameters);
+  }
+
+  /**
+   * A string identifier that uniquely identifies a particle among its siblings.
+   * This can be used by DocNode.getChildren() visitors to determine what the particle
+   * represents.
+   */
+  public get particleId(): string {
+    return this._particleId!;
   }
 
   /**
@@ -57,8 +68,13 @@ export class DocParticle extends DocNodeLeaf {
   public updateParameters(parameters: IDocParticleParameters): void {
     DocNode.validateSpacing(parameters.spacingAfterContent, 'spacingAfterContent');
 
+    if (this._particleId && parameters.particleId !== this._particleId) {
+      throw new Error('The particleId cannot be changed using updateParameters()');
+    }
+
     super.updateParameters(parameters);
 
+    this._particleId = parameters.particleId;
     this._content = parameters.content;
     this._spacingAfterContent = parameters.spacingAfterContent;
   }

--- a/tsdoc/src/nodes/index.ts
+++ b/tsdoc/src/nodes/index.ts
@@ -10,6 +10,7 @@ export * from './DocHtmlAttribute';
 export * from './DocHtmlEndTag';
 export * from './DocHtmlStartTag';
 export * from './DocInlineTag';
+export * from './DocLinkTag';
 export * from './DocNode';
 export * from './DocNodeContainer';
 export * from './DocNodeLeaf';

--- a/tsdoc/src/parser/NodeParser.ts
+++ b/tsdoc/src/parser/NodeParser.ts
@@ -571,6 +571,8 @@ export class NodeParser {
       });
 
       // Read everything until the end
+      // NOTE: Because we're using an embedded TokenReader, the TokenKind.EndOfInput occurs
+      // when we reach the "}", not the end of the original input
       while (embeddedTokenReader.peekTokenKind() !== TokenKind.EndOfInput) {
         embeddedTokenReader.readToken();
       }

--- a/tsdoc/src/parser/NodeParser.ts
+++ b/tsdoc/src/parser/NodeParser.ts
@@ -447,11 +447,10 @@ export class NodeParser {
     const tagNameExcerptParameters: IExcerptParameters = {
       content: tokenReader.extractAccumulatedSequence()
     };
+    const spacingAfterTagName: string = this._readSpacingAndNewlines(tokenReader);
+    tagNameExcerptParameters.spacingAfterContent = tokenReader.tryExtractAccumulatedSequence();
 
-    // We include the space in tagContent in case the implementor wants to assign some
-    // special meaning to spaces for their tag.
-    let tagContent: string = this._readSpacingAndNewlines(tokenReader);
-    if (tagContent.length === 0) {
+    if (spacingAfterTagName.length === 0) {
       // If there were no spaces at all, that's an error unless it's the degenerate "{@tag}" case
       if (tokenReader.peekTokenKind() !== TokenKind.RightCurlyBracket) {
         const failure: IFailure = this._createFailureForToken(tokenReader,
@@ -460,6 +459,7 @@ export class NodeParser {
       }
     }
 
+    let tagContent: string = '';
     let done: boolean = false;
     while (!done) {
       switch (tokenReader.peekTokenKind()) {

--- a/tsdoc/src/parser/NodeParser.ts
+++ b/tsdoc/src/parser/NodeParser.ts
@@ -348,7 +348,7 @@ export class NodeParser {
     // a syntax error.  For two tags it should be "@one @two", or for literal text it
     // should be "\@one\@two".
     switch (tokenReader.peekPreviousTokenKind()) {
-      case TokenKind.None:
+      case TokenKind.EndOfInput:
       case TokenKind.Spacing:
       case TokenKind.Newline:
         break;
@@ -383,10 +383,9 @@ export class NodeParser {
     }
 
     switch (tokenReader.peekTokenKind()) {
-      case TokenKind.None:
+      case TokenKind.EndOfInput:
       case TokenKind.Spacing:
       case TokenKind.Newline:
-      case TokenKind.EndOfInput:
         break;
       default:
         return this._backtrackAndCreateError(tokenReader, marker,
@@ -801,7 +800,7 @@ export class NodeParser {
 
     switch (tokenReader.peekPreviousTokenKind()) {
       case TokenKind.Newline:
-      case TokenKind.None:
+      case TokenKind.EndOfInput:
         break;
       default:
         return this._backtrackAndCreateErrorRange(
@@ -994,7 +993,7 @@ export class NodeParser {
     switch (tokenReader.peekPreviousTokenKind()) {
       case TokenKind.Spacing:
       case TokenKind.Newline:
-      case TokenKind.None:
+      case TokenKind.EndOfInput:
         break;
       default:
         return this._createError(tokenReader,

--- a/tsdoc/src/parser/StringChecks.ts
+++ b/tsdoc/src/parser/StringChecks.ts
@@ -4,12 +4,14 @@
 export class StringChecks {
   private static readonly tsdocTagNameRegExp: RegExp = /^@[a-z][a-z0-9]*$/i;
 
+  private static readonly urlSchemeRegExp: RegExp = /^[a-z][a-z0-9+\-.]*\:/i;
+
   /**
    * Tests tagName to see whether it is a valid TSDoc tag name; if not, returns an error message.
    * TSDoc tag names start with an at-sign ("@") followed by ASCII letters using
    * "camelCase" capitalization.
    */
-  public static explainIfNotTSDocTagName(tagName: string): string | undefined {
+  public static explainIfInvalidTSDocTagName(tagName: string): string | undefined {
     if (tagName[0] !== '@') {
       return 'A TSDoc tag name must start with an "@" symbol';
     }
@@ -27,9 +29,24 @@ export class StringChecks {
    * "camelCase" capitalization.
    */
   public static validateTSDocTagName(tagName: string): void {
-    const explanation: string | undefined = StringChecks.explainIfNotTSDocTagName(tagName);
+    const explanation: string | undefined = StringChecks.explainIfInvalidTSDocTagName(tagName);
     if (explanation) {
       throw new Error(explanation);
     }
+  }
+
+  /**
+   * Tests whether the provided string is a URL; if not, returns an error mesage.
+   * This check is fairly basic and accepts anything starting with a URI scheme.
+   */
+  public static explainIfInvalidUrl(url: string): string | undefined {
+    if (url.length === 0) {
+      return 'The URL cannot be empty';
+    }
+    if (!StringChecks.urlSchemeRegExp.test(url)) {
+      return 'The URL must begin with a scheme followed by a colon character';
+    }
+
+    return undefined;
   }
 }

--- a/tsdoc/src/parser/Token.ts
+++ b/tsdoc/src/parser/Token.ts
@@ -5,11 +5,6 @@ import { TextRange } from './TextRange';
  */
 export enum TokenKind {
   /**
-   * A null/undefined value.
-   */
-  None = 2000,
-
-  /**
    * A token representing the end of the input.  The Token.range will be an empty range
    * at the end of the provided input.
    */

--- a/tsdoc/src/parser/Token.ts
+++ b/tsdoc/src/parser/Token.ts
@@ -143,7 +143,13 @@ export enum TokenKind {
    * The right square bracket character.
    * The Token.range will always be a string of length 1.
    */
-  RightSquareBracket = 2023
+  RightSquareBracket = 2023,
+
+  /**
+   * The pipe character `|`.
+   * The Token.range will always be a string of length 1.
+   */
+  Pipe = 2024
 }
 
 /**

--- a/tsdoc/src/parser/TokenReader.ts
+++ b/tsdoc/src/parser/TokenReader.ts
@@ -121,6 +121,9 @@ export class TokenReader {
    * consuming anything.
    */
   public peekTokenKind(): TokenKind {
+    if (this._currentIndex >= this._readerEndIndex) {
+      return TokenKind.EndOfInput;
+    }
     return this.tokens[this._currentIndex].kind;
   }
 
@@ -129,7 +132,7 @@ export class TokenReader {
    */
   public peekTokenAfterKind(): TokenKind {
     if (this._currentIndex + 1 >= this._readerEndIndex) {
-      return TokenKind.None;
+      return TokenKind.EndOfInput;
     }
     return this.tokens[this._currentIndex + 1].kind;
   }
@@ -139,7 +142,7 @@ export class TokenReader {
    */
   public peekTokenAfterAfterKind(): TokenKind {
     if (this._currentIndex + 2 >= this._readerEndIndex) {
-      return TokenKind.None;
+      return TokenKind.EndOfInput;
     }
     return this.tokens[this._currentIndex + 2].kind;
   }
@@ -171,7 +174,7 @@ export class TokenReader {
    */
   public peekPreviousTokenKind(): TokenKind {
     if (this._currentIndex === 0) {
-      return TokenKind.None;
+      return TokenKind.EndOfInput;
     }
     return this.tokens[this._currentIndex - 1].kind;
   }

--- a/tsdoc/src/parser/Tokenizer.ts
+++ b/tsdoc/src/parser/Tokenizer.ts
@@ -141,7 +141,8 @@ export class Tokenizer {
       ':'  : TokenKind.Colon,
       ','  : TokenKind.Comma,
       '['  : TokenKind.LeftSquareBracket,
-      ']'  : TokenKind.RightSquareBracket
+      ']'  : TokenKind.RightSquareBracket,
+      '|'  : TokenKind.Pipe
     };
     for (const key of Object.getOwnPropertyNames(specialMap)) {
       Tokenizer._charCodeMap[key.charCodeAt(0)] = specialMap[key];

--- a/tsdoc/src/parser/__tests__/NodeParserLinkTag.test.ts
+++ b/tsdoc/src/parser/__tests__/NodeParserLinkTag.test.ts
@@ -1,0 +1,24 @@
+import { TestHelpers } from './TestHelpers';
+
+test('00 Link tags with URL: positive examples', () => {
+  TestHelpers.parseAndMatchNodeParserSnapshot([
+    '/**',
+    ' * {@link http://example1.com}',
+    ' * {@link mail:bob@example2.com}',
+    ' * {@link http://example3.com|link text}',
+    ' * {@link http://example4.com|}',
+    ' * {@link http://example5.com|',
+    ' *}',
+    ' */'
+  ].join('\n'));
+  TestHelpers.parseAndMatchNodeParserSnapshot([
+    '/**',
+    ' * {@link    mail:bob@example6.com   |  link text }',
+    ' * {@link  ',
+    ' *   http://example7.com  ',
+    ' *   | ',
+    ' *   link text ',
+    ' * }',
+    ' */'
+  ].join('\n'));
+});

--- a/tsdoc/src/parser/__tests__/TestHelpers.ts
+++ b/tsdoc/src/parser/__tests__/TestHelpers.ts
@@ -5,7 +5,8 @@ import {
   DocNode,
   DocComment,
   DocPlainText,
-  DocNodeLeaf
+  DocNodeLeaf,
+  DocParticle
 } from '../../nodes';
 import { ParserContext } from '../ParserContext';
 import { Excerpt } from '../Excerpt';
@@ -137,6 +138,10 @@ export class TestHelpers {
     const item: ISnapshotItem = {
       kind: docNode.kind
     };
+
+    if (docNode instanceof DocParticle) {
+      item.kind += ': ' + docNode.particleId;
+    }
 
     if (docNode instanceof DocNodeLeaf && docNode.excerpt) {
       const excerpt: Excerpt = docNode.excerpt;

--- a/tsdoc/src/parser/__tests__/__snapshots__/NodeParserCode.test.ts.snap
+++ b/tsdoc/src/parser/__tests__/__snapshots__/NodeParserCode.test.ts.snap
@@ -26,15 +26,15 @@ Object {
                 "kind": "CodeSpan",
                 "nodes": Array [
                   Object {
-                    "kind": "Particle",
+                    "kind": "Particle: openingDelimiter",
                     "nodeExcerpt": "[c]",
                   },
                   Object {
-                    "kind": "Particle",
+                    "kind": "Particle: code",
                     "nodeExcerpt": "1",
                   },
                   Object {
-                    "kind": "Particle",
+                    "kind": "Particle: closingDelimiter",
                     "nodeExcerpt": "[c]",
                   },
                 ],
@@ -51,15 +51,15 @@ Object {
                 "kind": "CodeSpan",
                 "nodes": Array [
                   Object {
-                    "kind": "Particle",
+                    "kind": "Particle: openingDelimiter",
                     "nodeExcerpt": "[c]",
                   },
                   Object {
-                    "kind": "Particle",
+                    "kind": "Particle: code",
                     "nodeExcerpt": " 2",
                   },
                   Object {
-                    "kind": "Particle",
+                    "kind": "Particle: closingDelimiter",
                     "nodeExcerpt": "[c]",
                   },
                 ],
@@ -250,20 +250,20 @@ Object {
             "kind": "CodeFence",
             "nodes": Array [
               Object {
-                "kind": "Particle",
+                "kind": "Particle: openingDelimiter",
                 "nodeExcerpt": "[c][c][c]",
               },
               Object {
-                "kind": "Particle",
+                "kind": "Particle: language",
                 "nodeExcerpt": "a language!",
                 "nodeSpacing": "[n]",
               },
               Object {
-                "kind": "Particle",
+                "kind": "Particle: code",
                 "nodeExcerpt": "  some [c]code[c] here[n]",
               },
               Object {
-                "kind": "Particle",
+                "kind": "Particle: closingDelimiter",
                 "nodeExcerpt": "[c][c][c]",
                 "nodeSpacing": "[n]",
               },
@@ -310,20 +310,20 @@ Object {
             "kind": "CodeFence",
             "nodes": Array [
               Object {
-                "kind": "Particle",
+                "kind": "Particle: openingDelimiter",
                 "nodeExcerpt": "[c][c][c]",
               },
               Object {
-                "kind": "Particle",
+                "kind": "Particle: language",
                 "nodeExcerpt": "",
                 "nodeSpacing": "[n]",
               },
               Object {
-                "kind": "Particle",
+                "kind": "Particle: code",
                 "nodeExcerpt": "  some [c]code[c] here[n]",
               },
               Object {
-                "kind": "Particle",
+                "kind": "Particle: closingDelimiter",
                 "nodeExcerpt": "[c][c][c]",
                 "nodeSpacing": "[n]",
               },
@@ -668,20 +668,20 @@ Object {
             "kind": "CodeFence",
             "nodes": Array [
               Object {
-                "kind": "Particle",
+                "kind": "Particle: openingDelimiter",
                 "nodeExcerpt": "[c][c][c]",
               },
               Object {
-                "kind": "Particle",
+                "kind": "Particle: language",
                 "nodeExcerpt": "",
                 "nodeSpacing": "[n]",
               },
               Object {
-                "kind": "Particle",
+                "kind": "Particle: code",
                 "nodeExcerpt": "code[n]",
               },
               Object {
-                "kind": "Particle",
+                "kind": "Particle: closingDelimiter",
                 "nodeExcerpt": "     [c][c][c]",
                 "nodeSpacing": "[n]",
               },
@@ -730,20 +730,20 @@ Object {
             "kind": "CodeFence",
             "nodes": Array [
               Object {
-                "kind": "Particle",
+                "kind": "Particle: openingDelimiter",
                 "nodeExcerpt": "[c][c][c]",
               },
               Object {
-                "kind": "Particle",
+                "kind": "Particle: language",
                 "nodeExcerpt": "",
                 "nodeSpacing": "[n]",
               },
               Object {
-                "kind": "Particle",
+                "kind": "Particle: code",
                 "nodeExcerpt": "code[n]",
               },
               Object {
-                "kind": "Particle",
+                "kind": "Particle: closingDelimiter",
                 "nodeExcerpt": "[c][c][c]",
                 "nodeSpacing": "  ",
               },

--- a/tsdoc/src/parser/__tests__/__snapshots__/NodeParserHtml.test.ts.snap
+++ b/tsdoc/src/parser/__tests__/__snapshots__/NodeParserHtml.test.ts.snap
@@ -27,15 +27,15 @@ Object {
                 "kind": "HtmlStartTag",
                 "nodes": Array [
                   Object {
-                    "kind": "Particle",
+                    "kind": "Particle: openingDelimiter",
                     "nodeExcerpt": "[<]",
                   },
                   Object {
-                    "kind": "Particle",
+                    "kind": "Particle: elementName",
                     "nodeExcerpt": "tag",
                   },
                   Object {
-                    "kind": "Particle",
+                    "kind": "Particle: closingDelimiter",
                     "nodeExcerpt": "/[>]",
                   },
                 ],
@@ -48,16 +48,16 @@ Object {
                 "kind": "HtmlStartTag",
                 "nodes": Array [
                   Object {
-                    "kind": "Particle",
+                    "kind": "Particle: openingDelimiter",
                     "nodeExcerpt": "[<]",
                   },
                   Object {
-                    "kind": "Particle",
+                    "kind": "Particle: elementName",
                     "nodeExcerpt": "tag-a",
                     "nodeSpacing": " ",
                   },
                   Object {
-                    "kind": "Particle",
+                    "kind": "Particle: closingDelimiter",
                     "nodeExcerpt": "/[>]",
                   },
                 ],
@@ -70,16 +70,16 @@ Object {
                 "kind": "HtmlStartTag",
                 "nodes": Array [
                   Object {
-                    "kind": "Particle",
+                    "kind": "Particle: openingDelimiter",
                     "nodeExcerpt": "[<]",
                   },
                   Object {
-                    "kind": "Particle",
+                    "kind": "Particle: elementName",
                     "nodeExcerpt": "tag-b",
                     "nodeSpacing": " ",
                   },
                   Object {
-                    "kind": "Particle",
+                    "kind": "Particle: closingDelimiter",
                     "nodeExcerpt": "[>]",
                   },
                 ],
@@ -88,16 +88,16 @@ Object {
                 "kind": "HtmlStartTag",
                 "nodes": Array [
                   Object {
-                    "kind": "Particle",
+                    "kind": "Particle: openingDelimiter",
                     "nodeExcerpt": "[<]",
                   },
                   Object {
-                    "kind": "Particle",
+                    "kind": "Particle: elementName",
                     "nodeExcerpt": "tag-c",
                     "nodeSpacing": " ",
                   },
                   Object {
-                    "kind": "Particle",
+                    "kind": "Particle: closingDelimiter",
                     "nodeExcerpt": "/[>]",
                   },
                 ],
@@ -110,16 +110,16 @@ Object {
                 "kind": "HtmlStartTag",
                 "nodes": Array [
                   Object {
-                    "kind": "Particle",
+                    "kind": "Particle: openingDelimiter",
                     "nodeExcerpt": "[<]",
                   },
                   Object {
-                    "kind": "Particle",
+                    "kind": "Particle: elementName",
                     "nodeExcerpt": "tag-d",
                     "nodeSpacing": "[n]",
                   },
                   Object {
-                    "kind": "Particle",
+                    "kind": "Particle: closingDelimiter",
                     "nodeExcerpt": "[>]",
                   },
                 ],
@@ -132,16 +132,16 @@ Object {
                 "kind": "HtmlStartTag",
                 "nodes": Array [
                   Object {
-                    "kind": "Particle",
+                    "kind": "Particle: openingDelimiter",
                     "nodeExcerpt": "[<]",
                   },
                   Object {
-                    "kind": "Particle",
+                    "kind": "Particle: elementName",
                     "nodeExcerpt": "tag-e",
                     "nodeSpacing": "[n]     ",
                   },
                   Object {
-                    "kind": "Particle",
+                    "kind": "Particle: closingDelimiter",
                     "nodeExcerpt": "/[>]",
                   },
                 ],
@@ -315,11 +315,11 @@ Object {
                 "kind": "HtmlStartTag",
                 "nodes": Array [
                   Object {
-                    "kind": "Particle",
+                    "kind": "Particle: openingDelimiter",
                     "nodeExcerpt": "[<]",
                   },
                   Object {
-                    "kind": "Particle",
+                    "kind": "Particle: elementName",
                     "nodeExcerpt": "tag-a",
                     "nodeSpacing": " ",
                   },
@@ -327,22 +327,22 @@ Object {
                     "kind": "HtmlAttribute",
                     "nodes": Array [
                       Object {
-                        "kind": "Particle",
+                        "kind": "Particle: attributeName",
                         "nodeExcerpt": "attr-one",
                       },
                       Object {
-                        "kind": "Particle",
+                        "kind": "Particle: equals",
                         "nodeExcerpt": "=",
                       },
                       Object {
-                        "kind": "Particle",
+                        "kind": "Particle: attributeValue",
                         "nodeExcerpt": "[q]one[q]",
                         "nodeSpacing": " ",
                       },
                     ],
                   },
                   Object {
-                    "kind": "Particle",
+                    "kind": "Particle: closingDelimiter",
                     "nodeExcerpt": "[>]",
                   },
                 ],
@@ -355,11 +355,11 @@ Object {
                 "kind": "HtmlStartTag",
                 "nodes": Array [
                   Object {
-                    "kind": "Particle",
+                    "kind": "Particle: openingDelimiter",
                     "nodeExcerpt": "[<]",
                   },
                   Object {
-                    "kind": "Particle",
+                    "kind": "Particle: elementName",
                     "nodeExcerpt": "tag-b",
                     "nodeSpacing": "[n]  ",
                   },
@@ -367,24 +367,24 @@ Object {
                     "kind": "HtmlAttribute",
                     "nodes": Array [
                       Object {
-                        "kind": "Particle",
+                        "kind": "Particle: attributeName",
                         "nodeExcerpt": "attr-two",
                         "nodeSpacing": "[n]  ",
                       },
                       Object {
-                        "kind": "Particle",
+                        "kind": "Particle: equals",
                         "nodeExcerpt": "=",
                         "nodeSpacing": " ",
                       },
                       Object {
-                        "kind": "Particle",
+                        "kind": "Particle: attributeValue",
                         "nodeExcerpt": "[q]2[q]",
                         "nodeSpacing": "[n]",
                       },
                     ],
                   },
                   Object {
-                    "kind": "Particle",
+                    "kind": "Particle: closingDelimiter",
                     "nodeExcerpt": "/[>]",
                   },
                 ],
@@ -429,11 +429,11 @@ Object {
                 "kind": "HtmlStartTag",
                 "nodes": Array [
                   Object {
-                    "kind": "Particle",
+                    "kind": "Particle: openingDelimiter",
                     "nodeExcerpt": "[<]",
                   },
                   Object {
-                    "kind": "Particle",
+                    "kind": "Particle: elementName",
                     "nodeExcerpt": "tag-c",
                     "nodeSpacing": " ",
                   },
@@ -441,15 +441,15 @@ Object {
                     "kind": "HtmlAttribute",
                     "nodes": Array [
                       Object {
-                        "kind": "Particle",
+                        "kind": "Particle: attributeName",
                         "nodeExcerpt": "attr-three",
                       },
                       Object {
-                        "kind": "Particle",
+                        "kind": "Particle: equals",
                         "nodeExcerpt": "=",
                       },
                       Object {
-                        "kind": "Particle",
+                        "kind": "Particle: attributeValue",
                         "nodeExcerpt": "[q]3[q]",
                         "nodeSpacing": " ",
                       },
@@ -459,21 +459,21 @@ Object {
                     "kind": "HtmlAttribute",
                     "nodes": Array [
                       Object {
-                        "kind": "Particle",
+                        "kind": "Particle: attributeName",
                         "nodeExcerpt": "four",
                       },
                       Object {
-                        "kind": "Particle",
+                        "kind": "Particle: equals",
                         "nodeExcerpt": "=",
                       },
                       Object {
-                        "kind": "Particle",
+                        "kind": "Particle: attributeValue",
                         "nodeExcerpt": "'4'",
                       },
                     ],
                   },
                   Object {
-                    "kind": "Particle",
+                    "kind": "Particle: closingDelimiter",
                     "nodeExcerpt": "/[>]",
                   },
                 ],
@@ -486,11 +486,11 @@ Object {
                 "kind": "HtmlStartTag",
                 "nodes": Array [
                   Object {
-                    "kind": "Particle",
+                    "kind": "Particle: openingDelimiter",
                     "nodeExcerpt": "[<]",
                   },
                   Object {
-                    "kind": "Particle",
+                    "kind": "Particle: elementName",
                     "nodeExcerpt": "tag-d",
                     "nodeSpacing": "[n]  ",
                   },
@@ -498,17 +498,17 @@ Object {
                     "kind": "HtmlAttribute",
                     "nodes": Array [
                       Object {
-                        "kind": "Particle",
+                        "kind": "Particle: attributeName",
                         "nodeExcerpt": "attr-five",
                         "nodeSpacing": "[n]  ",
                       },
                       Object {
-                        "kind": "Particle",
+                        "kind": "Particle: equals",
                         "nodeExcerpt": "=",
                         "nodeSpacing": " ",
                       },
                       Object {
-                        "kind": "Particle",
+                        "kind": "Particle: attributeValue",
                         "nodeExcerpt": "[q]5[q]",
                         "nodeSpacing": "[n]  ",
                       },
@@ -518,24 +518,24 @@ Object {
                     "kind": "HtmlAttribute",
                     "nodes": Array [
                       Object {
-                        "kind": "Particle",
+                        "kind": "Particle: attributeName",
                         "nodeExcerpt": "six",
                         "nodeSpacing": "[n]  ",
                       },
                       Object {
-                        "kind": "Particle",
+                        "kind": "Particle: equals",
                         "nodeExcerpt": "=",
                         "nodeSpacing": " ",
                       },
                       Object {
-                        "kind": "Particle",
+                        "kind": "Particle: attributeValue",
                         "nodeExcerpt": "'6'",
                         "nodeSpacing": "[n]",
                       },
                     ],
                   },
                   Object {
-                    "kind": "Particle",
+                    "kind": "Particle: closingDelimiter",
                     "nodeExcerpt": "/[>]",
                   },
                 ],
@@ -580,11 +580,11 @@ Object {
                 "kind": "HtmlStartTag",
                 "nodes": Array [
                   Object {
-                    "kind": "Particle",
+                    "kind": "Particle: openingDelimiter",
                     "nodeExcerpt": "[<]",
                   },
                   Object {
-                    "kind": "Particle",
+                    "kind": "Particle: elementName",
                     "nodeExcerpt": "tag-e",
                     "nodeSpacing": " ",
                   },
@@ -592,15 +592,15 @@ Object {
                     "kind": "HtmlAttribute",
                     "nodes": Array [
                       Object {
-                        "kind": "Particle",
+                        "kind": "Particle: attributeName",
                         "nodeExcerpt": "attr-one",
                       },
                       Object {
-                        "kind": "Particle",
+                        "kind": "Particle: equals",
                         "nodeExcerpt": "=",
                       },
                       Object {
-                        "kind": "Particle",
+                        "kind": "Particle: attributeValue",
                         "nodeExcerpt": "[q]one[q]",
                         "nodeSpacing": " ",
                       },
@@ -610,21 +610,21 @@ Object {
                     "kind": "HtmlAttribute",
                     "nodes": Array [
                       Object {
-                        "kind": "Particle",
+                        "kind": "Particle: attributeName",
                         "nodeExcerpt": "two",
                       },
                       Object {
-                        "kind": "Particle",
+                        "kind": "Particle: equals",
                         "nodeExcerpt": "=",
                       },
                       Object {
-                        "kind": "Particle",
+                        "kind": "Particle: attributeValue",
                         "nodeExcerpt": "'two'",
                       },
                     ],
                   },
                   Object {
-                    "kind": "Particle",
+                    "kind": "Particle: closingDelimiter",
                     "nodeExcerpt": "/[>]",
                   },
                 ],
@@ -637,11 +637,11 @@ Object {
                 "kind": "HtmlStartTag",
                 "nodes": Array [
                   Object {
-                    "kind": "Particle",
+                    "kind": "Particle: openingDelimiter",
                     "nodeExcerpt": "[<]",
                   },
                   Object {
-                    "kind": "Particle",
+                    "kind": "Particle: elementName",
                     "nodeExcerpt": "tag-f",
                     "nodeSpacing": "[n]  ",
                   },
@@ -649,17 +649,17 @@ Object {
                     "kind": "HtmlAttribute",
                     "nodes": Array [
                       Object {
-                        "kind": "Particle",
+                        "kind": "Particle: attributeName",
                         "nodeExcerpt": "attr-one",
                         "nodeSpacing": "[n]  ",
                       },
                       Object {
-                        "kind": "Particle",
+                        "kind": "Particle: equals",
                         "nodeExcerpt": "=",
                         "nodeSpacing": " ",
                       },
                       Object {
-                        "kind": "Particle",
+                        "kind": "Particle: attributeValue",
                         "nodeExcerpt": "[q]one[q]",
                         "nodeSpacing": "[n]  ",
                       },
@@ -669,24 +669,24 @@ Object {
                     "kind": "HtmlAttribute",
                     "nodes": Array [
                       Object {
-                        "kind": "Particle",
+                        "kind": "Particle: attributeName",
                         "nodeExcerpt": "two",
                         "nodeSpacing": "[n]  ",
                       },
                       Object {
-                        "kind": "Particle",
+                        "kind": "Particle: equals",
                         "nodeExcerpt": "=",
                         "nodeSpacing": " ",
                       },
                       Object {
-                        "kind": "Particle",
+                        "kind": "Particle: attributeValue",
                         "nodeExcerpt": "'two'",
                         "nodeSpacing": "[n]",
                       },
                     ],
                   },
                   Object {
-                    "kind": "Particle",
+                    "kind": "Particle: closingDelimiter",
                     "nodeExcerpt": "/[>]",
                   },
                 ],
@@ -985,11 +985,11 @@ Object {
                 "kind": "HtmlStartTag",
                 "nodes": Array [
                   Object {
-                    "kind": "Particle",
+                    "kind": "Particle: openingDelimiter",
                     "nodeExcerpt": "[<]",
                   },
                   Object {
-                    "kind": "Particle",
+                    "kind": "Particle: elementName",
                     "nodeExcerpt": "tag",
                     "nodeSpacing": " ",
                   },
@@ -997,22 +997,22 @@ Object {
                     "kind": "HtmlAttribute",
                     "nodes": Array [
                       Object {
-                        "kind": "Particle",
+                        "kind": "Particle: attributeName",
                         "nodeExcerpt": "attr-one",
                       },
                       Object {
-                        "kind": "Particle",
+                        "kind": "Particle: equals",
                         "nodeExcerpt": "=",
                       },
                       Object {
-                        "kind": "Particle",
+                        "kind": "Particle: attributeValue",
                         "nodeExcerpt": "[q]@tag[q]",
                         "nodeSpacing": " ",
                       },
                     ],
                   },
                   Object {
-                    "kind": "Particle",
+                    "kind": "Particle: closingDelimiter",
                     "nodeExcerpt": "/[>]",
                   },
                 ],
@@ -1054,15 +1054,15 @@ Object {
                 "kind": "HtmlEndTag",
                 "nodes": Array [
                   Object {
-                    "kind": "Particle",
+                    "kind": "Particle: openingDelimiter",
                     "nodeExcerpt": "[<]/",
                   },
                   Object {
-                    "kind": "Particle",
+                    "kind": "Particle: elementName",
                     "nodeExcerpt": "tag-a",
                   },
                   Object {
-                    "kind": "Particle",
+                    "kind": "Particle: closingDelimiter",
                     "nodeExcerpt": "[>]",
                   },
                 ],
@@ -1075,16 +1075,16 @@ Object {
                 "kind": "HtmlEndTag",
                 "nodes": Array [
                   Object {
-                    "kind": "Particle",
+                    "kind": "Particle: openingDelimiter",
                     "nodeExcerpt": "[<]/",
                   },
                   Object {
-                    "kind": "Particle",
+                    "kind": "Particle: elementName",
                     "nodeExcerpt": "tag-b",
                     "nodeSpacing": "  ",
                   },
                   Object {
-                    "kind": "Particle",
+                    "kind": "Particle: closingDelimiter",
                     "nodeExcerpt": "[>]",
                   },
                 ],
@@ -1097,16 +1097,16 @@ Object {
                 "kind": "HtmlEndTag",
                 "nodes": Array [
                   Object {
-                    "kind": "Particle",
+                    "kind": "Particle: openingDelimiter",
                     "nodeExcerpt": "[<]/",
                   },
                   Object {
-                    "kind": "Particle",
+                    "kind": "Particle: elementName",
                     "nodeExcerpt": "tag-c",
                     "nodeSpacing": "[n]  ",
                   },
                   Object {
-                    "kind": "Particle",
+                    "kind": "Particle: closingDelimiter",
                     "nodeExcerpt": "[>]",
                   },
                 ],

--- a/tsdoc/src/parser/__tests__/__snapshots__/NodeParserLinkTag.test.ts.snap
+++ b/tsdoc/src/parser/__tests__/__snapshots__/NodeParserLinkTag.test.ts.snap
@@ -26,20 +26,20 @@ Object {
                 "kind": "LinkTag",
                 "nodes": Array [
                   Object {
-                    "kind": "Particle",
+                    "kind": "Particle: openingDelimiter",
                     "nodeExcerpt": "{",
                   },
                   Object {
-                    "kind": "Particle",
+                    "kind": "Particle: tagName",
                     "nodeExcerpt": "@link",
                     "nodeSpacing": " ",
                   },
                   Object {
-                    "kind": "Particle",
+                    "kind": "Particle: urlDestination",
                     "nodeExcerpt": "http://example1.com",
                   },
                   Object {
-                    "kind": "Particle",
+                    "kind": "Particle: closingDelimiter",
                     "nodeExcerpt": "}",
                   },
                 ],
@@ -52,20 +52,20 @@ Object {
                 "kind": "LinkTag",
                 "nodes": Array [
                   Object {
-                    "kind": "Particle",
+                    "kind": "Particle: openingDelimiter",
                     "nodeExcerpt": "{",
                   },
                   Object {
-                    "kind": "Particle",
+                    "kind": "Particle: tagName",
                     "nodeExcerpt": "@link",
                     "nodeSpacing": " ",
                   },
                   Object {
-                    "kind": "Particle",
+                    "kind": "Particle: urlDestination",
                     "nodeExcerpt": "mail:bob@example2.com",
                   },
                   Object {
-                    "kind": "Particle",
+                    "kind": "Particle: closingDelimiter",
                     "nodeExcerpt": "}",
                   },
                 ],
@@ -78,28 +78,28 @@ Object {
                 "kind": "LinkTag",
                 "nodes": Array [
                   Object {
-                    "kind": "Particle",
+                    "kind": "Particle: openingDelimiter",
                     "nodeExcerpt": "{",
                   },
                   Object {
-                    "kind": "Particle",
+                    "kind": "Particle: tagName",
                     "nodeExcerpt": "@link",
                     "nodeSpacing": " ",
                   },
                   Object {
-                    "kind": "Particle",
+                    "kind": "Particle: urlDestination",
                     "nodeExcerpt": "http://example3.com",
                   },
                   Object {
-                    "kind": "Particle",
+                    "kind": "Particle: pipe",
                     "nodeExcerpt": "|",
                   },
                   Object {
-                    "kind": "Particle",
+                    "kind": "Particle: linkText",
                     "nodeExcerpt": "link text",
                   },
                   Object {
-                    "kind": "Particle",
+                    "kind": "Particle: closingDelimiter",
                     "nodeExcerpt": "}",
                   },
                 ],
@@ -112,24 +112,24 @@ Object {
                 "kind": "LinkTag",
                 "nodes": Array [
                   Object {
-                    "kind": "Particle",
+                    "kind": "Particle: openingDelimiter",
                     "nodeExcerpt": "{",
                   },
                   Object {
-                    "kind": "Particle",
+                    "kind": "Particle: tagName",
                     "nodeExcerpt": "@link",
                     "nodeSpacing": " ",
                   },
                   Object {
-                    "kind": "Particle",
+                    "kind": "Particle: urlDestination",
                     "nodeExcerpt": "http://example4.com",
                   },
                   Object {
-                    "kind": "Particle",
+                    "kind": "Particle: pipe",
                     "nodeExcerpt": "|",
                   },
                   Object {
-                    "kind": "Particle",
+                    "kind": "Particle: closingDelimiter",
                     "nodeExcerpt": "}",
                   },
                 ],
@@ -142,28 +142,28 @@ Object {
                 "kind": "LinkTag",
                 "nodes": Array [
                   Object {
-                    "kind": "Particle",
+                    "kind": "Particle: openingDelimiter",
                     "nodeExcerpt": "{",
                   },
                   Object {
-                    "kind": "Particle",
+                    "kind": "Particle: tagName",
                     "nodeExcerpt": "@link",
                     "nodeSpacing": " ",
                   },
                   Object {
-                    "kind": "Particle",
+                    "kind": "Particle: urlDestination",
                     "nodeExcerpt": "http://example5.com",
                   },
                   Object {
-                    "kind": "Particle",
+                    "kind": "Particle: pipe",
                     "nodeExcerpt": "|",
                   },
                   Object {
-                    "kind": "Particle",
+                    "kind": "Particle: linkText",
                     "nodeExcerpt": "[n]",
                   },
                   Object {
-                    "kind": "Particle",
+                    "kind": "Particle: closingDelimiter",
                     "nodeExcerpt": "}",
                   },
                 ],
@@ -207,29 +207,29 @@ Object {
                 "kind": "LinkTag",
                 "nodes": Array [
                   Object {
-                    "kind": "Particle",
+                    "kind": "Particle: openingDelimiter",
                     "nodeExcerpt": "{",
                   },
                   Object {
-                    "kind": "Particle",
+                    "kind": "Particle: tagName",
                     "nodeExcerpt": "@link",
                     "nodeSpacing": "    ",
                   },
                   Object {
-                    "kind": "Particle",
+                    "kind": "Particle: urlDestination",
                     "nodeExcerpt": "mail:bob@example6.com",
                     "nodeSpacing": "   ",
                   },
                   Object {
-                    "kind": "Particle",
+                    "kind": "Particle: pipe",
                     "nodeExcerpt": "|",
                   },
                   Object {
-                    "kind": "Particle",
+                    "kind": "Particle: linkText",
                     "nodeExcerpt": "  link text ",
                   },
                   Object {
-                    "kind": "Particle",
+                    "kind": "Particle: closingDelimiter",
                     "nodeExcerpt": "}",
                   },
                 ],
@@ -242,29 +242,29 @@ Object {
                 "kind": "LinkTag",
                 "nodes": Array [
                   Object {
-                    "kind": "Particle",
+                    "kind": "Particle: openingDelimiter",
                     "nodeExcerpt": "{",
                   },
                   Object {
-                    "kind": "Particle",
+                    "kind": "Particle: tagName",
                     "nodeExcerpt": "@link",
                     "nodeSpacing": "[n]  ",
                   },
                   Object {
-                    "kind": "Particle",
+                    "kind": "Particle: urlDestination",
                     "nodeExcerpt": "http://example7.com",
                     "nodeSpacing": "[n]  ",
                   },
                   Object {
-                    "kind": "Particle",
+                    "kind": "Particle: pipe",
                     "nodeExcerpt": "|",
                   },
                   Object {
-                    "kind": "Particle",
+                    "kind": "Particle: linkText",
                     "nodeExcerpt": "[n]  link text[n]",
                   },
                   Object {
-                    "kind": "Particle",
+                    "kind": "Particle: closingDelimiter",
                     "nodeExcerpt": "}",
                   },
                 ],

--- a/tsdoc/src/parser/__tests__/__snapshots__/NodeParserLinkTag.test.ts.snap
+++ b/tsdoc/src/parser/__tests__/__snapshots__/NodeParserLinkTag.test.ts.snap
@@ -1,0 +1,283 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`00 Link tags with URL: positive examples 1`] = `
+Object {
+  "buffer": "/**[n] * {@link http://example1.com}[n] * {@link mail:bob@example2.com}[n] * {@link http://example3.com|link text}[n] * {@link http://example4.com|}[n] * {@link http://example5.com|[n] *}[n] */",
+  "gaps": Array [],
+  "lines": Array [
+    "{@link http://example1.com}",
+    "{@link mail:bob@example2.com}",
+    "{@link http://example3.com|link text}",
+    "{@link http://example4.com|}",
+    "{@link http://example5.com|",
+    "}",
+  ],
+  "logMessages": Array [],
+  "nodes": Object {
+    "kind": "Comment",
+    "nodes": Array [
+      Object {
+        "kind": "Section",
+        "nodes": Array [
+          Object {
+            "kind": "Paragraph",
+            "nodes": Array [
+              Object {
+                "kind": "LinkTag",
+                "nodes": Array [
+                  Object {
+                    "kind": "Particle",
+                    "nodeExcerpt": "{",
+                  },
+                  Object {
+                    "kind": "Particle",
+                    "nodeExcerpt": "@link",
+                    "nodeSpacing": " ",
+                  },
+                  Object {
+                    "kind": "Particle",
+                    "nodeExcerpt": "http://example1.com",
+                  },
+                  Object {
+                    "kind": "Particle",
+                    "nodeExcerpt": "}",
+                  },
+                ],
+              },
+              Object {
+                "kind": "SoftBreak",
+                "nodeExcerpt": "[n]",
+              },
+              Object {
+                "kind": "LinkTag",
+                "nodes": Array [
+                  Object {
+                    "kind": "Particle",
+                    "nodeExcerpt": "{",
+                  },
+                  Object {
+                    "kind": "Particle",
+                    "nodeExcerpt": "@link",
+                    "nodeSpacing": " ",
+                  },
+                  Object {
+                    "kind": "Particle",
+                    "nodeExcerpt": "mail:bob@example2.com",
+                  },
+                  Object {
+                    "kind": "Particle",
+                    "nodeExcerpt": "}",
+                  },
+                ],
+              },
+              Object {
+                "kind": "SoftBreak",
+                "nodeExcerpt": "[n]",
+              },
+              Object {
+                "kind": "LinkTag",
+                "nodes": Array [
+                  Object {
+                    "kind": "Particle",
+                    "nodeExcerpt": "{",
+                  },
+                  Object {
+                    "kind": "Particle",
+                    "nodeExcerpt": "@link",
+                    "nodeSpacing": " ",
+                  },
+                  Object {
+                    "kind": "Particle",
+                    "nodeExcerpt": "http://example3.com",
+                  },
+                  Object {
+                    "kind": "Particle",
+                    "nodeExcerpt": "|",
+                  },
+                  Object {
+                    "kind": "Particle",
+                    "nodeExcerpt": "link text",
+                  },
+                  Object {
+                    "kind": "Particle",
+                    "nodeExcerpt": "}",
+                  },
+                ],
+              },
+              Object {
+                "kind": "SoftBreak",
+                "nodeExcerpt": "[n]",
+              },
+              Object {
+                "kind": "LinkTag",
+                "nodes": Array [
+                  Object {
+                    "kind": "Particle",
+                    "nodeExcerpt": "{",
+                  },
+                  Object {
+                    "kind": "Particle",
+                    "nodeExcerpt": "@link",
+                    "nodeSpacing": " ",
+                  },
+                  Object {
+                    "kind": "Particle",
+                    "nodeExcerpt": "http://example4.com",
+                  },
+                  Object {
+                    "kind": "Particle",
+                    "nodeExcerpt": "|",
+                  },
+                  Object {
+                    "kind": "Particle",
+                    "nodeExcerpt": "}",
+                  },
+                ],
+              },
+              Object {
+                "kind": "SoftBreak",
+                "nodeExcerpt": "[n]",
+              },
+              Object {
+                "kind": "LinkTag",
+                "nodes": Array [
+                  Object {
+                    "kind": "Particle",
+                    "nodeExcerpt": "{",
+                  },
+                  Object {
+                    "kind": "Particle",
+                    "nodeExcerpt": "@link",
+                    "nodeSpacing": " ",
+                  },
+                  Object {
+                    "kind": "Particle",
+                    "nodeExcerpt": "http://example5.com",
+                  },
+                  Object {
+                    "kind": "Particle",
+                    "nodeExcerpt": "|",
+                  },
+                  Object {
+                    "kind": "Particle",
+                    "nodeExcerpt": "[n]",
+                  },
+                  Object {
+                    "kind": "Particle",
+                    "nodeExcerpt": "}",
+                  },
+                ],
+              },
+              Object {
+                "kind": "SoftBreak",
+                "nodeExcerpt": "[n]",
+              },
+            ],
+          },
+        ],
+      },
+    ],
+  },
+}
+`;
+
+exports[`00 Link tags with URL: positive examples 2`] = `
+Object {
+  "buffer": "/**[n] * {@link    mail:bob@example6.com   |  link text }[n] * {@link  [n] *   http://example7.com  [n] *   | [n] *   link text [n] * }[n] */",
+  "gaps": Array [],
+  "lines": Array [
+    "{@link    mail:bob@example6.com   |  link text }",
+    "{@link",
+    "  http://example7.com",
+    "  |",
+    "  link text",
+    "}",
+  ],
+  "logMessages": Array [],
+  "nodes": Object {
+    "kind": "Comment",
+    "nodes": Array [
+      Object {
+        "kind": "Section",
+        "nodes": Array [
+          Object {
+            "kind": "Paragraph",
+            "nodes": Array [
+              Object {
+                "kind": "LinkTag",
+                "nodes": Array [
+                  Object {
+                    "kind": "Particle",
+                    "nodeExcerpt": "{",
+                  },
+                  Object {
+                    "kind": "Particle",
+                    "nodeExcerpt": "@link",
+                    "nodeSpacing": "    ",
+                  },
+                  Object {
+                    "kind": "Particle",
+                    "nodeExcerpt": "mail:bob@example6.com",
+                    "nodeSpacing": "   ",
+                  },
+                  Object {
+                    "kind": "Particle",
+                    "nodeExcerpt": "|",
+                  },
+                  Object {
+                    "kind": "Particle",
+                    "nodeExcerpt": "  link text ",
+                  },
+                  Object {
+                    "kind": "Particle",
+                    "nodeExcerpt": "}",
+                  },
+                ],
+              },
+              Object {
+                "kind": "SoftBreak",
+                "nodeExcerpt": "[n]",
+              },
+              Object {
+                "kind": "LinkTag",
+                "nodes": Array [
+                  Object {
+                    "kind": "Particle",
+                    "nodeExcerpt": "{",
+                  },
+                  Object {
+                    "kind": "Particle",
+                    "nodeExcerpt": "@link",
+                    "nodeSpacing": "[n]  ",
+                  },
+                  Object {
+                    "kind": "Particle",
+                    "nodeExcerpt": "http://example7.com",
+                    "nodeSpacing": "[n]  ",
+                  },
+                  Object {
+                    "kind": "Particle",
+                    "nodeExcerpt": "|",
+                  },
+                  Object {
+                    "kind": "Particle",
+                    "nodeExcerpt": "[n]  link text[n]",
+                  },
+                  Object {
+                    "kind": "Particle",
+                    "nodeExcerpt": "}",
+                  },
+                ],
+              },
+              Object {
+                "kind": "SoftBreak",
+                "nodeExcerpt": "[n]",
+              },
+            ],
+          },
+        ],
+      },
+    ],
+  },
+}
+`;

--- a/tsdoc/src/parser/__tests__/__snapshots__/NodeParserTags.test.ts.snap
+++ b/tsdoc/src/parser/__tests__/__snapshots__/NodeParserTags.test.ts.snap
@@ -179,10 +179,10 @@ Object {
                   Object {
                     "kind": "Particle",
                     "nodeExcerpt": "@two",
+                    "nodeSpacing": " ",
                   },
                   Object {
                     "kind": "Particle",
-                    "nodeExcerpt": " ",
                   },
                   Object {
                     "kind": "Particle",
@@ -248,10 +248,10 @@ Object {
                   Object {
                     "kind": "Particle",
                     "nodeExcerpt": "@five",
+                    "nodeSpacing": "[n]  ",
                   },
                   Object {
                     "kind": "Particle",
-                    "nodeExcerpt": "[n]  ",
                   },
                   Object {
                     "kind": "Particle",
@@ -433,10 +433,11 @@ Object {
                   Object {
                     "kind": "Particle",
                     "nodeExcerpt": "@one",
+                    "nodeSpacing": " ",
                   },
                   Object {
                     "kind": "Particle",
-                    "nodeExcerpt": " some content",
+                    "nodeExcerpt": "some content",
                   },
                   Object {
                     "kind": "Particle",
@@ -458,10 +459,11 @@ Object {
                   Object {
                     "kind": "Particle",
                     "nodeExcerpt": "@two",
+                    "nodeSpacing": " ",
                   },
                   Object {
                     "kind": "Particle",
-                    "nodeExcerpt": " multi[n]line",
+                    "nodeExcerpt": "multi[n]line",
                   },
                   Object {
                     "kind": "Particle",
@@ -509,10 +511,11 @@ Object {
                   Object {
                     "kind": "Particle",
                     "nodeExcerpt": "@three",
+                    "nodeSpacing": " ",
                   },
                   Object {
                     "kind": "Particle",
-                    "nodeExcerpt": " @taglike",
+                    "nodeExcerpt": "@taglike",
                   },
                   Object {
                     "kind": "Particle",
@@ -560,10 +563,11 @@ Object {
                   Object {
                     "kind": "Particle",
                     "nodeExcerpt": "@one",
+                    "nodeSpacing": " ",
                   },
                   Object {
                     "kind": "Particle",
-                    "nodeExcerpt": " left [b]{ right [b]} backslash [b][b] ",
+                    "nodeExcerpt": "left [b]{ right [b]} backslash [b][b] ",
                   },
                   Object {
                     "kind": "Particle",

--- a/tsdoc/src/parser/__tests__/__snapshots__/NodeParserTags.test.ts.snap
+++ b/tsdoc/src/parser/__tests__/__snapshots__/NodeParserTags.test.ts.snap
@@ -149,18 +149,18 @@ Object {
                 "kind": "InlineTag",
                 "nodes": Array [
                   Object {
-                    "kind": "Particle",
+                    "kind": "Particle: openingDelimiter",
                     "nodeExcerpt": "{",
                   },
                   Object {
-                    "kind": "Particle",
+                    "kind": "Particle: tagName",
                     "nodeExcerpt": "@one",
                   },
                   Object {
-                    "kind": "Particle",
+                    "kind": "Particle: tagContent",
                   },
                   Object {
-                    "kind": "Particle",
+                    "kind": "Particle: closingDelimiter",
                     "nodeExcerpt": "}",
                   },
                 ],
@@ -173,19 +173,19 @@ Object {
                 "kind": "InlineTag",
                 "nodes": Array [
                   Object {
-                    "kind": "Particle",
+                    "kind": "Particle: openingDelimiter",
                     "nodeExcerpt": "{",
                   },
                   Object {
-                    "kind": "Particle",
+                    "kind": "Particle: tagName",
                     "nodeExcerpt": "@two",
                     "nodeSpacing": " ",
                   },
                   Object {
-                    "kind": "Particle",
+                    "kind": "Particle: tagContent",
                   },
                   Object {
-                    "kind": "Particle",
+                    "kind": "Particle: closingDelimiter",
                     "nodeExcerpt": "}",
                   },
                 ],
@@ -198,18 +198,18 @@ Object {
                 "kind": "InlineTag",
                 "nodes": Array [
                   Object {
-                    "kind": "Particle",
+                    "kind": "Particle: openingDelimiter",
                     "nodeExcerpt": "{",
                   },
                   Object {
-                    "kind": "Particle",
+                    "kind": "Particle: tagName",
                     "nodeExcerpt": "@three",
                   },
                   Object {
-                    "kind": "Particle",
+                    "kind": "Particle: tagContent",
                   },
                   Object {
-                    "kind": "Particle",
+                    "kind": "Particle: closingDelimiter",
                     "nodeExcerpt": "}",
                   },
                 ],
@@ -218,18 +218,18 @@ Object {
                 "kind": "InlineTag",
                 "nodes": Array [
                   Object {
-                    "kind": "Particle",
+                    "kind": "Particle: openingDelimiter",
                     "nodeExcerpt": "{",
                   },
                   Object {
-                    "kind": "Particle",
+                    "kind": "Particle: tagName",
                     "nodeExcerpt": "@four",
                   },
                   Object {
-                    "kind": "Particle",
+                    "kind": "Particle: tagContent",
                   },
                   Object {
-                    "kind": "Particle",
+                    "kind": "Particle: closingDelimiter",
                     "nodeExcerpt": "}",
                   },
                 ],
@@ -242,19 +242,19 @@ Object {
                 "kind": "InlineTag",
                 "nodes": Array [
                   Object {
-                    "kind": "Particle",
+                    "kind": "Particle: openingDelimiter",
                     "nodeExcerpt": "{",
                   },
                   Object {
-                    "kind": "Particle",
+                    "kind": "Particle: tagName",
                     "nodeExcerpt": "@five",
                     "nodeSpacing": "[n]  ",
                   },
                   Object {
-                    "kind": "Particle",
+                    "kind": "Particle: tagContent",
                   },
                   Object {
-                    "kind": "Particle",
+                    "kind": "Particle: closingDelimiter",
                     "nodeExcerpt": "}",
                   },
                 ],
@@ -427,20 +427,20 @@ Object {
                 "kind": "InlineTag",
                 "nodes": Array [
                   Object {
-                    "kind": "Particle",
+                    "kind": "Particle: openingDelimiter",
                     "nodeExcerpt": "{",
                   },
                   Object {
-                    "kind": "Particle",
+                    "kind": "Particle: tagName",
                     "nodeExcerpt": "@one",
                     "nodeSpacing": " ",
                   },
                   Object {
-                    "kind": "Particle",
+                    "kind": "Particle: tagContent",
                     "nodeExcerpt": "some content",
                   },
                   Object {
-                    "kind": "Particle",
+                    "kind": "Particle: closingDelimiter",
                     "nodeExcerpt": "}",
                   },
                 ],
@@ -453,20 +453,20 @@ Object {
                 "kind": "InlineTag",
                 "nodes": Array [
                   Object {
-                    "kind": "Particle",
+                    "kind": "Particle: openingDelimiter",
                     "nodeExcerpt": "{",
                   },
                   Object {
-                    "kind": "Particle",
+                    "kind": "Particle: tagName",
                     "nodeExcerpt": "@two",
                     "nodeSpacing": " ",
                   },
                   Object {
-                    "kind": "Particle",
+                    "kind": "Particle: tagContent",
                     "nodeExcerpt": "multi[n]line",
                   },
                   Object {
-                    "kind": "Particle",
+                    "kind": "Particle: closingDelimiter",
                     "nodeExcerpt": "}",
                   },
                 ],
@@ -505,20 +505,20 @@ Object {
                 "kind": "InlineTag",
                 "nodes": Array [
                   Object {
-                    "kind": "Particle",
+                    "kind": "Particle: openingDelimiter",
                     "nodeExcerpt": "{",
                   },
                   Object {
-                    "kind": "Particle",
+                    "kind": "Particle: tagName",
                     "nodeExcerpt": "@three",
                     "nodeSpacing": " ",
                   },
                   Object {
-                    "kind": "Particle",
+                    "kind": "Particle: tagContent",
                     "nodeExcerpt": "@taglike",
                   },
                   Object {
-                    "kind": "Particle",
+                    "kind": "Particle: closingDelimiter",
                     "nodeExcerpt": "}",
                   },
                 ],
@@ -557,20 +557,20 @@ Object {
                 "kind": "InlineTag",
                 "nodes": Array [
                   Object {
-                    "kind": "Particle",
+                    "kind": "Particle: openingDelimiter",
                     "nodeExcerpt": "{",
                   },
                   Object {
-                    "kind": "Particle",
+                    "kind": "Particle: tagName",
                     "nodeExcerpt": "@one",
                     "nodeSpacing": " ",
                   },
                   Object {
-                    "kind": "Particle",
+                    "kind": "Particle: tagContent",
                     "nodeExcerpt": "left [b]{ right [b]} backslash [b][b] ",
                   },
                   Object {
-                    "kind": "Particle",
+                    "kind": "Particle: closingDelimiter",
                     "nodeExcerpt": "}",
                   },
                 ],

--- a/tsdoc/src/parser/__tests__/__snapshots__/Tokenizer.test.ts.snap
+++ b/tsdoc/src/parser/__tests__/__snapshots__/Tokenizer.test.ts.snap
@@ -530,7 +530,7 @@ Object {
       "indexOfLine": 0,
       "line": ">![q]#$%&'()*+,-./:;[<]=[>]?@[]^_[c]{|}~<",
       "span": "                                    > < ",
-      "tokenKind": "OtherPunctuation",
+      "tokenKind": "Pipe",
     },
     Object {
       "indexOfLine": 0,


### PR DESCRIPTION
This is the first half of the support for @link tags, which supports URL destinations. Support for [declaration references](https://github.com/Microsoft/tsdoc/issues/9) targets will be in the next PR.

This PR also introduces the idea that `DocParticle` children can be included or not depending on whether the construct was present.  The new `DocParticle.particleId` field helps a visitor to distinguish them.