### PR TITLE
Add support for the @inheritDoc tag

### DIFF
--- a/tsdoc/CHANGELOG.md
+++ b/tsdoc/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Change Log - @microsoft/tsdoc
 
+## 0.6.0
+- Add support for `@link` tags using the new declaration reference syntax
+- Add support for `@inheritDoc` tags
+- Add new APIs: `DocDeclarationReference`, `DocInheritDocTag`, `DocLinkTag`, `DocMemberIdentifier`, `DocMemberReference`, `DocMemberSelector`, `DocMemberSymbol`
+- Remove `ParserContext.verbatimNodes`
+- Add `DocParticle.particleId` property
+
 ## 0.5.0
 - Add a new API `DocNode.updateParameters()` that allows a `DocNode` object to be updated after it was created; the tree nodes are no longer immutable
 - Add `DocNodeTransforms.trimSpacesInParagraphNodes()` for collapsing whitespace inside `DocParagraph` subtrees

--- a/tsdoc/package.json
+++ b/tsdoc/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@microsoft/tsdoc",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "A parser for the TypeScript doc comment syntax",
   "keywords": [
     "TypeScript",

--- a/tsdoc/src/nodes/DocBlock.ts
+++ b/tsdoc/src/nodes/DocBlock.ts
@@ -14,7 +14,7 @@ export interface IDocBlockParameters extends IDocSectionParameters {
  * For example, an `@example` block.
  */
 export class DocBlock extends DocSection {
-  /** {@inheritdoc} */
+  /** {@inheritDoc} */
   public readonly kind: DocNodeKind = DocNodeKind.Block;
 
   private _blockTag: DocBlockTag | undefined; // never undefined after updateParameters()
@@ -41,7 +41,7 @@ export class DocBlock extends DocSection {
   }
 
   /**
-   * {@inheritdoc}
+   * {@inheritDoc}
    * @override
    */
   public getChildNodes(): ReadonlyArray<DocNode> {

--- a/tsdoc/src/nodes/DocBlockTag.ts
+++ b/tsdoc/src/nodes/DocBlockTag.ts
@@ -13,7 +13,7 @@ export interface IDocBlockTagParameters extends IDocNodeLeafParameters {
  * Represents a TSDoc block tag such as `@param` or `@public`.
  */
 export class DocBlockTag extends DocNodeLeaf {
-  /** {@inheritdoc} */
+  /** {@inheritDoc} */
   public readonly kind: DocNodeKind = DocNodeKind.BlockTag;
 
   private _tagName: string | undefined;              // never undefined after updateParameters()

--- a/tsdoc/src/nodes/DocCodeFence.ts
+++ b/tsdoc/src/nodes/DocCodeFence.ts
@@ -23,7 +23,7 @@ export interface IDocCodeFenceParameters extends IDocNodeParameters {
  * can also specify a language for a syntax highlighter.
  */
 export class DocCodeFence extends DocNode {
-  /** {@inheritdoc} */
+  /** {@inheritDoc} */
   public readonly kind: DocNodeKind = DocNodeKind.CodeFence;
 
   // The opening ``` delimiter and padding
@@ -102,7 +102,7 @@ export class DocCodeFence extends DocNode {
   }
 
   /**
-   * {@inheritdoc}
+   * {@inheritDoc}
    * @override
    */
   public getChildNodes(): ReadonlyArray<DocNode> {

--- a/tsdoc/src/nodes/DocCodeSpan.ts
+++ b/tsdoc/src/nodes/DocCodeSpan.ts
@@ -19,7 +19,7 @@ export interface IDocCodeSpanParameters extends IDocNodeParameters {
  * backtick characters.
  */
 export class DocCodeSpan extends DocNode {
-  /** {@inheritdoc} */
+  /** {@inheritDoc} */
   public readonly kind: DocNodeKind = DocNodeKind.CodeSpan;
 
   // The opening ` delimiter
@@ -70,7 +70,7 @@ export class DocCodeSpan extends DocNode {
   }
 
   /**
-   * {@inheritdoc}
+   * {@inheritDoc}
    * @override
    */
   public getChildNodes(): ReadonlyArray<DocNode> {

--- a/tsdoc/src/nodes/DocComment.ts
+++ b/tsdoc/src/nodes/DocComment.ts
@@ -16,7 +16,7 @@ export interface IDocCommentParameters extends IDocNodeParameters {
  * This is the root of the DocNode tree.
  */
 export class DocComment extends DocNode {
-  /** {@inheritdoc} */
+  /** {@inheritDoc} */
   public readonly kind: DocNodeKind = DocNodeKind.Comment;
 
   /**
@@ -120,7 +120,7 @@ export class DocComment extends DocNode {
   }
 
   /**
-   * {@inheritdoc}
+   * {@inheritDoc}
    * @override
    */
   public getChildNodes(): ReadonlyArray<DocNode> {

--- a/tsdoc/src/nodes/DocComment.ts
+++ b/tsdoc/src/nodes/DocComment.ts
@@ -3,6 +3,7 @@ import { DocSection } from './DocSection';
 import { StandardModifierTagSet } from '../details/StandardModifierTagSet';
 import { DocBlock } from './DocBlock';
 import { DocParamBlock } from './DocParamBlock';
+import { DocInheritDocTag } from './DocInheritDocTag';
 
 /**
  * Constructor parameters for {@link DocComment}.
@@ -73,6 +74,12 @@ export class DocComment extends DocNode {
   public returnsBlock: DocBlock | undefined;
 
   /**
+   * If this doc comment contains an `@inheritDoc` tag, it will be extracted and associated
+   * with the DocComment.
+   */
+  public inheritDocTag: DocInheritDocTag | undefined;
+
+  /**
    * The modifier tags for this DocComment.
    */
   public readonly modifierTagSet: StandardModifierTagSet;
@@ -117,32 +124,16 @@ export class DocComment extends DocNode {
    * @override
    */
   public getChildNodes(): ReadonlyArray<DocNode> {
-    const result: DocNode[] = [ ];
-
-    result.push(this.summarySection);
-
-    if (this.remarksBlock) {
-      result.push(this.remarksBlock);
-    }
-
-    if (this.privateRemarks) {
-      result.push(this.privateRemarks);
-    }
-
-    if (this.deprecatedBlock) {
-      result.push(this.deprecatedBlock);
-    }
-
-    result.push(...this.paramBlocks);
-
-    if (this.returnsBlock) {
-      result.push(this.returnsBlock);
-    }
-
-    result.push(...this._customBlocks);
-
-    result.push(...this.modifierTagSet.nodes);
-
-    return result;
+    return DocNode.trimUndefinedNodes([
+      this.summarySection,
+      this.remarksBlock,
+      this.privateRemarks,
+      this.deprecatedBlock,
+      ...this.paramBlocks,
+      this.returnsBlock,
+      ...this._customBlocks,
+      this.inheritDocTag,
+      ...this.modifierTagSet.nodes
+    ]);
   }
 }

--- a/tsdoc/src/nodes/DocDeclarationReference.ts
+++ b/tsdoc/src/nodes/DocDeclarationReference.ts
@@ -26,7 +26,7 @@ export interface IDocDeclarationReferenceParameters extends IDocNodeParameters {
  * or `{@inheritDoc}` that need to refer to another declaration.
  */
 export class DocDeclarationReference extends DocNode {
-  /** {@inheritdoc} */
+  /** {@inheritDoc} */
   public readonly kind: DocNodeKind = DocNodeKind.DeclarationReference;
 
   private _packageNameParticle: DocParticle | undefined;
@@ -117,7 +117,7 @@ export class DocDeclarationReference extends DocNode {
   }
 
   /**
-   * {@inheritdoc}
+   * {@inheritDoc}
    * @override
    */
   public getChildNodes(): ReadonlyArray<DocNode> {

--- a/tsdoc/src/nodes/DocErrorText.ts
+++ b/tsdoc/src/nodes/DocErrorText.ts
@@ -16,7 +16,7 @@ export interface IDocErrorTextParameters extends IDocNodeLeafParameters {
  * The characters should be rendered as plain text.
  */
 export class DocErrorText extends DocNodeLeaf {
-  /** {@inheritdoc} */
+  /** {@inheritDoc} */
   public readonly kind: DocNodeKind = DocNodeKind.ErrorText;
 
   private _text: string | undefined;                  // never undefined after updateParameters()

--- a/tsdoc/src/nodes/DocEscapedText.ts
+++ b/tsdoc/src/nodes/DocEscapedText.ts
@@ -27,7 +27,7 @@ export enum EscapeStyle {
  * forces a specific escaping that may not be the default.
  */
 export class DocEscapedText extends DocNodeLeaf {
-  /** {@inheritdoc} */
+  /** {@inheritDoc} */
   public readonly kind: DocNodeKind = DocNodeKind.EscapedText;
 
   private _escapeStyle: EscapeStyle | undefined;  // never undefined after updateParameters()

--- a/tsdoc/src/nodes/DocHtmlAttribute.ts
+++ b/tsdoc/src/nodes/DocHtmlAttribute.ts
@@ -24,7 +24,7 @@ export interface IDocHtmlAttributeParameters extends IDocNodeParameters {
  * Example: `href="#"` inside `<a href="#" />`
  */
 export class DocHtmlAttribute extends DocNode {
-  /** {@inheritdoc} */
+  /** {@inheritDoc} */
   public readonly kind: DocNodeKind = DocNodeKind.HtmlAttribute;
 
   // The attribute name
@@ -109,7 +109,7 @@ export class DocHtmlAttribute extends DocNode {
   }
 
   /**
-   * {@inheritdoc}
+   * {@inheritDoc}
    * @override
    */
   public getChildNodes(): ReadonlyArray<DocNode> {

--- a/tsdoc/src/nodes/DocHtmlEndTag.ts
+++ b/tsdoc/src/nodes/DocHtmlEndTag.ts
@@ -18,7 +18,7 @@ export interface IDocHtmlEndTagParameters extends IDocNodeParameters {
  * Represents an HTML end tag.  Example: `</a>`
  */
 export class DocHtmlEndTag extends DocNode {
-  /** {@inheritdoc} */
+  /** {@inheritDoc} */
   public readonly kind: DocNodeKind = DocNodeKind.HtmlEndTag;
 
   // The "</" delimiter
@@ -69,7 +69,7 @@ export class DocHtmlEndTag extends DocNode {
   }
 
   /**
-   * {@inheritdoc}
+   * {@inheritDoc}
    * @override
    */
   public getChildNodes(): ReadonlyArray<DocNode> {

--- a/tsdoc/src/nodes/DocHtmlStartTag.ts
+++ b/tsdoc/src/nodes/DocHtmlStartTag.ts
@@ -25,7 +25,7 @@ export interface IDocHtmlStartTagParameters extends IDocNodeParameters {
  * Example: `<a href="#" />`
  */
 export class DocHtmlStartTag extends DocNode {
-  /** {@inheritdoc} */
+  /** {@inheritDoc} */
   public readonly kind: DocNodeKind = DocNodeKind.HtmlStartTag;
 
   // The "<" delimiter
@@ -107,7 +107,7 @@ export class DocHtmlStartTag extends DocNode {
   }
 
   /**
-   * {@inheritdoc}
+   * {@inheritDoc}
    * @override
    */
   public getChildNodes(): ReadonlyArray<DocNode> {

--- a/tsdoc/src/nodes/DocInheritDocTag.ts
+++ b/tsdoc/src/nodes/DocInheritDocTag.ts
@@ -51,6 +51,15 @@ export class DocInheritDocTag extends DocInlineTag {
    * @override
    */
   protected getChildNodesForContent(): ReadonlyArray<DocNode> {
-    return DocNode.trimUndefinedNodes([ this._declarationReference ]);
+    if (this.tagContentParticle.excerpt) {
+      // If the parser associated the inline tag input with the tagContentExcerpt (e.g. because
+      // second stage parsing encountered an error), then fall back to the base class's representation
+      return super.getChildNodesForContent();
+    } else {
+      // Otherwise return the detailed structure
+      return DocNode.trimUndefinedNodes([
+        this._declarationReference
+      ]);
+    }
   }
 }

--- a/tsdoc/src/nodes/DocInheritDocTag.ts
+++ b/tsdoc/src/nodes/DocInheritDocTag.ts
@@ -14,7 +14,7 @@ export interface IDocInheritDocTagParameters extends IDocInlineTagParameters {
  */
 export class DocInheritDocTag extends DocInlineTag {
 
-  /** {@inheritdoc} */
+  /** {@inheritDoc} */
   public readonly kind: DocNodeKind = DocNodeKind.InheritDocTag;
 
   private _declarationReference: DocDeclarationReference | undefined;
@@ -47,7 +47,7 @@ export class DocInheritDocTag extends DocInlineTag {
   }
 
   /**
-   * {@inheritdoc}
+   * {@inheritDoc}
    * @override
    */
   protected getChildNodesForContent(): ReadonlyArray<DocNode> {

--- a/tsdoc/src/nodes/DocInheritDocTag.ts
+++ b/tsdoc/src/nodes/DocInheritDocTag.ts
@@ -1,0 +1,56 @@
+import { DocNodeKind, DocNode } from './DocNode';
+import { DocInlineTag, IDocInlineTagParameters } from './DocInlineTag';
+import { DocDeclarationReference } from './DocDeclarationReference';
+
+/**
+ * Constructor parameters for {@link DocInheritDocTag}.
+ */
+export interface IDocInheritDocTagParameters extends IDocInlineTagParameters {
+  declarationReference?: DocDeclarationReference;
+}
+
+/**
+ * Represents an `{@inheritDoc}` tag.
+ */
+export class DocInheritDocTag extends DocInlineTag {
+
+  /** {@inheritdoc} */
+  public readonly kind: DocNodeKind = DocNodeKind.InheritDocTag;
+
+  private _declarationReference: DocDeclarationReference | undefined;
+
+  /**
+   * Don't call this directly.  Instead use {@link TSDocParser}
+   * @internal
+   */
+  public constructor(parameters: IDocInheritDocTagParameters) {
+    super(parameters);
+  }
+
+  /**
+   * The declaration that the documentation will be inherited from.
+   * If omitted, the documentation will be inherited from the parent class.
+   */
+  public get declarationReference(): DocDeclarationReference | undefined {
+    return this._declarationReference;
+  }
+
+  /** @override */
+  public updateParameters(parameters: IDocInheritDocTagParameters): void {
+    if (parameters.tagName.toUpperCase() !== '@INHERITDOC') {
+      throw new Error('DocInheritDocTag requires the tag name to be "{@inheritDoc}"');
+    }
+
+    super.updateParameters(parameters);
+
+    this._declarationReference = parameters.declarationReference;
+  }
+
+  /**
+   * {@inheritdoc}
+   * @override
+   */
+  protected getChildNodesForContent(): ReadonlyArray<DocNode> {
+    return DocNode.trimUndefinedNodes([ this._declarationReference ]);
+  }
+}

--- a/tsdoc/src/nodes/DocInlineTag.ts
+++ b/tsdoc/src/nodes/DocInlineTag.ts
@@ -19,10 +19,10 @@ export interface IDocInlineTagParameters extends IDocNodeParameters {
 }
 
 /**
- * Represents a TSDoc inline tag such as `{@inheritdoc}` or `{@link}`.
+ * Represents a TSDoc inline tag such as `{@inheritDoc}` or `{@link}`.
  */
 export class DocInlineTag extends DocNode {
-  /** {@inheritdoc} */
+  /** {@inheritDoc} */
   public readonly kind: DocNodeKind = DocNodeKind.InlineTag;
 
   private _openingDelimiterParticle: DocParticle | undefined;  // never undefined after updateParameters()
@@ -88,7 +88,7 @@ export class DocInlineTag extends DocNode {
   }
 
   /**
-   * {@inheritdoc}
+   * {@inheritDoc}
    * @override @sealed
    */
   public getChildNodes(): ReadonlyArray<DocNode> {

--- a/tsdoc/src/nodes/DocLinkTag.ts
+++ b/tsdoc/src/nodes/DocLinkTag.ts
@@ -24,7 +24,7 @@ export interface IDocLinkTagParameters extends IDocInlineTagParameters {
  */
 export class DocLinkTag extends DocInlineTag {
 
-  /** {@inheritdoc} */
+  /** {@inheritDoc} */
   public readonly kind: DocNodeKind = DocNodeKind.LinkTag;
 
   private _codeDestination: DocDeclarationReference | undefined;
@@ -130,7 +130,7 @@ export class DocLinkTag extends DocInlineTag {
   }
 
   /**
-   * {@inheritdoc}
+   * {@inheritDoc}
    * @override
    */
   protected getChildNodesForContent(): ReadonlyArray<DocNode> {

--- a/tsdoc/src/nodes/DocMemberIdentifier.ts
+++ b/tsdoc/src/nodes/DocMemberIdentifier.ts
@@ -19,7 +19,7 @@ export interface IDocMemberIdentifierParameters extends IDocNodeParameters {
  * A member identifier is part of a {@link DocMemberReference}.
  */
 export class DocMemberIdentifier extends DocNode {
-  /** {@inheritdoc} */
+  /** {@inheritDoc} */
   public readonly kind: DocNodeKind = DocNodeKind.MemberIdentifier;
 
   private _leftQuoteParticle: DocParticle | undefined;
@@ -97,7 +97,7 @@ export class DocMemberIdentifier extends DocNode {
   }
 
   /**
-   * {@inheritdoc}
+   * {@inheritDoc}
    * @override
    */
   public getChildNodes(): ReadonlyArray<DocNode> {

--- a/tsdoc/src/nodes/DocMemberReference.ts
+++ b/tsdoc/src/nodes/DocMemberReference.ts
@@ -33,7 +33,7 @@ export interface IDocMemberReferenceParameters extends IDocNodeParameters {
  * `ui`, `.controls`, and `.Button`, and `.(render:static)`.
  */
 export class DocMemberReference extends DocNode {
-  /** {@inheritdoc} */
+  /** {@inheritDoc} */
   public readonly kind: DocNodeKind = DocNodeKind.MemberReference;
 
   // The "." token if unless this was the member reference in the chain
@@ -148,7 +148,7 @@ export class DocMemberReference extends DocNode {
   }
 
   /**
-   * {@inheritdoc}
+   * {@inheritDoc}
    * @override
    */
   public getChildNodes(): ReadonlyArray<DocNode> {

--- a/tsdoc/src/nodes/DocMemberSelector.ts
+++ b/tsdoc/src/nodes/DocMemberSelector.ts
@@ -57,7 +57,7 @@ export class DocMemberSelector extends DocNodeLeaf {
 
   private static readonly _likeSystemSelectorRegExp: RegExp = /^[a-z]+$/u;
 
-  /** {@inheritdoc} */
+  /** {@inheritDoc} */
   public readonly kind: DocNodeKind = DocNodeKind.MemberSelector;
 
   private _selector: string | undefined;  // never undefined after updateParameters()

--- a/tsdoc/src/nodes/DocMemberSymbol.ts
+++ b/tsdoc/src/nodes/DocMemberSymbol.ts
@@ -25,7 +25,7 @@ export interface IDocMemberSymbolParameters extends IDocNodeParameters {
  * of the class.
  */
 export class DocMemberSymbol extends DocNode {
-  /** {@inheritdoc} */
+  /** {@inheritDoc} */
   public readonly kind: DocNodeKind = DocNodeKind.MemberSymbol;
 
   private _leftBracketParticle: DocParticle | undefined;          // never undefined after updateParameters()
@@ -70,7 +70,7 @@ export class DocMemberSymbol extends DocNode {
   }
 
   /**
-   * {@inheritdoc}
+   * {@inheritDoc}
    * @override
    */
   public getChildNodes(): ReadonlyArray<DocNode> {

--- a/tsdoc/src/nodes/DocNode.ts
+++ b/tsdoc/src/nodes/DocNode.ts
@@ -13,6 +13,7 @@ export const enum DocNodeKind {
   HtmlAttribute = 'HtmlAttribute',
   HtmlEndTag = 'HtmlEndTag',
   HtmlStartTag = 'HtmlStartTag',
+  InheritDocTag = 'InheritDocTag',
   InlineTag = 'InlineTag',
   LinkTag = 'LinkTag',
   MemberIdentifier = 'MemberIdentifier',

--- a/tsdoc/src/nodes/DocNodeContainer.ts
+++ b/tsdoc/src/nodes/DocNodeContainer.ts
@@ -40,7 +40,7 @@ export abstract class DocNodeContainer extends DocNode {
   }
 
   /**
-   * {@inheritdoc}
+   * {@inheritDoc}
    * @override
    */
   public getChildNodes(): ReadonlyArray<DocNode> {

--- a/tsdoc/src/nodes/DocParagraph.ts
+++ b/tsdoc/src/nodes/DocParagraph.ts
@@ -38,7 +38,6 @@ export class DocParagraph extends DocNodeContainer {
       case DocNodeKind.HtmlStartTag:
       case DocNodeKind.HtmlEndTag:
       case DocNodeKind.InlineTag:
-      case DocNodeKind.InheritDocTag:
       case DocNodeKind.LinkTag:
       case DocNodeKind.PlainText:
       case DocNodeKind.SoftBreak:

--- a/tsdoc/src/nodes/DocParagraph.ts
+++ b/tsdoc/src/nodes/DocParagraph.ts
@@ -38,6 +38,7 @@ export class DocParagraph extends DocNodeContainer {
       case DocNodeKind.HtmlStartTag:
       case DocNodeKind.HtmlEndTag:
       case DocNodeKind.InlineTag:
+      case DocNodeKind.InheritDocTag:
       case DocNodeKind.LinkTag:
       case DocNodeKind.PlainText:
       case DocNodeKind.SoftBreak:

--- a/tsdoc/src/nodes/DocParagraph.ts
+++ b/tsdoc/src/nodes/DocParagraph.ts
@@ -13,7 +13,7 @@ export interface IDocParagraphParameters extends IDocNodeContainerParameters {
  * instead of explicitly notating them.
  */
 export class DocParagraph extends DocNodeContainer {
-  /** {@inheritdoc} */
+  /** {@inheritDoc} */
   public readonly kind: DocNodeKind = DocNodeKind.Paragraph;
 
   /**
@@ -25,7 +25,7 @@ export class DocParagraph extends DocNodeContainer {
   }
 
   /**
-   * {@inheritdoc}
+   * {@inheritDoc}
    * @override
    */
   public isAllowedChildNode(docNode: DocNode): boolean {

--- a/tsdoc/src/nodes/DocParamBlock.ts
+++ b/tsdoc/src/nodes/DocParamBlock.ts
@@ -18,7 +18,7 @@ export interface IDocParamBlockParameters extends IDocBlockParameters {
  * function parameter.
  */
 export class DocParamBlock extends DocBlock {
-  /** {@inheritdoc} */
+  /** {@inheritDoc} */
   public readonly kind: DocNodeKind = DocNodeKind.ParamBlock;
 
   private _parameterNameParticle: DocParticle | undefined;  // never undefined after updateParameters()
@@ -58,7 +58,7 @@ export class DocParamBlock extends DocBlock {
   }
 
   /**
-   * {@inheritdoc}
+   * {@inheritDoc}
    * @override
    */
   public getChildNodes(): ReadonlyArray<DocNode> {

--- a/tsdoc/src/nodes/DocParticle.ts
+++ b/tsdoc/src/nodes/DocParticle.ts
@@ -25,7 +25,7 @@ export interface IDocParticleParameters extends IDocNodeLeafParameters {
  * they are represented as generic "DocParticle" nodes.
  */
 export class DocParticle extends DocNodeLeaf {
-  /** {@inheritdoc} */
+  /** {@inheritDoc} */
   public readonly kind: DocNodeKind = DocNodeKind.Particle;
 
   private _particleId: string | undefined;          // never undefined after updateParameters()

--- a/tsdoc/src/nodes/DocPlainText.ts
+++ b/tsdoc/src/nodes/DocPlainText.ts
@@ -21,7 +21,7 @@ export class DocPlainText extends DocNodeLeaf {
   // to interpret a lone "\r" as a newline
   private static readonly _newlineCharacterRegExp: RegExp = /[\n]/;
 
-  /** {@inheritdoc} */
+  /** {@inheritDoc} */
   public readonly kind: DocNodeKind = DocNodeKind.PlainText;
 
   private _text: string | undefined;  // never undefined after updateParameters()

--- a/tsdoc/src/nodes/DocSection.ts
+++ b/tsdoc/src/nodes/DocSection.ts
@@ -14,7 +14,7 @@ export interface IDocSectionParameters extends IDocNodeContainerParameters {
  * act as a simple container for other child nodes.
  */
 export class DocSection extends DocNodeContainer {
-  /** {@inheritdoc} */
+  /** {@inheritDoc} */
   public readonly kind: DocNodeKind = DocNodeKind.Section;
 
   /**
@@ -26,7 +26,7 @@ export class DocSection extends DocNodeContainer {
   }
 
   /**
-   * {@inheritdoc}
+   * {@inheritDoc}
    * @override
    */
   public isAllowedChildNode(docNode: DocNode): boolean {

--- a/tsdoc/src/nodes/DocSoftBreak.ts
+++ b/tsdoc/src/nodes/DocSoftBreak.ts
@@ -21,7 +21,7 @@ export interface IDocSoftBreakParameters extends IDocNodeLeafParameters {
  * two empty lines (because that could start a new CommonMark paragraph).
  */
 export class DocSoftBreak extends DocNodeLeaf {
-  /** {@inheritdoc} */
+  /** {@inheritDoc} */
   public readonly kind: DocNodeKind = DocNodeKind.SoftBreak;
 
   /**

--- a/tsdoc/src/nodes/index.ts
+++ b/tsdoc/src/nodes/index.ts
@@ -11,6 +11,7 @@ export * from './DocHtmlAttribute';
 export * from './DocHtmlEndTag';
 export * from './DocHtmlStartTag';
 export * from './DocInlineTag';
+export * from './DocInheritDocTag';
 export * from './DocLinkTag';
 export * from './DocMemberIdentifier';
 export * from './DocMemberReference';

--- a/tsdoc/src/parser/NodeParser.ts
+++ b/tsdoc/src/parser/NodeParser.ts
@@ -574,19 +574,20 @@ export class NodeParser {
     const parameters: IDocInheritDocTagParameters = { ...docInlineTagParameters};
 
     if (embeddedTokenReader.peekTokenKind() !== TokenKind.EndOfInput) {
+
       parameters.declarationReference = this._parseDeclarationReference(embeddedTokenReader,
         docInlineTagParameters.tagNameExcerpt!.content, docInheritDocTag);
       if (!parameters.declarationReference) {
         return docInheritDocTag; // error
       }
-    }
 
-    if (embeddedTokenReader.peekTokenKind() !== TokenKind.EndOfInput) {
-      embeddedTokenReader.readToken();
+      if (embeddedTokenReader.peekTokenKind() !== TokenKind.EndOfInput) {
+        embeddedTokenReader.readToken();
 
-      this._parserContext.log.addMessageForTokenSequence('Unexpected character after declaration reference',
-        embeddedTokenReader.extractAccumulatedSequence(), docInheritDocTag);
-      return docInheritDocTag; // error
+        this._parserContext.log.addMessageForTokenSequence('Unexpected character after declaration reference',
+          embeddedTokenReader.extractAccumulatedSequence(), docInheritDocTag);
+        return docInheritDocTag; // error
+      }
     }
 
     // We don't need the tagContentExcerpt since those tokens are now associated with the link particles
@@ -956,6 +957,7 @@ export class NodeParser {
       // We didn't find any parts of a declaration reference
       this._parserContext.log.addMessageForTokenSequence('Expecting a declaration reference',
         tokenSequenceForErrorContext, nodeForErrorContext);
+      return undefined;
     }
 
     return new DocDeclarationReference({

--- a/tsdoc/src/parser/__tests__/NodeParserInheritDocTag.test.ts
+++ b/tsdoc/src/parser/__tests__/NodeParserInheritDocTag.test.ts
@@ -1,0 +1,19 @@
+import { TestHelpers } from './TestHelpers';
+
+test('00 InheritDoc tag: positive examples', () => {
+  TestHelpers.parseAndMatchNodeParserSnapshot([
+    '/**',
+    ' * {@inheritDoc}',
+    ' * {@inheritDoc Class.member}',
+    ' * {@inheritDoc package# Class . member}',
+    ' */'
+  ].join('\n'));
+});
+
+test('01 InheritDoc tag: negative examples', () => {
+  TestHelpers.parseAndMatchNodeParserSnapshot([
+    '/**',
+    ' * {@inheritDoc | link text}',
+    ' */'
+  ].join('\n'));
+});

--- a/tsdoc/src/parser/__tests__/NodeParserInheritDocTag.test.ts
+++ b/tsdoc/src/parser/__tests__/NodeParserInheritDocTag.test.ts
@@ -26,6 +26,11 @@ test('01 InheritDoc tag: negative examples', () => {
   ].join('\n'));
   TestHelpers.parseAndMatchNodeParserSnapshot([
     '/**',
+    ' * {@inheritDoc Class % junk}',
+    ' */'
+  ].join('\n'));
+  TestHelpers.parseAndMatchNodeParserSnapshot([
+    '/**',
     ' * {@inheritDoc}',
     ' * {@inheritDoc}',
     ' */'

--- a/tsdoc/src/parser/__tests__/NodeParserInheritDocTag.test.ts
+++ b/tsdoc/src/parser/__tests__/NodeParserInheritDocTag.test.ts
@@ -4,7 +4,15 @@ test('00 InheritDoc tag: positive examples', () => {
   TestHelpers.parseAndMatchNodeParserSnapshot([
     '/**',
     ' * {@inheritDoc}',
+    ' */'
+  ].join('\n'));
+  TestHelpers.parseAndMatchNodeParserSnapshot([
+    '/**',
     ' * {@inheritDoc Class.member}',
+    ' */'
+  ].join('\n'));
+  TestHelpers.parseAndMatchNodeParserSnapshot([
+    '/**',
     ' * {@inheritDoc package# Class . member}',
     ' */'
   ].join('\n'));
@@ -14,6 +22,12 @@ test('01 InheritDoc tag: negative examples', () => {
   TestHelpers.parseAndMatchNodeParserSnapshot([
     '/**',
     ' * {@inheritDoc | link text}',
+    ' */'
+  ].join('\n'));
+  TestHelpers.parseAndMatchNodeParserSnapshot([
+    '/**',
+    ' * {@inheritDoc}',
+    ' * {@inheritDoc}',
     ' */'
   ].join('\n'));
 });

--- a/tsdoc/src/parser/__tests__/__snapshots__/NodeParserInheritDocTag.test.ts.snap
+++ b/tsdoc/src/parser/__tests__/__snapshots__/NodeParserInheritDocTag.test.ts.snap
@@ -1,0 +1,234 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`00 InheritDoc tag: positive examples 1`] = `
+Object {
+  "buffer": "/**[n] * {@inheritDoc}[n] * {@inheritDoc Class.member}[n] * {@inheritDoc package# Class . member}[n] */",
+  "gaps": Array [],
+  "lines": Array [
+    "{@inheritDoc}",
+    "{@inheritDoc Class.member}",
+    "{@inheritDoc package# Class . member}",
+  ],
+  "logMessages": Array [],
+  "nodes": Object {
+    "kind": "Comment",
+    "nodes": Array [
+      Object {
+        "kind": "Section",
+        "nodes": Array [
+          Object {
+            "kind": "Paragraph",
+            "nodes": Array [
+              Object {
+                "kind": "InheritDocTag",
+                "nodes": Array [
+                  Object {
+                    "kind": "Particle: openingDelimiter",
+                    "nodeExcerpt": "{",
+                  },
+                  Object {
+                    "kind": "Particle: tagName",
+                    "nodeExcerpt": "@inheritDoc",
+                  },
+                  Object {
+                    "kind": "Particle: closingDelimiter",
+                    "nodeExcerpt": "}",
+                  },
+                ],
+              },
+              Object {
+                "kind": "SoftBreak",
+                "nodeExcerpt": "[n]",
+              },
+              Object {
+                "kind": "InheritDocTag",
+                "nodes": Array [
+                  Object {
+                    "kind": "Particle: openingDelimiter",
+                    "nodeExcerpt": "{",
+                  },
+                  Object {
+                    "kind": "Particle: tagName",
+                    "nodeExcerpt": "@inheritDoc",
+                    "nodeSpacing": " ",
+                  },
+                  Object {
+                    "kind": "DeclarationReference",
+                    "nodes": Array [
+                      Object {
+                        "kind": "MemberReference",
+                        "nodes": Array [
+                          Object {
+                            "kind": "MemberIdentifier",
+                            "nodes": Array [
+                              Object {
+                                "kind": "Particle: identifier",
+                                "nodeExcerpt": "Class",
+                              },
+                            ],
+                          },
+                        ],
+                      },
+                      Object {
+                        "kind": "MemberReference",
+                        "nodes": Array [
+                          Object {
+                            "kind": "Particle: dot",
+                            "nodeExcerpt": ".",
+                          },
+                          Object {
+                            "kind": "MemberIdentifier",
+                            "nodes": Array [
+                              Object {
+                                "kind": "Particle: identifier",
+                                "nodeExcerpt": "member",
+                              },
+                            ],
+                          },
+                        ],
+                      },
+                    ],
+                  },
+                  Object {
+                    "kind": "Particle: closingDelimiter",
+                    "nodeExcerpt": "}",
+                  },
+                ],
+              },
+              Object {
+                "kind": "SoftBreak",
+                "nodeExcerpt": "[n]",
+              },
+              Object {
+                "kind": "InheritDocTag",
+                "nodes": Array [
+                  Object {
+                    "kind": "Particle: openingDelimiter",
+                    "nodeExcerpt": "{",
+                  },
+                  Object {
+                    "kind": "Particle: tagName",
+                    "nodeExcerpt": "@inheritDoc",
+                    "nodeSpacing": " ",
+                  },
+                  Object {
+                    "kind": "DeclarationReference",
+                    "nodes": Array [
+                      Object {
+                        "kind": "Particle: packageName",
+                        "nodeExcerpt": "package",
+                      },
+                      Object {
+                        "kind": "Particle: importHash",
+                        "nodeExcerpt": "#",
+                        "nodeSpacing": " ",
+                      },
+                      Object {
+                        "kind": "MemberReference",
+                        "nodes": Array [
+                          Object {
+                            "kind": "MemberIdentifier",
+                            "nodes": Array [
+                              Object {
+                                "kind": "Particle: identifier",
+                                "nodeExcerpt": "Class",
+                                "nodeSpacing": " ",
+                              },
+                            ],
+                          },
+                        ],
+                      },
+                      Object {
+                        "kind": "MemberReference",
+                        "nodes": Array [
+                          Object {
+                            "kind": "Particle: dot",
+                            "nodeExcerpt": ".",
+                            "nodeSpacing": " ",
+                          },
+                          Object {
+                            "kind": "MemberIdentifier",
+                            "nodes": Array [
+                              Object {
+                                "kind": "Particle: identifier",
+                                "nodeExcerpt": "member",
+                              },
+                            ],
+                          },
+                        ],
+                      },
+                    ],
+                  },
+                  Object {
+                    "kind": "Particle: closingDelimiter",
+                    "nodeExcerpt": "}",
+                  },
+                ],
+              },
+              Object {
+                "kind": "SoftBreak",
+                "nodeExcerpt": "[n]",
+              },
+            ],
+          },
+        ],
+      },
+    ],
+  },
+}
+`;
+
+exports[`01 InheritDoc tag: negative examples 1`] = `
+Object {
+  "buffer": "/**[n] * {@inheritDoc | link text}[n] */",
+  "gaps": Array [
+    "| link text",
+  ],
+  "lines": Array [
+    "{@inheritDoc | link text}",
+  ],
+  "logMessages": Array [
+    "(2,5): Expecting a declaration reference",
+  ],
+  "nodes": Object {
+    "kind": "Comment",
+    "nodes": Array [
+      Object {
+        "kind": "Section",
+        "nodes": Array [
+          Object {
+            "kind": "Paragraph",
+            "nodes": Array [
+              Object {
+                "kind": "InheritDocTag",
+                "nodes": Array [
+                  Object {
+                    "kind": "Particle: openingDelimiter",
+                    "nodeExcerpt": "{",
+                  },
+                  Object {
+                    "kind": "Particle: tagName",
+                    "nodeExcerpt": "@inheritDoc",
+                    "nodeSpacing": " ",
+                  },
+                  Object {
+                    "kind": "DeclarationReference",
+                  },
+                  Object {
+                    "kind": "Particle: closingDelimiter",
+                    "nodeExcerpt": "}",
+                  },
+                ],
+              },
+              Object {
+                "kind": "SoftBreak",
+                "nodeExcerpt": "[n]",
+              },
+            ],
+          },
+        ],
+      },
+    ],
+  },
+}
+`;

--- a/tsdoc/src/parser/__tests__/__snapshots__/NodeParserInheritDocTag.test.ts.snap
+++ b/tsdoc/src/parser/__tests__/__snapshots__/NodeParserInheritDocTag.test.ts.snap
@@ -237,7 +237,6 @@ Object {
   ],
   "logMessages": Array [
     "(2,5): Expecting a declaration reference",
-    "(2,17): Unexpected character after declaration reference",
   ],
   "nodes": Object {
     "kind": "Comment",
@@ -284,6 +283,60 @@ Object {
 `;
 
 exports[`01 InheritDoc tag: negative examples 2`] = `
+Object {
+  "buffer": "/**[n] * {@inheritDoc Class % junk}[n] */",
+  "gaps": Array [],
+  "lines": Array [
+    "{@inheritDoc Class % junk}",
+  ],
+  "logMessages": Array [
+    "(2,23): Unexpected character after declaration reference",
+  ],
+  "nodes": Object {
+    "kind": "Comment",
+    "nodes": Array [
+      Object {
+        "kind": "Section",
+        "nodes": Array [
+          Object {
+            "kind": "Paragraph",
+            "nodes": Array [
+              Object {
+                "kind": "SoftBreak",
+                "nodeExcerpt": "[n]",
+              },
+            ],
+          },
+        ],
+      },
+      Object {
+        "kind": "InheritDocTag",
+        "nodes": Array [
+          Object {
+            "kind": "Particle: openingDelimiter",
+            "nodeExcerpt": "{",
+          },
+          Object {
+            "kind": "Particle: tagName",
+            "nodeExcerpt": "@inheritDoc",
+            "nodeSpacing": " ",
+          },
+          Object {
+            "kind": "Particle: tagContent",
+            "nodeExcerpt": "Class % junk",
+          },
+          Object {
+            "kind": "Particle: closingDelimiter",
+            "nodeExcerpt": "}",
+          },
+        ],
+      },
+    ],
+  },
+}
+`;
+
+exports[`01 InheritDoc tag: negative examples 3`] = `
 Object {
   "buffer": "/**[n] * {@inheritDoc}[n] * {@inheritDoc}[n] */",
   "gaps": Array [],

--- a/tsdoc/src/parser/__tests__/__snapshots__/NodeParserInheritDocTag.test.ts.snap
+++ b/tsdoc/src/parser/__tests__/__snapshots__/NodeParserInheritDocTag.test.ts.snap
@@ -2,11 +2,141 @@
 
 exports[`00 InheritDoc tag: positive examples 1`] = `
 Object {
-  "buffer": "/**[n] * {@inheritDoc}[n] * {@inheritDoc Class.member}[n] * {@inheritDoc package# Class . member}[n] */",
+  "buffer": "/**[n] * {@inheritDoc}[n] */",
   "gaps": Array [],
   "lines": Array [
     "{@inheritDoc}",
+  ],
+  "logMessages": Array [],
+  "nodes": Object {
+    "kind": "Comment",
+    "nodes": Array [
+      Object {
+        "kind": "Section",
+        "nodes": Array [
+          Object {
+            "kind": "Paragraph",
+            "nodes": Array [
+              Object {
+                "kind": "SoftBreak",
+                "nodeExcerpt": "[n]",
+              },
+            ],
+          },
+        ],
+      },
+      Object {
+        "kind": "InheritDocTag",
+        "nodes": Array [
+          Object {
+            "kind": "Particle: openingDelimiter",
+            "nodeExcerpt": "{",
+          },
+          Object {
+            "kind": "Particle: tagName",
+            "nodeExcerpt": "@inheritDoc",
+          },
+          Object {
+            "kind": "Particle: closingDelimiter",
+            "nodeExcerpt": "}",
+          },
+        ],
+      },
+    ],
+  },
+}
+`;
+
+exports[`00 InheritDoc tag: positive examples 2`] = `
+Object {
+  "buffer": "/**[n] * {@inheritDoc Class.member}[n] */",
+  "gaps": Array [],
+  "lines": Array [
     "{@inheritDoc Class.member}",
+  ],
+  "logMessages": Array [],
+  "nodes": Object {
+    "kind": "Comment",
+    "nodes": Array [
+      Object {
+        "kind": "Section",
+        "nodes": Array [
+          Object {
+            "kind": "Paragraph",
+            "nodes": Array [
+              Object {
+                "kind": "SoftBreak",
+                "nodeExcerpt": "[n]",
+              },
+            ],
+          },
+        ],
+      },
+      Object {
+        "kind": "InheritDocTag",
+        "nodes": Array [
+          Object {
+            "kind": "Particle: openingDelimiter",
+            "nodeExcerpt": "{",
+          },
+          Object {
+            "kind": "Particle: tagName",
+            "nodeExcerpt": "@inheritDoc",
+            "nodeSpacing": " ",
+          },
+          Object {
+            "kind": "DeclarationReference",
+            "nodes": Array [
+              Object {
+                "kind": "MemberReference",
+                "nodes": Array [
+                  Object {
+                    "kind": "MemberIdentifier",
+                    "nodes": Array [
+                      Object {
+                        "kind": "Particle: identifier",
+                        "nodeExcerpt": "Class",
+                      },
+                    ],
+                  },
+                ],
+              },
+              Object {
+                "kind": "MemberReference",
+                "nodes": Array [
+                  Object {
+                    "kind": "Particle: dot",
+                    "nodeExcerpt": ".",
+                  },
+                  Object {
+                    "kind": "MemberIdentifier",
+                    "nodes": Array [
+                      Object {
+                        "kind": "Particle: identifier",
+                        "nodeExcerpt": "member",
+                      },
+                    ],
+                  },
+                ],
+              },
+            ],
+          },
+          Object {
+            "kind": "Particle: closingDelimiter",
+            "nodeExcerpt": "}",
+          },
+        ],
+      },
+    ],
+  },
+}
+`;
+
+exports[`00 InheritDoc tag: positive examples 3`] = `
+Object {
+  "buffer": "/**[n] * {@inheritDoc package# Class . member}[n] */",
+  "gaps": Array [],
+  "lines": Array [
     "{@inheritDoc package# Class . member}",
   ],
   "logMessages": Array [],
@@ -20,156 +150,76 @@ Object {
             "kind": "Paragraph",
             "nodes": Array [
               Object {
-                "kind": "InheritDocTag",
-                "nodes": Array [
-                  Object {
-                    "kind": "Particle: openingDelimiter",
-                    "nodeExcerpt": "{",
-                  },
-                  Object {
-                    "kind": "Particle: tagName",
-                    "nodeExcerpt": "@inheritDoc",
-                  },
-                  Object {
-                    "kind": "Particle: closingDelimiter",
-                    "nodeExcerpt": "}",
-                  },
-                ],
-              },
-              Object {
-                "kind": "SoftBreak",
-                "nodeExcerpt": "[n]",
-              },
-              Object {
-                "kind": "InheritDocTag",
-                "nodes": Array [
-                  Object {
-                    "kind": "Particle: openingDelimiter",
-                    "nodeExcerpt": "{",
-                  },
-                  Object {
-                    "kind": "Particle: tagName",
-                    "nodeExcerpt": "@inheritDoc",
-                    "nodeSpacing": " ",
-                  },
-                  Object {
-                    "kind": "DeclarationReference",
-                    "nodes": Array [
-                      Object {
-                        "kind": "MemberReference",
-                        "nodes": Array [
-                          Object {
-                            "kind": "MemberIdentifier",
-                            "nodes": Array [
-                              Object {
-                                "kind": "Particle: identifier",
-                                "nodeExcerpt": "Class",
-                              },
-                            ],
-                          },
-                        ],
-                      },
-                      Object {
-                        "kind": "MemberReference",
-                        "nodes": Array [
-                          Object {
-                            "kind": "Particle: dot",
-                            "nodeExcerpt": ".",
-                          },
-                          Object {
-                            "kind": "MemberIdentifier",
-                            "nodes": Array [
-                              Object {
-                                "kind": "Particle: identifier",
-                                "nodeExcerpt": "member",
-                              },
-                            ],
-                          },
-                        ],
-                      },
-                    ],
-                  },
-                  Object {
-                    "kind": "Particle: closingDelimiter",
-                    "nodeExcerpt": "}",
-                  },
-                ],
-              },
-              Object {
-                "kind": "SoftBreak",
-                "nodeExcerpt": "[n]",
-              },
-              Object {
-                "kind": "InheritDocTag",
-                "nodes": Array [
-                  Object {
-                    "kind": "Particle: openingDelimiter",
-                    "nodeExcerpt": "{",
-                  },
-                  Object {
-                    "kind": "Particle: tagName",
-                    "nodeExcerpt": "@inheritDoc",
-                    "nodeSpacing": " ",
-                  },
-                  Object {
-                    "kind": "DeclarationReference",
-                    "nodes": Array [
-                      Object {
-                        "kind": "Particle: packageName",
-                        "nodeExcerpt": "package",
-                      },
-                      Object {
-                        "kind": "Particle: importHash",
-                        "nodeExcerpt": "#",
-                        "nodeSpacing": " ",
-                      },
-                      Object {
-                        "kind": "MemberReference",
-                        "nodes": Array [
-                          Object {
-                            "kind": "MemberIdentifier",
-                            "nodes": Array [
-                              Object {
-                                "kind": "Particle: identifier",
-                                "nodeExcerpt": "Class",
-                                "nodeSpacing": " ",
-                              },
-                            ],
-                          },
-                        ],
-                      },
-                      Object {
-                        "kind": "MemberReference",
-                        "nodes": Array [
-                          Object {
-                            "kind": "Particle: dot",
-                            "nodeExcerpt": ".",
-                            "nodeSpacing": " ",
-                          },
-                          Object {
-                            "kind": "MemberIdentifier",
-                            "nodes": Array [
-                              Object {
-                                "kind": "Particle: identifier",
-                                "nodeExcerpt": "member",
-                              },
-                            ],
-                          },
-                        ],
-                      },
-                    ],
-                  },
-                  Object {
-                    "kind": "Particle: closingDelimiter",
-                    "nodeExcerpt": "}",
-                  },
-                ],
-              },
-              Object {
                 "kind": "SoftBreak",
                 "nodeExcerpt": "[n]",
               },
             ],
+          },
+        ],
+      },
+      Object {
+        "kind": "InheritDocTag",
+        "nodes": Array [
+          Object {
+            "kind": "Particle: openingDelimiter",
+            "nodeExcerpt": "{",
+          },
+          Object {
+            "kind": "Particle: tagName",
+            "nodeExcerpt": "@inheritDoc",
+            "nodeSpacing": " ",
+          },
+          Object {
+            "kind": "DeclarationReference",
+            "nodes": Array [
+              Object {
+                "kind": "Particle: packageName",
+                "nodeExcerpt": "package",
+              },
+              Object {
+                "kind": "Particle: importHash",
+                "nodeExcerpt": "#",
+                "nodeSpacing": " ",
+              },
+              Object {
+                "kind": "MemberReference",
+                "nodes": Array [
+                  Object {
+                    "kind": "MemberIdentifier",
+                    "nodes": Array [
+                      Object {
+                        "kind": "Particle: identifier",
+                        "nodeExcerpt": "Class",
+                        "nodeSpacing": " ",
+                      },
+                    ],
+                  },
+                ],
+              },
+              Object {
+                "kind": "MemberReference",
+                "nodes": Array [
+                  Object {
+                    "kind": "Particle: dot",
+                    "nodeExcerpt": ".",
+                    "nodeSpacing": " ",
+                  },
+                  Object {
+                    "kind": "MemberIdentifier",
+                    "nodes": Array [
+                      Object {
+                        "kind": "Particle: identifier",
+                        "nodeExcerpt": "member",
+                      },
+                    ],
+                  },
+                ],
+              },
+            ],
+          },
+          Object {
+            "kind": "Particle: closingDelimiter",
+            "nodeExcerpt": "}",
           },
         ],
       },
@@ -181,14 +231,13 @@ Object {
 exports[`01 InheritDoc tag: negative examples 1`] = `
 Object {
   "buffer": "/**[n] * {@inheritDoc | link text}[n] */",
-  "gaps": Array [
-    "| link text",
-  ],
+  "gaps": Array [],
   "lines": Array [
     "{@inheritDoc | link text}",
   ],
   "logMessages": Array [
     "(2,5): Expecting a declaration reference",
+    "(2,17): Unexpected character after declaration reference",
   ],
   "nodes": Object {
     "kind": "Comment",
@@ -200,31 +249,94 @@ Object {
             "kind": "Paragraph",
             "nodes": Array [
               Object {
-                "kind": "InheritDocTag",
-                "nodes": Array [
-                  Object {
-                    "kind": "Particle: openingDelimiter",
-                    "nodeExcerpt": "{",
-                  },
-                  Object {
-                    "kind": "Particle: tagName",
-                    "nodeExcerpt": "@inheritDoc",
-                    "nodeSpacing": " ",
-                  },
-                  Object {
-                    "kind": "DeclarationReference",
-                  },
-                  Object {
-                    "kind": "Particle: closingDelimiter",
-                    "nodeExcerpt": "}",
-                  },
-                ],
+                "kind": "SoftBreak",
+                "nodeExcerpt": "[n]",
+              },
+            ],
+          },
+        ],
+      },
+      Object {
+        "kind": "InheritDocTag",
+        "nodes": Array [
+          Object {
+            "kind": "Particle: openingDelimiter",
+            "nodeExcerpt": "{",
+          },
+          Object {
+            "kind": "Particle: tagName",
+            "nodeExcerpt": "@inheritDoc",
+            "nodeSpacing": " ",
+          },
+          Object {
+            "kind": "Particle: tagContent",
+            "nodeExcerpt": "| link text",
+          },
+          Object {
+            "kind": "Particle: closingDelimiter",
+            "nodeExcerpt": "}",
+          },
+        ],
+      },
+    ],
+  },
+}
+`;
+
+exports[`01 InheritDoc tag: negative examples 2`] = `
+Object {
+  "buffer": "/**[n] * {@inheritDoc}[n] * {@inheritDoc}[n] */",
+  "gaps": Array [],
+  "lines": Array [
+    "{@inheritDoc}",
+    "{@inheritDoc}",
+  ],
+  "logMessages": Array [
+    "(3,4): A doc comment cannot have more than one @inheritDoc tag",
+  ],
+  "nodes": Object {
+    "kind": "Comment",
+    "nodes": Array [
+      Object {
+        "kind": "Section",
+        "nodes": Array [
+          Object {
+            "kind": "Paragraph",
+            "nodes": Array [
+              Object {
+                "kind": "SoftBreak",
+                "nodeExcerpt": "[n]",
+              },
+              Object {
+                "errorLocation": "{@inheritDoc}",
+                "errorLocationPrecedingToken": "
+",
+                "errorMessage": "A doc comment cannot have more than one @inheritDoc tag",
+                "kind": "ErrorText",
+                "nodeExcerpt": "{@inheritDoc}",
               },
               Object {
                 "kind": "SoftBreak",
                 "nodeExcerpt": "[n]",
               },
             ],
+          },
+        ],
+      },
+      Object {
+        "kind": "InheritDocTag",
+        "nodes": Array [
+          Object {
+            "kind": "Particle: openingDelimiter",
+            "nodeExcerpt": "{",
+          },
+          Object {
+            "kind": "Particle: tagName",
+            "nodeExcerpt": "@inheritDoc",
+          },
+          Object {
+            "kind": "Particle: closingDelimiter",
+            "nodeExcerpt": "}",
           },
         ],
       },

--- a/tsdoc/src/parser/__tests__/__snapshots__/NodeParserLinkTag.test.ts.snap
+++ b/tsdoc/src/parser/__tests__/__snapshots__/NodeParserLinkTag.test.ts.snap
@@ -1239,7 +1239,6 @@ Object {
   "logMessages": Array [
     "(2,11): An import path must not start with \\"/\\" unless prefixed by a package name",
     "(3,5): Expecting a declaration reference",
-    "(3,11): Unexpected character after link destination",
   ],
   "nodes": Object {
     "kind": "Comment",

--- a/tsdoc/src/parser/__tests__/__snapshots__/NodeParserLinkTag3.test.ts.snap
+++ b/tsdoc/src/parser/__tests__/__snapshots__/NodeParserLinkTag3.test.ts.snap
@@ -272,6 +272,7 @@ Object {
   "logMessages": Array [
     "(2,18): Missing closing square bracket for symbol reference",
     "(3,18): Expecting a declaration reference",
+    "(3,18): Missing declaration reference in symbol reference",
   ],
   "nodes": Object {
     "kind": "Comment",
@@ -321,48 +322,8 @@ Object {
                     "nodeSpacing": " ",
                   },
                   Object {
-                    "kind": "DeclarationReference",
-                    "nodes": Array [
-                      Object {
-                        "kind": "MemberReference",
-                        "nodes": Array [
-                          Object {
-                            "kind": "MemberIdentifier",
-                            "nodes": Array [
-                              Object {
-                                "kind": "Particle: identifier",
-                                "nodeExcerpt": "Class1",
-                              },
-                            ],
-                          },
-                        ],
-                      },
-                      Object {
-                        "kind": "MemberReference",
-                        "nodes": Array [
-                          Object {
-                            "kind": "Particle: dot",
-                            "nodeExcerpt": ".",
-                          },
-                          Object {
-                            "kind": "MemberSymbol",
-                            "nodes": Array [
-                              Object {
-                                "kind": "Particle: leftBracket",
-                                "nodeExcerpt": "[",
-                              },
-                              Object {
-                                "kind": "DeclarationReference",
-                              },
-                              Object {
-                                "kind": "Particle: rightBracket",
-                                "nodeExcerpt": "]",
-                              },
-                            ],
-                          },
-                        ],
-                      },
-                    ],
+                    "kind": "Particle: tagContent",
+                    "nodeExcerpt": "Class1.[]",
                   },
                   Object {
                     "kind": "Particle: closingDelimiter",


### PR DESCRIPTION
This PR adds support for `@inheritDoc` tags using the new declaration reference syntax.  Example:

```ts
export class BaseClass {
  /**
   * Comment 1
   */
  public doSomething(): void {
  }
}

/** Comment 2 */
export function unrelatedDefinition(): void {
}

export class ChildClass extends BaseClass {
  // inherits "Comment 1"
  /** @inheritDoc */
  public doSomething(): void {
  }

  // inherits "Comment 2"
  /** @inheritDoc unrelatedDefinition */
  public doSomethingElse(): void {
  }
}

```
