### PR TITLE
Change DocErrorText organization in tree, add emit helpers for HTML and declaration references

### DIFF
--- a/common/changes/@microsoft/tsdoc/pgonzal-docerrortext-topology_2018-11-01-22-59.json
+++ b/common/changes/@microsoft/tsdoc/pgonzal-docerrortext-topology_2018-11-01-22-59.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/tsdoc",
+      "comment": "Add `DocDeclarationReference.emitAsTsdoc()`, `DocHtmlStartTag.emitAsHtml()`, and `DocHtmlEndTag.emitAsHtml()`",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@microsoft/tsdoc",
+  "email": "pgonzal@users.noreply.github.com"
+}

--- a/common/changes/@microsoft/tsdoc/pgonzal-docerrortext-topology_2018-11-01-23-00.json
+++ b/common/changes/@microsoft/tsdoc/pgonzal-docerrortext-topology_2018-11-01-23-00.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/tsdoc",
+      "comment": "(API change) `DocErrorText` is no longer allowed in `DocSection`; instead it must be part of a `DocParagraph`",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@microsoft/tsdoc",
+  "email": "pgonzal@users.noreply.github.com"
+}

--- a/tsdoc/src/emitters/TSDocEmitter.ts
+++ b/tsdoc/src/emitters/TSDocEmitter.ts
@@ -63,13 +63,25 @@ export class TSDocEmitter {
   private _hangingParagraph: boolean = false;
 
   public renderComment(output: StringBuilder, docComment: DocComment): void {
+    this._renderCompleteObject(output, docComment);
+  }
+
+  public renderHtmlTag(output: StringBuilder, htmlTag: DocHtmlStartTag | DocHtmlEndTag): void {
+    this._renderCompleteObject(output, htmlTag);
+  }
+
+  public renderDeclarationReference(output: StringBuilder, declarationReference: DocDeclarationReference): void {
+    this._renderCompleteObject(output, declarationReference);
+  }
+
+  private _renderCompleteObject(output: StringBuilder, docNode: DocNode): void {
     this._output = output;
 
     this._lineState = LineState.Closed;
     this._previousLineHadContent = false;
     this._hangingParagraph = false;
 
-    this._renderNode(docComment);
+    this._renderNode(docNode);
 
     this._writeEnd();
   }

--- a/tsdoc/src/nodes/DocDeclarationReference.ts
+++ b/tsdoc/src/nodes/DocDeclarationReference.ts
@@ -2,6 +2,7 @@ import { DocNode, DocNodeKind, IDocNodeParameters, IDocNodeParsedParameters } fr
 import { DocMemberReference } from './DocMemberReference';
 import { TokenSequence } from '../parser/TokenSequence';
 import { DocExcerpt, ExcerptKind } from './DocExcerpt';
+import { StringBuilder } from '../emitters/StringBuilder';
 
 /**
  * Constructor parameters for {@link DocDeclarationReference}.
@@ -129,6 +130,17 @@ export class DocDeclarationReference extends DocNode {
     return this._memberReferences;
   }
 
+  /**
+   * Generates the TSDoc representation of this declaration reference.
+   */
+  public emitAsTsdoc(): string {
+    const stringBuilder: StringBuilder = new StringBuilder();
+    // tslint:disable-next-line:no-use-before-declare
+    const emitter: TSDocEmitter = new TSDocEmitter();
+    emitter.renderDeclarationReference(stringBuilder, this);
+    return stringBuilder.toString();
+  }
+
   /** @override */
   protected onGetChildNodes(): ReadonlyArray<DocNode | undefined> {
     return [
@@ -140,3 +152,6 @@ export class DocDeclarationReference extends DocNode {
     ];
   }
 }
+
+// Circular reference
+import { TSDocEmitter } from '../emitters/TSDocEmitter';

--- a/tsdoc/src/nodes/DocHtmlEndTag.ts
+++ b/tsdoc/src/nodes/DocHtmlEndTag.ts
@@ -1,6 +1,7 @@
 import { DocNode, DocNodeKind, IDocNodeParameters, IDocNodeParsedParameters } from './DocNode';
 import { TokenSequence } from '../parser/TokenSequence';
 import { DocExcerpt, ExcerptKind } from './DocExcerpt';
+import { StringBuilder } from '../emitters/StringBuilder';
 
 /**
  * Constructor parameters for {@link DocHtmlEndTag}.
@@ -82,6 +83,18 @@ export class DocHtmlEndTag extends DocNode {
     return this._name;
   }
 
+  /**
+   * Generates the HTML for this tag.
+   */
+  public emitAsHtml(): string {
+    // NOTE: Here we're assuming that the TSDoc representation for a tag is also a valid HTML expression.
+    const stringBuilder: StringBuilder = new StringBuilder();
+    // tslint:disable-next-line:no-use-before-declare
+    const emitter: TSDocEmitter = new TSDocEmitter();
+    emitter.renderHtmlTag(stringBuilder, this);
+    return stringBuilder.toString();
+  }
+
   /** @override */
   protected onGetChildNodes(): ReadonlyArray<DocNode | undefined> {
     return [
@@ -91,5 +104,7 @@ export class DocHtmlEndTag extends DocNode {
       this._closingDelimiterExcerpt
     ];
   }
-
 }
+
+// Circular reference
+import { TSDocEmitter } from '../emitters/TSDocEmitter';

--- a/tsdoc/src/nodes/DocHtmlStartTag.ts
+++ b/tsdoc/src/nodes/DocHtmlStartTag.ts
@@ -2,6 +2,7 @@ import { DocNode, DocNodeKind, IDocNodeParameters, IDocNodeParsedParameters } fr
 import { DocHtmlAttribute } from './DocHtmlAttribute';
 import { TokenSequence } from '../parser/TokenSequence';
 import { DocExcerpt, ExcerptKind } from './DocExcerpt';
+import { StringBuilder } from '../emitters/StringBuilder';
 
 /**
  * Constructor parameters for {@link DocHtmlStartTag}.
@@ -132,6 +133,18 @@ export class DocHtmlStartTag extends DocNode {
     return this._spacingAfterName;
   }
 
+  /**
+   * Generates the HTML for this tag.
+   */
+  public emitAsHtml(): string {
+    // NOTE: Here we're assuming that the TSDoc representation for a tag is also a valid HTML expression.
+    const stringBuilder: StringBuilder = new StringBuilder();
+    // tslint:disable-next-line:no-use-before-declare
+    const emitter: TSDocEmitter = new TSDocEmitter();
+    emitter.renderHtmlTag(stringBuilder, this);
+    return stringBuilder.toString();
+  }
+
   /** @override */
   protected onGetChildNodes(): ReadonlyArray<DocNode | undefined> {
     return [
@@ -144,3 +157,6 @@ export class DocHtmlStartTag extends DocNode {
   }
 
 }
+
+// Circular reference
+import { TSDocEmitter } from '../emitters/TSDocEmitter';

--- a/tsdoc/src/nodes/DocSection.ts
+++ b/tsdoc/src/nodes/DocSection.ts
@@ -36,17 +36,24 @@ export class DocSection extends DocNodeContainer {
   }
 
   /**
-   * {@inheritDoc}
+   * {@inheritDoc DocNode.isAllowedChildNode}
    * @override
    */
-  public isAllowedChildNode(docNode: DocNode): boolean {
+  public static isAllowedChildNode(docNode: DocNode): boolean {
     switch (docNode.kind) {
       case DocNodeKind.FencedCode:
-      case DocNodeKind.ErrorText:
       case DocNodeKind.Paragraph:
         return true;
     }
     return false;
+  }
+
+  /**
+   * {@inheritDoc}
+   * @override
+   */
+  public isAllowedChildNode(docNode: DocNode): boolean {
+    return DocSection.isAllowedChildNode(docNode);
   }
 
   /**

--- a/tsdoc/src/parser/__tests__/__snapshots__/NodeParserCode.test.ts.snap
+++ b/tsdoc/src/parser/__tests__/__snapshots__/NodeParserCode.test.ts.snap
@@ -520,23 +520,18 @@ Object {
                   },
                 ],
               },
-            ],
-          },
-          Object {
-            "errorLocation": "[c][c][c]",
-            "errorLocationPrecedingToken": "   ",
-            "errorMessage": "The opening backtick for a code fence must appear at the start of the line",
-            "kind": "ErrorText",
-            "nodes": Array [
               Object {
-                "kind": "Excerpt: ErrorText",
-                "nodeExcerpt": "[c][c][c]",
+                "errorLocation": "[c][c][c]",
+                "errorLocationPrecedingToken": "   ",
+                "errorMessage": "The opening backtick for a code fence must appear at the start of the line",
+                "kind": "ErrorText",
+                "nodes": Array [
+                  Object {
+                    "kind": "Excerpt: ErrorText",
+                    "nodeExcerpt": "[c][c][c]",
+                  },
+                ],
               },
-            ],
-          },
-          Object {
-            "kind": "Paragraph",
-            "nodes": Array [
               Object {
                 "kind": "SoftBreak",
                 "nodes": Array [
@@ -602,23 +597,18 @@ Object {
                   },
                 ],
               },
-            ],
-          },
-          Object {
-            "errorLocation": "[c][c][c]",
-            "errorLocationPrecedingToken": "a",
-            "errorMessage": "The opening backtick for a code fence must appear at the start of the line",
-            "kind": "ErrorText",
-            "nodes": Array [
               Object {
-                "kind": "Excerpt: ErrorText",
-                "nodeExcerpt": "[c][c][c]",
+                "errorLocation": "[c][c][c]",
+                "errorLocationPrecedingToken": "a",
+                "errorMessage": "The opening backtick for a code fence must appear at the start of the line",
+                "kind": "ErrorText",
+                "nodes": Array [
+                  Object {
+                    "kind": "Excerpt: ErrorText",
+                    "nodeExcerpt": "[c][c][c]",
+                  },
+                ],
               },
-            ],
-          },
-          Object {
-            "kind": "Paragraph",
-            "nodes": Array [
               Object {
                 "kind": "SoftBreak",
                 "nodes": Array [
@@ -675,24 +665,19 @@ Object {
                   },
                 ],
               },
-            ],
-          },
-          Object {
-            "errorLocation": "",
-            "errorLocationPrecedingToken": "
-",
-            "errorMessage": "Error parsing code fence: Missing closing delimiter",
-            "kind": "ErrorText",
-            "nodes": Array [
               Object {
-                "kind": "Excerpt: ErrorText",
-                "nodeExcerpt": "[c][c][c]",
+                "errorLocation": "",
+                "errorLocationPrecedingToken": "
+",
+                "errorMessage": "Error parsing code fence: Missing closing delimiter",
+                "kind": "ErrorText",
+                "nodes": Array [
+                  Object {
+                    "kind": "Excerpt: ErrorText",
+                    "nodeExcerpt": "[c][c][c]",
+                  },
+                ],
               },
-            ],
-          },
-          Object {
-            "kind": "Paragraph",
-            "nodes": Array [
               Object {
                 "kind": "SoftBreak",
                 "nodes": Array [
@@ -749,24 +734,19 @@ Object {
                   },
                 ],
               },
-            ],
-          },
-          Object {
-            "errorLocation": "",
-            "errorLocationPrecedingToken": "
-",
-            "errorMessage": "Error parsing code fence: Missing closing delimiter",
-            "kind": "ErrorText",
-            "nodes": Array [
               Object {
-                "kind": "Excerpt: ErrorText",
-                "nodeExcerpt": "[c][c][c]",
+                "errorLocation": "",
+                "errorLocationPrecedingToken": "
+",
+                "errorMessage": "Error parsing code fence: Missing closing delimiter",
+                "kind": "ErrorText",
+                "nodes": Array [
+                  Object {
+                    "kind": "Excerpt: ErrorText",
+                    "nodeExcerpt": "[c][c][c]",
+                  },
+                ],
               },
-            ],
-          },
-          Object {
-            "kind": "Paragraph",
-            "nodes": Array [
               Object {
                 "kind": "PlainText",
                 "nodes": Array [
@@ -833,23 +813,18 @@ Object {
                   },
                 ],
               },
-            ],
-          },
-          Object {
-            "errorLocation": "[c]",
-            "errorLocationPrecedingToken": " ",
-            "errorMessage": "Error parsing code fence: The language specifier cannot contain backtick characters",
-            "kind": "ErrorText",
-            "nodes": Array [
               Object {
-                "kind": "Excerpt: ErrorText",
-                "nodeExcerpt": "[c][c][c]",
+                "errorLocation": "[c]",
+                "errorLocationPrecedingToken": " ",
+                "errorMessage": "Error parsing code fence: The language specifier cannot contain backtick characters",
+                "kind": "ErrorText",
+                "nodes": Array [
+                  Object {
+                    "kind": "Excerpt: ErrorText",
+                    "nodeExcerpt": "[c][c][c]",
+                  },
+                ],
               },
-            ],
-          },
-          Object {
-            "kind": "Paragraph",
-            "nodes": Array [
               Object {
                 "kind": "PlainText",
                 "nodes": Array [
@@ -859,23 +834,18 @@ Object {
                   },
                 ],
               },
-            ],
-          },
-          Object {
-            "errorLocation": "[c][c][c]",
-            "errorLocationPrecedingToken": " ",
-            "errorMessage": "The opening backtick for a code fence must appear at the start of the line",
-            "kind": "ErrorText",
-            "nodes": Array [
               Object {
-                "kind": "Excerpt: ErrorText",
-                "nodeExcerpt": "[c][c][c]",
+                "errorLocation": "[c][c][c]",
+                "errorLocationPrecedingToken": " ",
+                "errorMessage": "The opening backtick for a code fence must appear at the start of the line",
+                "kind": "ErrorText",
+                "nodes": Array [
+                  Object {
+                    "kind": "Excerpt: ErrorText",
+                    "nodeExcerpt": "[c][c][c]",
+                  },
+                ],
               },
-            ],
-          },
-          Object {
-            "kind": "Paragraph",
-            "nodes": Array [
               Object {
                 "kind": "SoftBreak",
                 "nodes": Array [


### PR DESCRIPTION
Some miscellaneous improvements:
- Add `DocDeclarationReference.emitAsTsdoc()`, `DocHtmlStartTag.emitAsHtml()`, and `DocHtmlEndTag.emitAsHtml()`
- `DocErrorText` is no longer allowed in `DocSection`; instead it must be part of a `DocParagraph`