### PR TITLE
Fix <pre> overflow in flex container

### DIFF
--- a/playground/src/TabPane.tsx
+++ b/playground/src/TabPane.tsx
@@ -82,8 +82,13 @@ export class TabPane extends React.Component<ITabPaneProps, ITabPaneState>  {
       flex: 1
     };
 
+    const tabPaneStyle: React.CSSProperties = {
+      ...this.props.style,
+      minWidth: 0
+    };
+
     return (
-      <FlexColDiv className='playground-tab-pane' style={ this.props.style }>
+      <FlexColDiv className='playground-tab-pane' style={ tabPaneStyle }>
         <FlexRowDiv className='playground-tab-pane-buttons' style={ this.props.buttonRowStyle }>
           { buttons }
         </FlexRowDiv>

--- a/playground/src/index.css
+++ b/playground/src/index.css
@@ -25,6 +25,7 @@ html, body {
   border: 1px solid #ccc;
   padding: 6px 10px;
   border-radius: 3px;
+  overflow: auto;
 }
 
 .doc-code-span {


### PR DESCRIPTION
Fixes `<pre>`  overflow expanding the flex container's width rather than overflow-x due to default `min-width` value of flex container being `auto`.

### Testing

**Before**

![image](https://user-images.githubusercontent.com/706967/46770489-771ea500-cca4-11e8-9e75-859973b946bb.png)

**After**

![image](https://user-images.githubusercontent.com/706967/46770469-5eae8a80-cca4-11e8-8147-d0bfaa253e7f.png)

**Reference:** https://weblog.west-wind.com/posts/2016/Feb/15/Flexbox-Containers-PRE-tags-and-managing-Overflow