### PR TITLE
Implement warnings for undefined/unused tags, plus some other fixes

### DIFF
--- a/api-demo/assets/simple-input.ts
+++ b/api-demo/assets/simple-input.ts
@@ -7,7 +7,7 @@
    * This incomplete HTML tag should be reported as an error: <tag
    *
    * @privateRemarks
-   * This content should @not show up on the web site.
+   * This content should not show up on the web site.
    *
    * @param x - The first input number
    * @param y - The second input number

--- a/tsdoc/.npmignore
+++ b/tsdoc/.npmignore
@@ -9,8 +9,8 @@
 
 # Ignore certain files in the above folder
 /dist/*.stats.*
-/lib/*/test/*
-/lib/*/__tests__/*
+/lib/**/test/*
+/lib/**/__tests__/*
 
 # NOTE: These don't need to be specified, because NPM includes them automatically.
 #

--- a/tsdoc/CHANGELOG.md
+++ b/tsdoc/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Change Log - @microsoft/tsdoc
 
+## 0.8.0
+- Introduce a distinction between "defined" tags (i.e. recognized) versus "supported" tags (i.e. implemented by the tool)
+- The parser optionally reports usage of undefined tags
+- The parser optionally reports usage of unsupported tags
+- The parser reports usage of inline/block syntax that is inconsistent with the tag definition
+- Code spans are no allowed to be adjacent to other text, but must contain at least one character
+- An `@deprecated` block must contain a deprecation message
+- If `@inheritDoc` is used, then the summary section must be empty, and there must not be an `@remarks` block
+
 ## 0.7.0
 - Add support for `@defaultValue` tag
 - Add support for `@typeParam` tag

--- a/tsdoc/src/__tests__/__snapshots__/ParagraphSplitter.test.ts.snap
+++ b/tsdoc/src/__tests__/__snapshots__/ParagraphSplitter.test.ts.snap
@@ -179,9 +179,7 @@ Object {
       "nodeExcerpt": "@public",
     },
   ],
-  "_12_logMessages": Array [
-    "(4,6): The TSDoc tag \\"@public\\" is not supported by this tool",
-  ],
+  "_12_logMessages": Array [],
 }
 `;
 

--- a/tsdoc/src/__tests__/__snapshots__/ParagraphSplitter.test.ts.snap
+++ b/tsdoc/src/__tests__/__snapshots__/ParagraphSplitter.test.ts.snap
@@ -179,7 +179,9 @@ Object {
       "nodeExcerpt": "@public",
     },
   ],
-  "_12_logMessages": Array [],
+  "_12_logMessages": Array [
+    "(4,6): The TSDoc tag \\"@public\\" is not supported by this tool",
+  ],
 }
 `;
 

--- a/tsdoc/src/__tests__/__snapshots__/ParsingBasics.test.ts.snap
+++ b/tsdoc/src/__tests__/__snapshots__/ParsingBasics.test.ts.snap
@@ -66,7 +66,12 @@ Object {
       "nodeExcerpt": "@internal",
     },
   ],
-  "_12_logMessages": Array [],
+  "_12_logMessages": Array [
+    "(2,10): The TSDoc tag \\"@beta\\" is not supported by this tool",
+    "(3,4): The TSDoc tag \\"@unknownTag\\" is not defined in this configuration",
+    "(4,4): The TSDoc tag \\"@internal\\" is not supported by this tool",
+    "(4,14): The TSDoc tag \\"@internal\\" is not supported by this tool",
+  ],
 }
 `;
 
@@ -388,7 +393,12 @@ Object {
       "nodeExcerpt": "@customModifier",
     },
   ],
-  "_12_logMessages": Array [],
+  "_12_logMessages": Array [
+    "(7,4): The TSDoc tag \\"@customBlock\\" is not supported by this tool",
+    "(8,41): The TSDoc tag \\"@undefinedBlockTag\\" is not defined in this configuration",
+    "(14,4): The TSDoc tag \\"@beta\\" is not supported by this tool",
+    "(14,10): The TSDoc tag \\"@customModifier\\" is not supported by this tool",
+  ],
 }
 `;
 
@@ -823,7 +833,12 @@ Object {
       "nodeExcerpt": "@customModifier",
     },
   ],
-  "_12_logMessages": Array [],
+  "_12_logMessages": Array [
+    "(4,4): The TSDoc tag \\"@beta\\" is not supported by this tool",
+    "(4,10): The TSDoc tag \\"@customModifier\\" is not supported by this tool",
+    "(7,4): The TSDoc tag \\"@customBlock\\" is not supported by this tool",
+    "(8,41): The TSDoc tag \\"@undefinedBlockTag\\" is not defined in this configuration",
+  ],
 }
 `;
 

--- a/tsdoc/src/__tests__/__snapshots__/ParsingBasics.test.ts.snap
+++ b/tsdoc/src/__tests__/__snapshots__/ParsingBasics.test.ts.snap
@@ -67,10 +67,7 @@ Object {
     },
   ],
   "_12_logMessages": Array [
-    "(2,10): The TSDoc tag \\"@beta\\" is not supported by this tool",
     "(3,4): The TSDoc tag \\"@unknownTag\\" is not defined in this configuration",
-    "(4,4): The TSDoc tag \\"@internal\\" is not supported by this tool",
-    "(4,14): The TSDoc tag \\"@internal\\" is not supported by this tool",
   ],
 }
 `;
@@ -394,10 +391,7 @@ Object {
     },
   ],
   "_12_logMessages": Array [
-    "(7,4): The TSDoc tag \\"@customBlock\\" is not supported by this tool",
     "(8,41): The TSDoc tag \\"@undefinedBlockTag\\" is not defined in this configuration",
-    "(14,4): The TSDoc tag \\"@beta\\" is not supported by this tool",
-    "(14,10): The TSDoc tag \\"@customModifier\\" is not supported by this tool",
   ],
 }
 `;
@@ -834,9 +828,6 @@ Object {
     },
   ],
   "_12_logMessages": Array [
-    "(4,4): The TSDoc tag \\"@beta\\" is not supported by this tool",
-    "(4,10): The TSDoc tag \\"@customModifier\\" is not supported by this tool",
-    "(7,4): The TSDoc tag \\"@customBlock\\" is not supported by this tool",
     "(8,41): The TSDoc tag \\"@undefinedBlockTag\\" is not defined in this configuration",
   ],
 }

--- a/tsdoc/src/details/StandardTags.ts
+++ b/tsdoc/src/details/StandardTags.ts
@@ -58,7 +58,7 @@ export class StandardTags {
   });
 
   /**
-   * (Core)
+   * (Extended)
    *
    * This block tag is used to document the default value for a field or property,
    * if a value is not assigned explicitly.

--- a/tsdoc/src/index.ts
+++ b/tsdoc/src/index.ts
@@ -14,7 +14,7 @@ export { TextRange, ITextLocation } from './parser/TextRange';
 export { Token, TokenKind } from './parser/Token';
 export { TokenSequence, ITokenSequenceParameters } from './parser/TokenSequence';
 export { TSDocParser } from './parser/TSDocParser';
-export { TSDocParserConfiguration } from './parser/TSDocParserConfiguration';
+export { TSDocParserConfiguration, TSDocParserValidationConfiguration } from './parser/TSDocParserConfiguration';
 export {
   ITSDocTagDefinitionParameters,
   TSDocTagSyntaxKind,

--- a/tsdoc/src/parser/NodeParser.ts
+++ b/tsdoc/src/parser/NodeParser.ts
@@ -209,7 +209,7 @@ export class NodeParser {
             tokenSequenceForErrorContext, nodeForErrorContext);
         }
       } else {
-        if (!this._parserContext.configuration.validation.ignoreUnsupportedTags) {
+        if (this._parserContext.configuration.validation.reportUnsupportedTags) {
           if (!this._parserContext.configuration.isTagSupported(tagDefinition)) {
             // The tag is defined, but not supported
             this._parserContext.log.addMessageForTokenSequence(

--- a/tsdoc/src/parser/NodeParser.ts
+++ b/tsdoc/src/parser/NodeParser.ts
@@ -173,12 +173,26 @@ export class NodeParser {
         );
       }
     }
+
+    if (docComment.inheritDocTag) {
+      if (docComment.remarksBlock) {
+        this._parserContext.log.addMessageForTokenSequence(
+          `A "${docComment.remarksBlock.blockTag.tagName}" block must not be used, because that`
+          + ` content is provided by the @inheritDoc tag`,
+          docComment.remarksBlock.blockTag.excerpt!.content, docComment.remarksBlock.blockTag);
+      }
+      if (PlainTextRenderer.hasAnyTextContent(docComment.summarySection)) {
+        this._parserContext.log.addMessageForTextRange(
+          'The summary section must not have any content, because that'
+          + ' content is provided by the @inheritDoc tag',
+          this._parserContext.commentRange);
+      }
+    }
   }
 
   private _validateTagDefinition(tagDefinition: TSDocTagDefinition | undefined,
     tagName: string, expectingInlineTag: boolean,
     tokenSequenceForErrorContext: TokenSequence, nodeForErrorContext: DocNode): void {
-
 
     if (tagDefinition) {
       const isInlineTag: boolean = tagDefinition.syntaxKind === TSDocTagSyntaxKind.InlineTag;

--- a/tsdoc/src/parser/NodeParser.ts
+++ b/tsdoc/src/parser/NodeParser.ts
@@ -42,6 +42,7 @@ import {
   TSDocTagSyntaxKind
 } from './TSDocTagDefinition';
 import { StandardTags } from '../details/StandardTags';
+import { PlainTextRenderer } from '../renderers/PlainTextRenderer';
 
 interface IFailure {
   // (We use "failureMessage" instead of "errorMessage" here so that DocErrorText doesn't
@@ -157,6 +158,21 @@ export class NodeParser {
       }
     }
     this._pushAccumulatedPlainText(tokenReader);
+    this._performValidationChecks();
+  }
+
+  private _performValidationChecks(): void {
+    const docComment: DocComment = this._parserContext.docComment;
+    if (docComment.deprecatedBlock) {
+      if (!PlainTextRenderer.hasAnyTextContent(docComment.deprecatedBlock)) {
+        this._parserContext.log.addMessageForTokenSequence(
+          `The ${docComment.deprecatedBlock.blockTag.tagName} block must include a deprecation message,`
+            + ` e.g. describing the recommended alternative`,
+          docComment.deprecatedBlock.blockTag.excerpt!.content,
+          docComment.deprecatedBlock
+        );
+      }
+    }
   }
 
   private _pushAccumulatedPlainText(tokenReader: TokenReader): void {

--- a/tsdoc/src/parser/TSDocParserConfiguration.ts
+++ b/tsdoc/src/parser/TSDocParserConfiguration.ts
@@ -1,30 +1,41 @@
 import { StandardTags } from '../details/StandardTags';
 import { TSDocTagDefinition } from './TSDocTagDefinition';
-import { Standardization } from '../details/Standardization';
 
 /**
  * Part of the {@link TSDocParserConfiguration} object.
  */
 export class TSDocParserValidationConfiguration {
   /**
+   * Set `ignoreUndefinedTags` to true to silently ignore unrecognized tags,
+   * instead of reporting a warning.
+   *
+   * @remarks
    * Normally the parser will issue errors when it encounters tag names that do not
    * have a corresponding definition in {@link TSDocParserConfiguration.tagDefinitions}.
-   *
-   * Set this to true to silently ignore such tags.
+   * This helps to catch common mistakes such as a misspelled tag.
    *
    * @defaultValue `false`
    */
   public ignoreUndefinedTags: boolean = false;
 
   /**
-   * Normally the parser will issue errors when it encounters tag names that are not
-   * listed in {@link TSDocParserConfiguration.supportedTagDefinitions}.
+   * Set `reportUnsupportedTags` to true to issue a warning for tags that are not
+   * supported by your tool.
    *
-   * Set this to true to silently ignore such tags.
+   * @remarks
+   * The TSDoc standard defines may tags.  By default it assumes that if your tool does
+   * not implement one of these tags, then it will simply ignore it.  But sometimes this
+   * may be misleading for developers. (For example, they might write an `@example` block
+   * and then be surprised if it doesn't appear in the documentation output.).
+   *
+   * For a better experience, you can tell the parser which tags you support, and then it
+   * will issue warnings wherever unsupported tags are used.  This is done using
+   * {@link TSDocParserConfiguration.setSupportForTag}.  Note that calling that function
+   * automatically sets `reportUnsupportedTags` to true.
    *
    * @defaultValue `false`
    */
-  public ignoreUnsupportedTags: boolean = false;
+  public reportUnsupportedTags: boolean = false;
 }
 
 /**
@@ -44,11 +55,6 @@ export class TSDocParserConfiguration {
 
     // Define all the standard tags
     this.addTagDefinitions(StandardTags.allDefinitions);
-
-    // But conservatively assume that the application only supports the core tags
-    this.setSupportForTags(StandardTags.allDefinitions.filter(
-      x => x.standardization === Standardization.Core
-    ), true);
   }
 
   /**
@@ -61,6 +67,10 @@ export class TSDocParserConfiguration {
   /**
    * Returns the subset of {@link TSDocParserConfiguration.tagDefinitions}
    * that are supported in this configuration.
+   *
+   * @remarks
+   * This property is only used when
+   * {@link TSDocParserValidationConfiguration.reportUnsupportedTags} is enabled.
    */
   public get supportedTagDefinitions(): ReadonlyArray<TSDocTagDefinition> {
     return this.tagDefinitions.filter(x => this.isTagSupported(x));
@@ -147,6 +157,9 @@ export class TSDocParserConfiguration {
    * @remarks
    * If a tag is "defined" this means that the parser recognizes it and understands its syntax.
    * Whereas if a tag is "supported", this means it is defined AND the application implements the tag.
+   *
+   * This function automatically sets {@link TSDocParserValidationConfiguration.reportUnsupportedTags}
+   * to true.
    */
   public setSupportForTag(tagDefinition: TSDocTagDefinition, supported: boolean): void {
     this._requireTagToBeDefined(tagDefinition);
@@ -155,8 +168,13 @@ export class TSDocParserConfiguration {
     } else {
       this._supportedTagDefinitions.delete(tagDefinition);
     }
+
+    this.validation.reportUnsupportedTags = true;
   }
 
+  /**
+   * Calls {@link TSDocParserConfiguration.setSupportForTag} for multiple tag definitions.
+   */
   public setSupportForTags(tagDefinitions: ReadonlyArray<TSDocTagDefinition>, supported: boolean): void {
     for (const tagDefinition of tagDefinitions) {
       this.setSupportForTag(tagDefinition, supported);

--- a/tsdoc/src/parser/TSDocParserConfiguration.ts
+++ b/tsdoc/src/parser/TSDocParserConfiguration.ts
@@ -113,9 +113,22 @@ export class TSDocParserConfiguration {
     this._tagDefinitionsByName.set(tagDefinition.tagNameWithUpperCase, tagDefinition);
   }
 
-  public addTagDefinitions(tagDefinitions: ReadonlyArray<TSDocTagDefinition>): void {
+  /**
+   * Calls {@link TSDocParserConfiguration.addTagDefinition} for a list of definitions,
+   * and optionally marks them as supported.
+   * @param tagDefinitions - the definitions to be added
+   * @param supported - if specified, calls the {@link TSDocParserConfiguration.setSupportForTag}
+   *    method to mark the definitions as supported or unsupported
+   */
+  public addTagDefinitions(tagDefinitions: ReadonlyArray<TSDocTagDefinition>,
+    supported?: boolean | undefined): void {
+
     for (const tagDefinition of tagDefinitions) {
       this.addTagDefinition(tagDefinition);
+
+      if (supported !== undefined) {
+        this.setSupportForTag(tagDefinition, supported);
+      }
     }
   }
 

--- a/tsdoc/src/parser/TSDocParserConfiguration.ts
+++ b/tsdoc/src/parser/TSDocParserConfiguration.ts
@@ -1,18 +1,54 @@
 import { StandardTags } from '../details/StandardTags';
 import { TSDocTagDefinition } from './TSDocTagDefinition';
+import { Standardization } from '../details/Standardization';
+
+/**
+ * Part of the {@link TSDocParserConfiguration} object.
+ */
+export class TSDocParserValidationConfiguration {
+  /**
+   * Normally the parser will issue errors when it encounters tag names that do not
+   * have a corresponding definition in {@link TSDocParserConfiguration.tagDefinitions}.
+   *
+   * Set this to true to silently ignore such tags.
+   *
+   * @defaultValue `false`
+   */
+  public ignoreUndefinedTags: boolean = false;
+
+  /**
+   * Normally the parser will issue errors when it encounters tag names that are not
+   * listed in {@link TSDocParserConfiguration.supportedTagDefinitions}.
+   *
+   * Set this to true to silently ignore such tags.
+   *
+   * @defaultValue `false`
+   */
+  public ignoreUnsupportedTags: boolean = false;
+}
 
 /**
  * Configuration for the TSDocParser.
  */
 export class TSDocParserConfiguration {
-  private _tagDefinitions: TSDocTagDefinition[];
-  private _tagDefinitionsByName: Map<string, TSDocTagDefinition>;
+  private readonly _tagDefinitions: TSDocTagDefinition[];
+  private readonly _tagDefinitionsByName: Map<string, TSDocTagDefinition>;
+  private readonly _supportedTagDefinitions: Set<TSDocTagDefinition>;
+  private readonly _validation: TSDocParserValidationConfiguration;
 
   public constructor() {
     this._tagDefinitions = [];
     this._tagDefinitionsByName = new Map<string, TSDocTagDefinition>();
+    this._supportedTagDefinitions = new Set<TSDocTagDefinition>();
+    this._validation = new TSDocParserValidationConfiguration();
 
+    // Define all the standard tags
     this.addTagDefinitions(StandardTags.allDefinitions);
+
+    // But conservatively assume that the application only supports the core tags
+    this.setSupportForTags(StandardTags.allDefinitions.filter(
+      x => x.standardization === Standardization.Core
+    ), true);
   }
 
   /**
@@ -20,6 +56,21 @@ export class TSDocParserConfiguration {
    */
   public get tagDefinitions(): ReadonlyArray<TSDocTagDefinition> {
     return this._tagDefinitions;
+  }
+
+  /**
+   * Returns the subset of {@link TSDocParserConfiguration.tagDefinitions}
+   * that are supported in this configuration.
+   */
+  public get supportedTagDefinitions(): ReadonlyArray<TSDocTagDefinition> {
+    return this.tagDefinitions.filter(x => this.isTagSupported(x));
+  }
+
+  /**
+   * Enable/disable validation checks performed by the parser.
+   */
+  public get validation(): TSDocParserValidationConfiguration {
+    return this._validation;
   }
 
   /**
@@ -39,11 +90,20 @@ export class TSDocParserConfiguration {
   }
 
   /**
-   * Define a new TSDoc tag to be recognized by the TSDocParser.
+   * Define a new TSDoc tag to be recognized by the TSDocParser, and mark it as unsupported.
+   * Use {@link TSDocParserConfiguration.setSupportForTag} to mark it as supported.
+   *
+   * @remarks
+   * If a tag is "defined" this means that the parser recognizes it and understands its syntax.
+   * Whereas if a tag is "supported", this means it is defined AND the application implements the tag.
    */
   public addTagDefinition(tagDefinition: TSDocTagDefinition): void {
     const existingDefinition: TSDocTagDefinition | undefined
       = this._tagDefinitionsByName.get(tagDefinition.tagNameWithUpperCase);
+
+    if (existingDefinition === tagDefinition) {
+      return;
+    }
 
     if (existingDefinition) {
       throw new Error(`A tag is already defined using the name ${existingDefinition.tagName}`);
@@ -57,5 +117,47 @@ export class TSDocParserConfiguration {
     for (const tagDefinition of tagDefinitions) {
       this.addTagDefinition(tagDefinition);
     }
+  }
+
+  /**
+   * Returns true if the tag is supported in this configuration.
+   */
+  public isTagSupported(tagDefinition: TSDocTagDefinition): boolean {
+    this._requireTagToBeDefined(tagDefinition);
+    return this._supportedTagDefinitions.has(tagDefinition);
+  }
+
+  /**
+   * Specifies whether the tag definition is supported in this configuration.
+   * The parser may issue warnings for unsupported tags.
+   *
+   * @remarks
+   * If a tag is "defined" this means that the parser recognizes it and understands its syntax.
+   * Whereas if a tag is "supported", this means it is defined AND the application implements the tag.
+   */
+  public setSupportForTag(tagDefinition: TSDocTagDefinition, supported: boolean): void {
+    this._requireTagToBeDefined(tagDefinition);
+    if (supported) {
+      this._supportedTagDefinitions.add(tagDefinition);
+    } else {
+      this._supportedTagDefinitions.delete(tagDefinition);
+    }
+  }
+
+  public setSupportForTags(tagDefinitions: ReadonlyArray<TSDocTagDefinition>, supported: boolean): void {
+    for (const tagDefinition of tagDefinitions) {
+      this.setSupportForTag(tagDefinition, supported);
+    }
+  }
+
+  private _requireTagToBeDefined(tagDefinition: TSDocTagDefinition): void {
+    const matching: TSDocTagDefinition | undefined
+      = this._tagDefinitionsByName.get(tagDefinition.tagNameWithUpperCase);
+    if (matching) {
+      if (matching === tagDefinition) {
+        return;
+      }
+    }
+    throw new Error('The specified TSDocTagDefinition is not defined for this TSDocParserConfiguration');
   }
 }

--- a/tsdoc/src/parser/__tests__/NodeParserCode.test.ts
+++ b/tsdoc/src/parser/__tests__/NodeParserCode.test.ts
@@ -7,6 +7,11 @@ test('00 Code span basic, positive', () => {
     ' * line ` 2` sdf',
     ' */'
   ].join('\n'));
+  TestHelpers.parseAndMatchNodeParserSnapshot([
+    '/**',
+    ' * M`&`M',
+    ' */'
+  ].join('\n'));
 });
 
 test('01 Code span basic, negative', () => {
@@ -18,8 +23,7 @@ test('01 Code span basic, negative', () => {
   ].join('\n'));
   TestHelpers.parseAndMatchNodeParserSnapshot([
     '/**',
-    ' * one`two',
-    ' * `three`four',
+    ' * ``',
     ' */'
   ].join('\n'));
 });

--- a/tsdoc/src/parser/__tests__/NodeParserInheritDocTag.test.ts
+++ b/tsdoc/src/parser/__tests__/NodeParserInheritDocTag.test.ts
@@ -35,4 +35,11 @@ test('01 InheritDoc tag: negative examples', () => {
     ' * {@inheritDoc}',
     ' */'
   ].join('\n'));
+  TestHelpers.parseAndMatchNodeParserSnapshot([
+    '/**',
+    ' * summary text',
+    ' * @remarks',
+    ' * {@inheritDoc}',
+    ' */'
+  ].join('\n'));
 });

--- a/tsdoc/src/parser/__tests__/NodeParserValidationChecks.test.ts
+++ b/tsdoc/src/parser/__tests__/NodeParserValidationChecks.test.ts
@@ -1,0 +1,20 @@
+import { TestHelpers } from './TestHelpers';
+
+test('00 Deprecated block: positive test', () => {
+  TestHelpers.parseAndMatchNodeParserSnapshot([
+    '/**',
+    ' * @deprecated',
+    ' * Use the other thing',
+    ' */'
+  ].join('\n'));
+});
+
+test('01 Deprecated block: negative test', () => {
+  TestHelpers.parseAndMatchNodeParserSnapshot([
+    '/**',
+    ' * @deprecated',
+    ' * ',
+    ' * @public',
+    ' */'
+  ].join('\n'));
+});

--- a/tsdoc/src/parser/__tests__/TestHelpers.ts
+++ b/tsdoc/src/parser/__tests__/TestHelpers.ts
@@ -92,7 +92,6 @@ export class TestHelpers {
 
     // For the parser tests, we use lots of custom tags without bothering to define them
     configuration.validation.ignoreUndefinedTags = true;
-    configuration.validation.ignoreUnsupportedTags = true;
 
     const tsdocParser: TSDocParser = new TSDocParser(configuration);
     const parserContext: ParserContext = tsdocParser.parseString(buffer);

--- a/tsdoc/src/parser/__tests__/TestHelpers.ts
+++ b/tsdoc/src/parser/__tests__/TestHelpers.ts
@@ -88,7 +88,13 @@ export class TestHelpers {
    * Main harness for tests under `./parser/*`.
    */
   public static parseAndMatchNodeParserSnapshot(buffer: string): void {
-    const tsdocParser: TSDocParser = new TSDocParser();
+    const configuration: TSDocParserConfiguration = new TSDocParserConfiguration();
+
+    // For the parser tests, we use lots of custom tags without bothering to define them
+    configuration.validation.ignoreUndefinedTags = true;
+    configuration.validation.ignoreUnsupportedTags = true;
+
+    const tsdocParser: TSDocParser = new TSDocParser(configuration);
     const parserContext: ParserContext = tsdocParser.parseString(buffer);
 
     expect({

--- a/tsdoc/src/parser/__tests__/__snapshots__/NodeParserCode.test.ts.snap
+++ b/tsdoc/src/parser/__tests__/__snapshots__/NodeParserCode.test.ts.snap
@@ -81,6 +81,61 @@ Object {
 }
 `;
 
+exports[`00 Code span basic, positive 2`] = `
+Object {
+  "buffer": "/**[n] * M[c]&[c]M[n] */",
+  "gaps": Array [],
+  "lines": Array [
+    "M[c]&[c]M",
+  ],
+  "logMessages": Array [],
+  "nodes": Object {
+    "kind": "Comment",
+    "nodes": Array [
+      Object {
+        "kind": "Section",
+        "nodes": Array [
+          Object {
+            "kind": "Paragraph",
+            "nodes": Array [
+              Object {
+                "kind": "PlainText",
+                "nodeExcerpt": "M",
+              },
+              Object {
+                "kind": "CodeSpan",
+                "nodes": Array [
+                  Object {
+                    "kind": "Particle: openingDelimiter",
+                    "nodeExcerpt": "[c]",
+                  },
+                  Object {
+                    "kind": "Particle: code",
+                    "nodeExcerpt": "&",
+                  },
+                  Object {
+                    "kind": "Particle: closingDelimiter",
+                    "nodeExcerpt": "[c]",
+                  },
+                ],
+              },
+              Object {
+                "kind": "PlainText",
+                "nodeExcerpt": "M",
+              },
+              Object {
+                "kind": "SoftBreak",
+                "nodeExcerpt": "[n]",
+              },
+            ],
+          },
+        ],
+      },
+    ],
+  },
+}
+`;
+
 exports[`01 Code span basic, negative 1`] = `
 Object {
   "buffer": "/**[n] * [c]multi[n] * line[c][n] */",
@@ -91,7 +146,7 @@ Object {
   ],
   "logMessages": Array [
     "(2,4): The code span is missing its closing backtick",
-    "(3,8): The opening backtick for a code span must be preceded by whitespace",
+    "(3,8): The code span is missing its closing backtick",
   ],
   "nodes": Object {
     "kind": "Comment",
@@ -123,7 +178,7 @@ Object {
               Object {
                 "errorLocation": "[c]",
                 "errorLocationPrecedingToken": "line",
-                "errorMessage": "The opening backtick for a code span must be preceded by whitespace",
+                "errorMessage": "The code span is missing its closing backtick",
                 "kind": "ErrorText",
                 "nodeExcerpt": "[c]",
               },
@@ -142,16 +197,13 @@ Object {
 
 exports[`01 Code span basic, negative 2`] = `
 Object {
-  "buffer": "/**[n] * one[c]two[n] * [c]three[c]four[n] */",
+  "buffer": "/**[n] * [c][c][n] */",
   "gaps": Array [],
   "lines": Array [
-    "one[c]two",
-    "[c]three[c]four",
+    "[c][c]",
   ],
   "logMessages": Array [
-    "(2,7): The opening backtick for a code span must be preceded by whitespace",
-    "(3,4): Error parsing code span: The closing backtick for a code span must be followed by whitespace",
-    "(3,10): The opening backtick for a code span must be preceded by whitespace",
+    "(2,4): A code span must contain at least one character between the backticks",
   ],
   "nodes": Object {
     "kind": "Comment",
@@ -163,45 +215,10 @@ Object {
             "kind": "Paragraph",
             "nodes": Array [
               Object {
-                "kind": "PlainText",
-                "nodeExcerpt": "one",
-              },
-              Object {
-                "errorLocation": "[c]",
-                "errorLocationPrecedingToken": "one",
-                "errorMessage": "The opening backtick for a code span must be preceded by whitespace",
+                "errorLocation": "[c][c]",
+                "errorMessage": "A code span must contain at least one character between the backticks",
                 "kind": "ErrorText",
-                "nodeExcerpt": "[c]",
-              },
-              Object {
-                "kind": "PlainText",
-                "nodeExcerpt": "two",
-              },
-              Object {
-                "kind": "SoftBreak",
-                "nodeExcerpt": "[n]",
-              },
-              Object {
-                "errorLocation": "[c]",
-                "errorLocationPrecedingToken": "three",
-                "errorMessage": "Error parsing code span: The closing backtick for a code span must be followed by whitespace",
-                "kind": "ErrorText",
-                "nodeExcerpt": "[c]",
-              },
-              Object {
-                "kind": "PlainText",
-                "nodeExcerpt": "three",
-              },
-              Object {
-                "errorLocation": "[c]",
-                "errorLocationPrecedingToken": "three",
-                "errorMessage": "The opening backtick for a code span must be preceded by whitespace",
-                "kind": "ErrorText",
-                "nodeExcerpt": "[c]",
-              },
-              Object {
-                "kind": "PlainText",
-                "nodeExcerpt": "four",
+                "nodeExcerpt": "[c][c]",
               },
               Object {
                 "kind": "SoftBreak",

--- a/tsdoc/src/parser/__tests__/__snapshots__/NodeParserInheritDocTag.test.ts.snap
+++ b/tsdoc/src/parser/__tests__/__snapshots__/NodeParserInheritDocTag.test.ts.snap
@@ -397,3 +397,81 @@ Object {
   },
 }
 `;
+
+exports[`01 InheritDoc tag: negative examples 4`] = `
+Object {
+  "buffer": "/**[n] * summary text[n] * @remarks[n] * {@inheritDoc}[n] */",
+  "gaps": Array [],
+  "lines": Array [
+    "summary text",
+    "@remarks",
+    "{@inheritDoc}",
+  ],
+  "logMessages": Array [
+    "(3,4): A \\"@remarks\\" block must not be used, because that content is provided by the @inheritDoc tag",
+    "(1,1): The summary section must not have any content, because that content is provided by the @inheritDoc tag",
+  ],
+  "nodes": Object {
+    "kind": "Comment",
+    "nodes": Array [
+      Object {
+        "kind": "Section",
+        "nodes": Array [
+          Object {
+            "kind": "Paragraph",
+            "nodes": Array [
+              Object {
+                "kind": "PlainText",
+                "nodeExcerpt": "summary text",
+              },
+              Object {
+                "kind": "SoftBreak",
+                "nodeExcerpt": "[n]",
+              },
+            ],
+          },
+        ],
+      },
+      Object {
+        "kind": "Block",
+        "nodes": Array [
+          Object {
+            "kind": "BlockTag",
+            "nodeExcerpt": "@remarks",
+          },
+          Object {
+            "kind": "Paragraph",
+            "nodes": Array [
+              Object {
+                "kind": "SoftBreak",
+                "nodeExcerpt": "[n]",
+              },
+              Object {
+                "kind": "SoftBreak",
+                "nodeExcerpt": "[n]",
+              },
+            ],
+          },
+        ],
+      },
+      Object {
+        "kind": "InheritDocTag",
+        "nodes": Array [
+          Object {
+            "kind": "Particle: openingDelimiter",
+            "nodeExcerpt": "{",
+          },
+          Object {
+            "kind": "Particle: tagName",
+            "nodeExcerpt": "@inheritDoc",
+          },
+          Object {
+            "kind": "Particle: closingDelimiter",
+            "nodeExcerpt": "}",
+          },
+        ],
+      },
+    ],
+  },
+}
+`;

--- a/tsdoc/src/parser/__tests__/__snapshots__/NodeParserValidationChecks.test.ts.snap
+++ b/tsdoc/src/parser/__tests__/__snapshots__/NodeParserValidationChecks.test.ts.snap
@@ -1,0 +1,100 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`00 Deprecated block: positive test 1`] = `
+Object {
+  "buffer": "/**[n] * @deprecated[n] * Use the other thing[n] */",
+  "gaps": Array [],
+  "lines": Array [
+    "@deprecated",
+    "Use the other thing",
+  ],
+  "logMessages": Array [],
+  "nodes": Object {
+    "kind": "Comment",
+    "nodes": Array [
+      Object {
+        "kind": "Section",
+      },
+      Object {
+        "kind": "Block",
+        "nodes": Array [
+          Object {
+            "kind": "BlockTag",
+            "nodeExcerpt": "@deprecated",
+          },
+          Object {
+            "kind": "Paragraph",
+            "nodes": Array [
+              Object {
+                "kind": "SoftBreak",
+                "nodeExcerpt": "[n]",
+              },
+              Object {
+                "kind": "PlainText",
+                "nodeExcerpt": "Use the other thing",
+              },
+              Object {
+                "kind": "SoftBreak",
+                "nodeExcerpt": "[n]",
+              },
+            ],
+          },
+        ],
+      },
+    ],
+  },
+}
+`;
+
+exports[`01 Deprecated block: negative test 1`] = `
+Object {
+  "buffer": "/**[n] * @deprecated[n] * [n] * @public[n] */",
+  "gaps": Array [],
+  "lines": Array [
+    "@deprecated",
+    "",
+    "@public",
+  ],
+  "logMessages": Array [
+    "(2,4): The @deprecated block must include a deprecation message, e.g. describing the recommended alternative",
+  ],
+  "nodes": Object {
+    "kind": "Comment",
+    "nodes": Array [
+      Object {
+        "kind": "Section",
+      },
+      Object {
+        "kind": "Block",
+        "nodes": Array [
+          Object {
+            "kind": "BlockTag",
+            "nodeExcerpt": "@deprecated",
+          },
+          Object {
+            "kind": "Paragraph",
+            "nodes": Array [
+              Object {
+                "kind": "SoftBreak",
+                "nodeExcerpt": "[n]",
+              },
+              Object {
+                "kind": "SoftBreak",
+                "nodeExcerpt": "[n]",
+              },
+              Object {
+                "kind": "SoftBreak",
+                "nodeExcerpt": "[n]",
+              },
+            ],
+          },
+        ],
+      },
+      Object {
+        "kind": "BlockTag",
+        "nodeExcerpt": "@public",
+      },
+    ],
+  },
+}
+`;

--- a/tsdoc/src/renderers/PlainTextRenderer.ts
+++ b/tsdoc/src/renderers/PlainTextRenderer.ts
@@ -1,0 +1,45 @@
+import { DocNode, DocNodeKind, DocNodeContainer, DocPlainText } from '../nodes';
+
+/**
+ * Renders a DocNode tree as plain text, without any rich text formatting or markup.
+ */
+export class PlainTextRenderer {
+
+  /**
+   * Returns true if the specified collection of nodes contains any text content.
+   */
+  public static hasAnyTextContent(node: DocNode): boolean;
+  public static hasAnyTextContent(nodes: ReadonlyArray<DocNode>): boolean;
+  public static hasAnyTextContent(nodeOrNodes: DocNode | ReadonlyArray<DocNode>): boolean {
+    if (nodeOrNodes instanceof DocNode) {
+      nodeOrNodes = [nodeOrNodes];
+    }
+
+    for (const node of nodeOrNodes) {
+      switch (node.kind) {
+        case DocNodeKind.CodeFence:
+        case DocNodeKind.CodeSpan:
+        case DocNodeKind.EscapedText:
+        case DocNodeKind.LinkTag:
+          return true;
+        case DocNodeKind.PlainText:
+          const docPlainText: DocPlainText = node as DocPlainText;
+          // Is there at least one non-spacing character?
+          if (docPlainText.text.trim().length > 0) {
+            return true;
+          }
+          break;
+      }
+
+      if (node instanceof DocNodeContainer) {
+        for (const childNode of node.getChildNodes()) {
+          if (this.hasAnyTextContent(childNode)) {
+            return true;
+          }
+        }
+      }
+    }
+
+    return false;
+  }
+}


### PR DESCRIPTION
This PR introduces a new configuration options `TSDocParserConfiguration.validation.ignoreUndefinedTags` and `ignoreUnsupportedTags`.

It also includes some other miscellaneous fixes:
- `@deprecated` blocks must now contain a deprecation message
- code spans can now be adjacent to other text
- code spans must not be empty
- When using `@inheritDoc`, the summary and remarks sections must not be present