### PR TITLE
Some miscellaneous minor fixes

### DIFF
--- a/common/changes/@microsoft/tsdoc/pgonzal-misc-fixes_2018-11-06-00-51.json
+++ b/common/changes/@microsoft/tsdoc/pgonzal-misc-fixes_2018-11-06-00-51.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/tsdoc",
+      "comment": "Allow HTML in a `DocSection` node",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@microsoft/tsdoc",
+  "email": "pgonzal@users.noreply.github.com"
+}

--- a/common/changes/@microsoft/tsdoc/pgonzal-misc-fixes_2018-11-06-00-52.json
+++ b/common/changes/@microsoft/tsdoc/pgonzal-misc-fixes_2018-11-06-00-52.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/tsdoc",
+      "comment": "Fix a bug where `TSDocEmitter.renderHtmlTag()` and `TSDocEmitter.renderDeclarationReference()` were including comment framing",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@microsoft/tsdoc",
+  "email": "pgonzal@users.noreply.github.com"
+}

--- a/common/changes/@microsoft/tsdoc/pgonzal-misc-fixes_2018-11-06-00-52.json
+++ b/common/changes/@microsoft/tsdoc/pgonzal-misc-fixes_2018-11-06-00-52.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@microsoft/tsdoc",
-      "comment": "Fix a bug where `TSDocEmitter.renderHtmlTag()` and `TSDocEmitter.renderDeclarationReference()` were including comment framing",
+      "comment": "Add `DocSection.appendNodesInParagraph()` API",
       "type": "patch"
     }
   ],

--- a/tsdoc/src/emitters/__tests__/TSDocEmitter.test.ts
+++ b/tsdoc/src/emitters/__tests__/TSDocEmitter.test.ts
@@ -1,4 +1,14 @@
-import { TSDocParser, ParserContext } from '../../index';
+import {
+  TSDocParser,
+  ParserContext,
+  DocHtmlStartTag,
+  DocHtmlAttribute,
+  DocDeclarationReference,
+  DocMemberReference,
+  DocMemberIdentifier,
+  DocMemberSelector,
+  TSDocConfiguration
+} from '../../index';
 
 function createSnapshot(input: string): {} {
   const tsdocParser: TSDocParser = new TSDocParser();
@@ -106,4 +116,31 @@ Object {
 ",
 }
 `);
+});
+
+test('03 TSDocEmitter.renderHtmlTag()', () => {
+  const configuration: TSDocConfiguration = new TSDocConfiguration();
+  const htmlTag: DocHtmlStartTag = new DocHtmlStartTag({
+    configuration,
+    name: 'img',
+    htmlAttributes: [new DocHtmlAttribute({ configuration, name: 'src', value: '"http://example.com"' })]
+  });
+  expect(htmlTag.emitAsHtml()).toMatchInlineSnapshot(`"<img src=\\"http://example.com\\">"`);
+});
+
+test('04 TSDocEmitter.renderDeclarationReference()', () => {
+  const configuration: TSDocConfiguration = new TSDocConfiguration();
+  const htmlTag: DocDeclarationReference = new DocDeclarationReference({
+    configuration,
+    packageName: 'my-package',
+    memberReferences: [
+      new DocMemberReference({
+        configuration,
+        hasDot: false,
+        memberIdentifier: new DocMemberIdentifier({ configuration, identifier: 'MyClass' }),
+        selector: new DocMemberSelector({ configuration, selector: 'class' })
+      })
+    ]
+  });
+  expect(htmlTag.emitAsTsdoc()).toMatchInlineSnapshot(`"my-package#(MyClass:class)"`);
 });

