### PR TITLE
[playground] Persist TabPane's selected tab in URL via URL fragment

### DIFF
--- a/playground/src/TabPane.tsx
+++ b/playground/src/TabPane.tsx
@@ -18,11 +18,13 @@ export interface ITabPaneState {
 }
 
 export class TabPane extends React.Component<ITabPaneProps, ITabPaneState>  {
+  private DEFAULT_TAB_INDEX: number = 0;
+
   constructor(props: ITabPaneProps, context?: any) { // tslint:disable-line:no-any
     super(props, context);
 
     this.state = {
-      selectedTabIndex: 0
+      selectedTabIndex: document.location.hash ? this.getTabIndexFromUrl() : this.DEFAULT_TAB_INDEX
     };
   }
 
@@ -96,4 +98,18 @@ export class TabPane extends React.Component<ITabPaneProps, ITabPaneState>  {
     this.setState({ selectedTabIndex: tabIndex });
   }
 
+  private getTabIndexFromUrl(): number {
+    const { tabs } = this.props;
+
+    let index: number = this.DEFAULT_TAB_INDEX;
+
+    tabs.forEach((tab: ITabDefinition, idx: number, _tabs: ITabDefinition[]) => {
+      const urlHashTitle: string = document.location.hash.substring(1, document.location.hash.length);
+      if (tab.title.toLowerCase() === urlHashTitle.toLowerCase()) {
+        index = idx;
+      }
+    });
+
+    return index;
+  }
 }

--- a/playground/src/TabPane.tsx
+++ b/playground/src/TabPane.tsx
@@ -33,7 +33,7 @@ export class TabPane extends React.Component<ITabPaneProps, ITabPaneState>  {
 
     for (let i: number = 0; i < this.props.tabs.length; ++i) {
       const tabDefinition: ITabDefinition  = this.props.tabs[i];
-
+      const { title } = tabDefinition;
       const style: React.CSSProperties = {
         padding: '8px',
         marginLeft: '1px',
@@ -54,7 +54,7 @@ export class TabPane extends React.Component<ITabPaneProps, ITabPaneState>  {
 
         buttons.push(
           <div key={`tab_${i}`} style={ selectedStyle }>
-            {tabDefinition.title}
+            {title}
           </div>
         );
 
@@ -62,10 +62,10 @@ export class TabPane extends React.Component<ITabPaneProps, ITabPaneState>  {
 
         buttons.push(
           <div key={`tab_${i}`} style={ style }>
-            <a href='#'
+            <a href={`#${title.toLowerCase()}`}
                style={ { textDecorationLine: 'none' } }
                onClick={this._onClickTab.bind(this, i)}>
-              {tabDefinition.title}
+              {title}
             </a>
           </div>
         );


### PR DESCRIPTION
## Overview

Persists the `TabPane`'s selected tab title in the URL as a URL fragment (`#`) for bookmark-ability & share-ability. Example use case: I want to test only the AST output of my tsdoc input and have that view as a bookmark.

## Changes

- If the tab title is in the URL hash, initialize the `TabPane` selected index to its index using lowercase comparison (uniqueness not guaranteed, but tabs are fixed currently).
- Otherwise OR if not found, default to index `0` (existing behavior).

## Thoughts

- We can also reflect the selected tab title in the `document.title` to differentiate state as tab and bookmark. Example: `TSDoc Playground | HTML)`