### PR TITLE
TSDoc Playground: Add support for caching and loading source string from localStorage

### DIFF
--- a/playground/src/PlaygroundView.tsx
+++ b/playground/src/PlaygroundView.tsx
@@ -40,6 +40,7 @@ export class PlaygroundView extends React.Component<IPlaygroundViewProps, IPlayg
     paddingLeft: '8px',
     paddingRight: '8px'
   };
+  private readonly _localStorageSourceKey: string = 'src';
 
   private _reparseTimerHandle: number | undefined = undefined;
   private _reparseNeeded: boolean = true;
@@ -48,7 +49,7 @@ export class PlaygroundView extends React.Component<IPlaygroundViewProps, IPlayg
     super(props, context);
 
     this.state = {
-      inputText: SampleInputs.basic,
+      inputText: this.getInitialInputText(),
       parserContext: undefined,
       parserFailureText: undefined,
       selectSampleValue: undefined,
@@ -332,10 +333,40 @@ export class PlaygroundView extends React.Component<IPlaygroundViewProps, IPlayg
     );
   }
 
+  private getInitialInputText(): string {
+    if (this.isLocalStorageSupported()) {
+      const storedSourceString: string | null = localStorage.getItem(this._localStorageSourceKey);
+
+      if (storedSourceString) {
+        return storedSourceString;
+      }
+    }
+
+    return SampleInputs.basic;
+  }
+
+  // Check to see if LocalStorage is available in current browsing context.
+  // Test copied from https://github.com/Modernizr/Modernizr/blob/master/feature-detects/storage/localstorage.js.
+  private isLocalStorageSupported(): boolean {
+    const testString: string = 'tsdoc';
+    try {
+      localStorage.setItem(testString, testString);
+      localStorage.removeItem(testString);
+      return true;
+    } catch (e) {
+      return false;
+    }
+  }
+
   private _inputTextArea_onChange(value: string): void {
     this.setState({
       inputText: value
     });
+
+    if (this.isLocalStorageSupported()) {
+      localStorage.setItem(this._localStorageSourceKey, value);
+    }
+
     this._reparseNeeded = true;
   }
 


### PR DESCRIPTION
## Description

This change adds support for caching the latest input source text in `localStorage` as http://www.typescriptlang.org/play/ does. This feature allows for one to write code in the editor, close their tab, and return to the site without losing their editor contents.

## The Change

The source string is stored in `localStorage` with its key as `src`. Its value is updated in the following scenarios:

- On manual input in `<CodeEditor/>`.
- On selection of a code sample.

On page load, the site will first see if there is a value stored in `localStorage`. If a value is present, then it will set that as the editor's contents. Otherwise it will default to the "Basic Sample".

**Note:** Also added is `localStorage` feature detection [copied from Modernizr](https://github.com/Modernizr/Modernizr/blob/501cc0a1d761ce1a789e3f776790a05c6f2fd3d8/feature-detects/storage/localstorage.js#L37) because I'm unsure of our browser support matrix for TSDoc Playground ([See Browser Compatibility](https://developer.mozilla.org/en-US/docs/Web/API/Window/localStorage#Browser_compatibility)). `localStorage` is widely supported these days aside from an edge-case with Safari Private Browsing ([StackOverflow](https://stackoverflow.com/a/14555361)). If we choose to keep the feature detection, I would like to replace the copied code with a [build from Modernizr](https://modernizr.com/download?localstorage-setclasses&q=local) as part of this PR.

## Testing

### On Manual Input

1. Run and open the TSDoc Playground locally.
1. Edit the source code text in the editor.
1. Close the tab.
1. Re-open a tab to the TSDoc Playground.
1. The source code should be the same as it was prior to closing the tab.

### On Code Sample Selection

1. Run and open the TSDoc Playground locally.
1. Select a sample code option that is not the basic option as that is loaded by default.
1. Close the tab.
1. Re-open a tab to the TSDoc Playground.
1. The source code should be the same as it was prior to closing the tab.

## References

- https://www.w3.org/TR/webstorage/#dom-localstorage
- https://developer.mozilla.org/en-US/docs/Web/API/Window/localStorage#Browser_compatibility
- https://stackoverflow.com/a/14555361

Happy #hacktoberfest 🎃!