### PR TITLE
Playground: Fix accessibility errors due to input controls missing labels

### DIFF
--- a/playground/src/PlaygroundView.tsx
+++ b/playground/src/PlaygroundView.tsx
@@ -206,6 +206,7 @@ export class PlaygroundView extends React.Component<IPlaygroundViewProps, IPlayg
       <select
         className='playground-select-sample'
         value={this.state.selectSampleValue}
+        aria-label='Select a code sample'
         onChange={this._selectSample_onChange.bind(this)}>
 
         <option value='none'>Choose a sample...</option>
@@ -221,6 +222,7 @@ export class PlaygroundView extends React.Component<IPlaygroundViewProps, IPlayg
       <select
         className='playground-select-theme'
         value={this.state.selectedTheme}
+        aria-label='Select an editor theme'
         onChange={this._selectTheme_onChange.bind(this)}>
 
         <option value='vs'>Light Theme</option>


### PR DESCRIPTION
Minor accessibility related fix for missing labels on input fields (`<select>`). Fixed using `aria-label` to avoid modifying UI.

**Before**

![image](https://user-images.githubusercontent.com/706967/46888473-73f6f680-ce15-11e8-92a2-822a15779723.png)

**After**

![image](https://user-images.githubusercontent.com/706967/46888476-778a7d80-ce15-11e8-8246-09664550ee4d.png)

Lighthouse Accessibility Score: `78 => 92`.

## References

- https://github.com/Microsoft/tsdoc/pull/100#discussion_r224229764
- https://www.w3.org/WAI/WCAG21/Understanding/labels-or-instructions.html