### PR TITLE
Improve error reporting for declaration references that are probably missing a `"#"` delimiter

### DIFF
--- a/tsdoc/CHANGELOG.md
+++ b/tsdoc/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Change Log - @microsoft/tsdoc
 
-## (next release)
+## 0.8.1
+- Improve error reporting for declaration references that are probably missing a `"#"` delimiter
 - Rename `DocCodeFence` to `DocFencedCode`
 
 ## 0.8.0

--- a/tsdoc/src/parser/__tests__/NodeParserInheritDocTag.test.ts
+++ b/tsdoc/src/parser/__tests__/NodeParserInheritDocTag.test.ts
@@ -42,4 +42,11 @@ test('01 InheritDoc tag: negative examples', () => {
     ' * {@inheritDoc}',
     ' */'
   ].join('\n'));
+
+  // Old API Extractor syntax
+  TestHelpers.parseAndMatchNodeParserSnapshot([
+    '/**',
+    ' * {@inheritdoc @scope/library:IDisposable.isDisposed}',
+    ' */'
+  ].join('\n'));
 });

--- a/tsdoc/src/parser/__tests__/__snapshots__/NodeParserInheritDocTag.test.ts.snap
+++ b/tsdoc/src/parser/__tests__/__snapshots__/NodeParserInheritDocTag.test.ts.snap
@@ -475,3 +475,57 @@ Object {
   },
 }
 `;
+
+exports[`01 InheritDoc tag: negative examples 5`] = `
+Object {
+  "buffer": "/**[n] * {@inheritdoc @scope/library:IDisposable.isDisposed}[n] */",
+  "gaps": Array [],
+  "lines": Array [
+    "{@inheritdoc @scope/library:IDisposable.isDisposed}",
+  ],
+  "logMessages": Array [
+    "(2,17): The declaration reference appears to contain a package name or import path, but it is missing the \\"#\\" delimiter",
+  ],
+  "nodes": Object {
+    "kind": "Comment",
+    "nodes": Array [
+      Object {
+        "kind": "Section",
+        "nodes": Array [
+          Object {
+            "kind": "Paragraph",
+            "nodes": Array [
+              Object {
+                "kind": "SoftBreak",
+                "nodeExcerpt": "[n]",
+              },
+            ],
+          },
+        ],
+      },
+      Object {
+        "kind": "InheritDocTag",
+        "nodes": Array [
+          Object {
+            "kind": "Particle: openingDelimiter",
+            "nodeExcerpt": "{",
+          },
+          Object {
+            "kind": "Particle: tagName",
+            "nodeExcerpt": "@inheritdoc",
+            "nodeSpacing": " ",
+          },
+          Object {
+            "kind": "Particle: tagContent",
+            "nodeExcerpt": "@scope/library:IDisposable.isDisposed",
+          },
+          Object {
+            "kind": "Particle: closingDelimiter",
+            "nodeExcerpt": "}",
+          },
+        ],
+      },
+    ],
+  },
+}
+`;

--- a/tsdoc/src/parser/__tests__/__snapshots__/NodeParserLinkTag.test.ts.snap
+++ b/tsdoc/src/parser/__tests__/__snapshots__/NodeParserLinkTag.test.ts.snap
@@ -1238,7 +1238,7 @@ Object {
   ],
   "logMessages": Array [
     "(2,11): An import path must not start with \\"/\\" unless prefixed by a package name",
-    "(3,5): Expecting a declaration reference",
+    "(3,11): The declaration reference appears to contain a package name or import path, but it is missing the \\"#\\" delimiter",
   ],
   "nodes": Object {
     "kind": "Comment",


### PR DESCRIPTION
If someone writes something like this:

```ts
// A path to a module
/** WRONG: {@link ./library/IDisposable} */
/** RIGHT: {@link ./library/IDisposable#} */

// Old AEDoc notation with ":"
/** WRONG: {@link @scope/library:IDisposable.isDisposed} */
/** RIGHT: {@link @scope/library#IDisposable.isDisposed} */
```

Before this PR, the error message was:
`Expecting a declaration reference`

After this PR, the error message is more clear:
`The declaration reference appears to contain a package name or import path, but it is missing the "#" delimiter`