### PR TITLE
Fixes a11y error due to missing label for errors pane

### DIFF
--- a/playground/src/PlaygroundView.tsx
+++ b/playground/src/PlaygroundView.tsx
@@ -229,10 +229,10 @@ export class PlaygroundView extends React.Component<IPlaygroundViewProps, IPlayg
 
     return (
       <>
-        Errors:
-        <br />
+        <label htmlFor="errors">Errors:</label>
         <FlexColDiv style={boxStyle}>
           <textarea
+            id="errors"
             className='playground-errors-textarea'
             readOnly={ true }
             value={ errorsText }


### PR DESCRIPTION
## Description

Fixes an accessibility error in TSDoc Playground due to missing `<label>` for `<textarea>` since it is an input type and therefore required. Providing a label helps users that are using screen-reader technology navigate the page.

## The Change

I replaced the in-line text node with a `<label>` and removed the `<br>` to preserve the same spacing.

**Before**

![image](https://user-images.githubusercontent.com/706967/46703249-3018ad00-cbdb-11e8-94a5-a07aa02eeac0.png)

**After**

![image](https://user-images.githubusercontent.com/706967/46703226-19725600-cbdb-11e8-9acd-d3c717d6312f.png)

**Reference:** https://www.w3.org/TR/WCAG20-TECHS/H44.html