--- a/tsdoc/src/nodes/BuiltInDocNodes.ts
+++ b/tsdoc/src/nodes/BuiltInDocNodes.ts
@@ -37,7 +37,9 @@ export class BuiltInDocNodes {
 
     docNodeManager.registerAllowableChildren(DocNodeKind.Section, [
       DocNodeKind.FencedCode,
-      DocNodeKind.Paragraph
+      DocNodeKind.Paragraph,
+      DocNodeKind.HtmlStartTag,
+      DocNodeKind.HtmlEndTag
     ]);
 
     docNodeManager.registerAllowableChildren(DocNodeKind.Paragraph, [

--- a/tsdoc/src/nodes/DocHtmlStartTag.ts
+++ b/tsdoc/src/nodes/DocHtmlStartTag.ts
@@ -11,8 +11,8 @@ export interface IDocHtmlStartTagParameters extends IDocNodeParameters {
   name: string;
   spacingAfterName?: string;
 
-  htmlAttributes: DocHtmlAttribute[];
-  selfClosingTag: boolean;
+  htmlAttributes?: DocHtmlAttribute[];
+  selfClosingTag?: boolean;
 }
 
 /**
@@ -91,9 +91,11 @@ export class DocHtmlStartTag extends DocNode {
     }
 
     this._htmlAttributes = [];
-    this._htmlAttributes.push(...parameters.htmlAttributes);
+    if (parameters.htmlAttributes) {
+      this._htmlAttributes.push(...parameters.htmlAttributes);
+    }
 
-    this._selfClosingTag = parameters.selfClosingTag;
+    this._selfClosingTag = !!parameters.selfClosingTag;
   }
 
   /** @override */

--- a/tsdoc/src/nodes/DocNodeContainer.ts
+++ b/tsdoc/src/nodes/DocNodeContainer.ts
@@ -26,12 +26,12 @@ export abstract class DocNodeContainer extends DocNode {
    * @internal
    */
   public constructor(parameters: IDocNodeContainerParameters | IDocNodeContainerParsedParameters,
-    children?: DocNode[]) {
+    childNodes?: ReadonlyArray<DocNode>) {
 
     super(parameters);
 
-    if (children !== undefined && children.length > 0) {
-      this.appendNodes(children);
+    if (childNodes !== undefined && childNodes.length > 0) {
+      this.appendNodes(childNodes);
     }
   }
 
@@ -47,7 +47,8 @@ export abstract class DocNodeContainer extends DocNode {
    */
   public appendNode(docNode: DocNode): void {
     if (!this.configuration.docNodeManager.isAllowedChild(this.kind, docNode.kind)) {
-      throw new Error(`The TSDocConfiguration does not permit ${this.kind} to contain nodes of type ${docNode.kind}`);
+      throw new Error(`The TSDocConfiguration does not allow a ${this.kind} node to`
+        + ` contain a node of type ${docNode.kind}`);
     }
 
     this._nodes!.push(docNode);

--- a/tsdoc/src/nodes/DocParagraph.ts
+++ b/tsdoc/src/nodes/DocParagraph.ts
@@ -17,8 +17,8 @@ export class DocParagraph extends DocNodeContainer {
    * Don't call this directly.  Instead use {@link TSDocParser}
    * @internal
    */
-  public constructor(parameters: IDocParagraphParameters, children?: DocNode[]) {
-    super(parameters, children);
+  public constructor(parameters: IDocParagraphParameters, childNodes?: ReadonlyArray<DocNode>) {
+    super(parameters, childNodes);
   }
 
   /** @override */

--- a/tsdoc/src/nodes/DocSection.ts
+++ b/tsdoc/src/nodes/DocSection.ts
@@ -28,8 +28,10 @@ export class DocSection extends DocNodeContainer {
    * Don't call this directly.  Instead use {@link TSDocParser}
    * @internal
    */
-  public constructor(parameters: IDocSectionParameters | IDocSectionParsedParameters, children?: DocNode[]) {
-    super(parameters, children);
+  public constructor(parameters: IDocSectionParameters | IDocSectionParsedParameters,
+    childNodes?: ReadonlyArray<DocNode>) {
+
+    super(parameters, childNodes);
   }
 
   /** @override */

--- a/tsdoc/src/nodes/DocSection.ts
+++ b/tsdoc/src/nodes/DocSection.ts
@@ -59,4 +59,11 @@ export class DocSection extends DocNodeContainer {
 
     paragraphNode.appendNode(docNode);
   }
+
+  public appendNodesInParagraph(docNodes: ReadonlyArray<DocNode>): void {
+    for (const docNode of docNodes) {
+      this.appendNodeInParagraph(docNode);
+    }
+  }
+
 }

--- a/tsdoc/src/parser/NodeParser.ts
+++ b/tsdoc/src/parser/NodeParser.ts
@@ -404,10 +404,10 @@ export class NodeParser {
   }
 
   private _pushNode(docNode: DocNode): void {
-    if (this._configuration.docNodeManager.isAllowedChild(DocNodeKind.Section, docNode.kind)) {
-      this._currentSection.appendNode(docNode);
-    } else {
+    if (this._configuration.docNodeManager.isAllowedChild(DocNodeKind.Paragraph, docNode.kind)) {
       this._currentSection.appendNodeInParagraph(docNode);
+    } else {
+      this._currentSection.appendNode(docNode);
     }
   }
 


### PR DESCRIPTION
* Add `DocSection.appendNodesInParagraph()`
* Fix a bug where `TSDocEmitter.renderHtmlTag()` and `TSDocEmitter.renderDeclarationReference()` were including comment framing
* Prefer to put HTML nodes in a paragraph
* `IDocHtmlStartTagParameters.htmlAttributes` and `selfClosingTag` should be optional
* Allow HTML in a DocSection
