### PR TITLE
TSDoc Playground: Open default browser on npm start

### DIFF
--- a/playground/package.json
+++ b/playground/package.json
@@ -6,7 +6,7 @@
   "license": "MIT",
   "scripts": {
     "build": "node build.js",
-    "start": "node node_modules/webpack-dev-server/bin/webpack-dev-server --config webpack.dev.config.js"
+    "start": "node node_modules/webpack-dev-server/bin/webpack-dev-server --config webpack.dev.config.js --open"
   },
   "dependencies": {
     "@microsoft/tsdoc": "0.8.1",


### PR DESCRIPTION
For consideration: Opens the developer's default browser when running `npm start` in `tsdoc-playground` using https://webpack.js.org/configuration/dev-server/#devserver-open.

## Testing

**Before**

1. Run `npm start` in `./playground`
1. Manually open http://localhost:8080/ in your browser to view changes

**After**

1. Run `npm start` in `./playground`
1. Observe that default browser is opened to http://localhost:8080/