### PR TITLE
Fix a regression where the paragraph splitter was sometimes skipping blocks

### DIFF
--- a/common/changes/@microsoft/tsdoc/pgonzal-fix-paragraph-splitter_2018-10-17-12-41.json
+++ b/common/changes/@microsoft/tsdoc/pgonzal-fix-paragraph-splitter_2018-10-17-12-41.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/tsdoc",
+      "comment": "Fix a regression where the paragraph splitter was sometimes skipping blocks",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@microsoft/tsdoc",
+  "email": "pgonzal@users.noreply.github.com"
+}

--- a/tsdoc/src/__tests__/ParagraphSplitter.test.ts
+++ b/tsdoc/src/__tests__/ParagraphSplitter.test.ts
@@ -20,7 +20,20 @@ test('01 Basic paragraph splitting', () => {
   ].join('\n'));
 });
 
-test('02 Degenerate paragraph', () => {
+test('02 Basic paragraph splitting in blocks', () => {
+  TestHelpers.parseAndMatchDocCommentSnapshot([
+    '/**',
+    ' * P1',
+    ' * @remarks P2',
+    ' *',
+    ' * P3 @deprecated P4',
+    ' *',
+    ' * P5',
+    ' */'
+  ].join('\n'));
+});
+
+test('03 Degenerate comment framing', () => {
   TestHelpers.parseAndMatchDocCommentSnapshot([
     '/** line 1',
     ' * line 2',
@@ -29,7 +42,7 @@ test('02 Degenerate paragraph', () => {
   ].join('\n'));
 });
 
-test('03 Degenerate manually constructed nodes', () => {
+test('04 Degenerate manually constructed nodes', () => {
   const docSection: DocSection = new DocSection({ });
 
   const docParagraph: DocParagraph = new DocParagraph({ } );

--- a/tsdoc/src/__tests__/__snapshots__/ParagraphSplitter.test.ts.snap
+++ b/tsdoc/src/__tests__/__snapshots__/ParagraphSplitter.test.ts.snap
@@ -184,7 +184,186 @@ Object {
 }
 `;
 
-exports[`02 Degenerate paragraph 1`] = `
+exports[`02 Basic paragraph splitting in blocks 1`] = `
+Object {
+  "_00_lines": Array [
+    "P1",
+    "@remarks P2",
+    "",
+    "P3 @deprecated P4",
+    "",
+    "P5",
+  ],
+  "_01_gaps": Array [],
+  "_02_summarySection": Object {
+    "kind": "Section",
+    "nodes": Array [
+      Object {
+        "kind": "Paragraph",
+        "nodes": Array [
+          Object {
+            "kind": "PlainText",
+            "nodes": Array [
+              Object {
+                "kind": "Excerpt: PlainText",
+                "nodeExcerpt": "P1",
+              },
+            ],
+          },
+          Object {
+            "kind": "SoftBreak",
+            "nodes": Array [
+              Object {
+                "kind": "Excerpt: SoftBreak",
+                "nodeExcerpt": "[n]",
+              },
+            ],
+          },
+        ],
+      },
+    ],
+  },
+  "_03_remarksBlock": Object {
+    "kind": "Block",
+    "nodes": Array [
+      Object {
+        "kind": "BlockTag",
+        "nodes": Array [
+          Object {
+            "kind": "Excerpt: BlockTag",
+            "nodeExcerpt": "@remarks",
+          },
+        ],
+      },
+      Object {
+        "kind": "Section",
+        "nodes": Array [
+          Object {
+            "kind": "Paragraph",
+            "nodes": Array [
+              Object {
+                "kind": "PlainText",
+                "nodes": Array [
+                  Object {
+                    "kind": "Excerpt: PlainText",
+                    "nodeExcerpt": " P2",
+                  },
+                ],
+              },
+              Object {
+                "kind": "SoftBreak",
+                "nodes": Array [
+                  Object {
+                    "kind": "Excerpt: SoftBreak",
+                    "nodeExcerpt": "[n]",
+                  },
+                ],
+              },
+              Object {
+                "kind": "SoftBreak",
+                "nodes": Array [
+                  Object {
+                    "kind": "Excerpt: SoftBreak",
+                    "nodeExcerpt": "[n]",
+                  },
+                ],
+              },
+              Object {
+                "kind": "PlainText",
+                "nodes": Array [
+                  Object {
+                    "kind": "Excerpt: PlainText",
+                    "nodeExcerpt": "P3 ",
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      },
+    ],
+  },
+  "_04_privateRemarksBlock": undefined,
+  "_05_deprecatedBlock": Object {
+    "kind": "Block",
+    "nodes": Array [
+      Object {
+        "kind": "BlockTag",
+        "nodes": Array [
+          Object {
+            "kind": "Excerpt: BlockTag",
+            "nodeExcerpt": "@deprecated",
+          },
+        ],
+      },
+      Object {
+        "kind": "Section",
+        "nodes": Array [
+          Object {
+            "kind": "Paragraph",
+            "nodes": Array [
+              Object {
+                "kind": "PlainText",
+                "nodes": Array [
+                  Object {
+                    "kind": "Excerpt: PlainText",
+                    "nodeExcerpt": " P4",
+                  },
+                ],
+              },
+              Object {
+                "kind": "SoftBreak",
+                "nodes": Array [
+                  Object {
+                    "kind": "Excerpt: SoftBreak",
+                    "nodeExcerpt": "[n]",
+                  },
+                ],
+              },
+              Object {
+                "kind": "SoftBreak",
+                "nodes": Array [
+                  Object {
+                    "kind": "Excerpt: SoftBreak",
+                    "nodeExcerpt": "[n]",
+                  },
+                ],
+              },
+              Object {
+                "kind": "PlainText",
+                "nodes": Array [
+                  Object {
+                    "kind": "Excerpt: PlainText",
+                    "nodeExcerpt": "P5",
+                  },
+                ],
+              },
+              Object {
+                "kind": "SoftBreak",
+                "nodes": Array [
+                  Object {
+                    "kind": "Excerpt: SoftBreak",
+                    "nodeExcerpt": "[n]",
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      },
+    ],
+  },
+  "_06_paramBlocks": Array [],
+  "_07_typeParamBlocks": Array [],
+  "_08_returnsBlock": undefined,
+  "_09_customBlocks": Array [],
+  "_10_inheritDocTag": undefined,
+  "_11_modifierTags": Array [],
+  "_12_logMessages": Array [],
+}
+`;
+
+exports[`03 Degenerate comment framing 1`] = `
 Object {
   "_00_lines": Array [
     "line 1",
@@ -303,7 +482,7 @@ Object {
 }
 `;
 
-exports[`03 Degenerate manually constructed nodes 1`] = `
+exports[`04 Degenerate manually constructed nodes 1`] = `
 Object {
   "kind": "Section",
   "nodes": Array [

--- a/tsdoc/src/__tests__/__snapshots__/ParagraphSplitter.test.ts.snap
+++ b/tsdoc/src/__tests__/__snapshots__/ParagraphSplitter.test.ts.snap
@@ -268,6 +268,11 @@ Object {
                   },
                 ],
               },
+            ],
+          },
+          Object {
+            "kind": "Paragraph",
+            "nodes": Array [
               Object {
                 "kind": "PlainText",
                 "nodes": Array [
@@ -329,6 +334,11 @@ Object {
                   },
                 ],
               },
+            ],
+          },
+          Object {
+            "kind": "Paragraph",
+            "nodes": Array [
               Object {
                 "kind": "PlainText",
                 "nodes": Array [

--- a/tsdoc/src/parser/ParagraphSplitter.ts
+++ b/tsdoc/src/parser/ParagraphSplitter.ts
@@ -1,5 +1,4 @@
 import {
-  DocComment,
   DocSection,
   DocNode,
   DocNodeKind,
@@ -20,12 +19,16 @@ export class ParagraphSplitter {
   private static readonly _whitespaceRegExp: RegExp = /^\s*$/;
 
   /**
-   * Split all paragraphs belonging to the provided DocComment.
+   * Split all paragraphs belonging to the provided subtree.
    */
-  public static splitParagraphs(docComment: DocComment): void {
-    for (const node of docComment.getChildNodes()) {
-      if (node instanceof DocSection) {
-        ParagraphSplitter.splitParagraphsForSection(node);
+  public static splitParagraphs(node: DocNode): void {
+    if (node instanceof DocSection) {
+      ParagraphSplitter.splitParagraphsForSection(node);
+
+      // (We don't recurse here, since sections cannot contain subsections)
+    } else {
+      for (const childNode of node.getChildNodes()) {
+        ParagraphSplitter.splitParagraphs(childNode);
       }
     }
   }


### PR DESCRIPTION
When PR https://github.com/Microsoft/tsdoc/pull/109 moved `DocBlock.nodes` into `DocBlock.content.nodes`, the paragraph splitter wasn't updated.