### PR TITLE
Fix stack overflow in DocFencedCode.language property getter

### DIFF
--- a/common/changes/@microsoft/tsdoc/pgonzal-fix-stack-overflow_2018-10-17-13-34.json
+++ b/common/changes/@microsoft/tsdoc/pgonzal-fix-stack-overflow_2018-10-17-13-34.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/tsdoc",
+      "comment": "Fix stack overflow in DocFencedCode.language property getter",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@microsoft/tsdoc",
+  "email": "pgonzal@users.noreply.github.com"
+}

--- a/tsdoc/src/nodes/DocFencedCode.ts
+++ b/tsdoc/src/nodes/DocFencedCode.ts
@@ -141,7 +141,7 @@ export class DocFencedCode extends DocNode {
         this._language = '';
       }
     }
-    return this.language;
+    return this._language;
   }
 
   /**


### PR DESCRIPTION
There should be a tslint rule for this...