### PR TITLE
Remove empty DIVs by using React.Fragment & paddingTop

### DIFF
--- a/playground/src/App.tsx
+++ b/playground/src/App.tsx
@@ -5,11 +5,11 @@ class App extends React.Component {
   public render(): React.ReactNode {
 
     return (
-      <div>
+      <>
         <h1>TSDoc Playground</h1>
 
         <PlaygroundView />
-      </div>
+      </>
     );
   }
 }

--- a/playground/src/DocHtmlView.tsx
+++ b/playground/src/DocHtmlView.tsx
@@ -40,7 +40,7 @@ export class DocHtmlView extends React.Component<IDocHtmlViewProps> {
       this._renderContainer(outputElements, docComment.returnsBlock);
     }
 
-    return <div>{outputElements}</div>;
+    return <>{outputElements}</>;
   }
 
   private _renderContainer(outputElements: React.ReactNode[], section: tsdoc.DocNodeContainer): void {

--- a/playground/src/PlaygroundView.tsx
+++ b/playground/src/PlaygroundView.tsx
@@ -96,8 +96,7 @@ export class PlaygroundView extends React.Component<IPlaygroundViewProps, IPlayg
     }
 
     return (
-      <FlexColDiv className='playground-input-box' style={ { flex: 1 } }>
-        <div style={ { height: '40px' } } />
+      <FlexColDiv className='playground-input-box' style={ { flex: 1, paddingTop: 40 } }>
         <MonacoWrapper
           className='playground-input-textarea'
           style={ { width: '100%', height: '100%', boxSizing: 'border-box', resize: 'none' } }


### PR DESCRIPTION
Removed some empty DIVs in favor of [React.Fragment](https://reactjs.org/docs/fragments.html) from React@16 and use of `padding-top`. Hope you don't mind the nit changes, just getting acquainted with the source.

## Changes

- Removes empty render DIVs with React.Fragment since fragments do not add to node count.
- Replaces empty DIV of `height: 40px` in favor of parent element `padding-top: 40px`.

## Test

- Monaco Editor container top should render in-line with top of tab content container

**After**

![image](https://user-images.githubusercontent.com/706967/46648928-f5b3ff00-cb4b-11e8-9cec-313844ea9394.png)

- Empty DIVs should be removed, total node count reduced by 3

**Before**

```js
document.getElementsByTagName('*').length
202
```

**After**

```js
document.getElementsByTagName('*').length
199
```

Minor feature proposals coming soon :)

