### PR TITLE
Improve trimming of spacing for link text in @link tags

### DIFF
--- a/common/changes/@microsoft/tsdoc/pgonzal-link-tag-trimming_2018-11-08-20-19.json
+++ b/common/changes/@microsoft/tsdoc/pgonzal-link-tag-trimming_2018-11-08-20-19.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/tsdoc",
+      "comment": "Improve trimming of spacing for link text in `{@link}` tags",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@microsoft/tsdoc",
+  "email": "pgonzal@users.noreply.github.com"
+}

--- a/playground/src/DocHtmlView.tsx
+++ b/playground/src/DocHtmlView.tsx
@@ -144,7 +144,7 @@ export class DocHtmlView extends React.Component<IDocHtmlViewProps> {
             }
           }
           const linkText: string = linkTag.linkText || identifier || '???';
-          return <a key={key} href='#'>{linkText.trim()}</a>;
+          return <a key={key} href='#'>{linkText}</a>;
         }
       case 'Paragraph':
         // Collapse spaces in the paragraph

--- a/tsdoc/src/__tests__/__snapshots__/ParsingBasics.test.ts.snap
+++ b/tsdoc/src/__tests__/__snapshots__/ParsingBasics.test.ts.snap
@@ -259,8 +259,12 @@ Object {
                     "nodeExcerpt": "|",
                   },
                   Object {
+                    "kind": "Excerpt: Spacing",
+                    "nodeExcerpt": " ",
+                  },
+                  Object {
                     "kind": "Excerpt: LinkTag_LinkText",
-                    "nodeExcerpt": " Statistics subsystem",
+                    "nodeExcerpt": "Statistics subsystem",
                   },
                   Object {
                     "kind": "Excerpt: InlineTag_ClosingDelimiter",
@@ -954,8 +958,12 @@ Object {
                     "nodeExcerpt": "|",
                   },
                   Object {
+                    "kind": "Excerpt: Spacing",
+                    "nodeExcerpt": " ",
+                  },
+                  Object {
                     "kind": "Excerpt: LinkTag_LinkText",
-                    "nodeExcerpt": " Statistics subsystem",
+                    "nodeExcerpt": "Statistics subsystem",
                   },
                   Object {
                     "kind": "Excerpt: InlineTag_ClosingDelimiter",

--- a/tsdoc/src/emitters/TSDocEmitter.ts
+++ b/tsdoc/src/emitters/TSDocEmitter.ts
@@ -232,15 +232,18 @@ export class TSDocEmitter {
         const docLinkTag: DocLinkTag = docNode as DocLinkTag;
         this._renderInlineTag(docLinkTag, () => {
           if (docLinkTag.urlDestination !== undefined || docLinkTag.codeDestination !== undefined) {
-            this._writeContent(' ');
             if (docLinkTag.urlDestination !== undefined) {
+              this._writeContent(' ');
               this._writeContent(docLinkTag.urlDestination);
-            } else {
+            } else if (docLinkTag.codeDestination !== undefined) {
+              this._writeContent(' ');
               this._renderNode(docLinkTag.codeDestination);
             }
           }
           if (docLinkTag.linkText !== undefined) {
+            this._writeContent(' ');
             this._writeContent('|');
+            this._writeContent(' ');
             this._writeContent(docLinkTag.linkText);
           }
         });

--- a/tsdoc/src/nodes/DocLinkTag.ts
+++ b/tsdoc/src/nodes/DocLinkTag.ts
@@ -30,8 +30,10 @@ export interface IDocLinkTagParsedParameters extends IDocInlineTagBaseParsedPara
   spacingAfterDestinationExcerpt?: TokenSequence;
 
   pipeExcerpt?: TokenSequence;
+  spacingAfterPipeExcerpt?: TokenSequence;
 
   linkTextExcerpt?: TokenSequence;
+  spacingAfterLinkTextExcerpt?: TokenSequence;
 }
 
 /**
@@ -46,8 +48,11 @@ export class DocLinkTag extends DocInlineTagBase {
   private readonly _spacingAfterDestinationExcerpt: DocExcerpt | undefined;
 
   private readonly _pipeExcerpt: DocExcerpt | undefined;
+  private readonly _spacingAfterPipeExcerpt: DocExcerpt | undefined;
 
   private _linkText: string | undefined;
+  private readonly _spacingAfterLinkTextExcerpt: DocExcerpt | undefined;
+
   private readonly _linkTextExcerpt: DocExcerpt | undefined;
 
   /**
@@ -90,12 +95,26 @@ export class DocLinkTag extends DocInlineTagBase {
           content: parameters.pipeExcerpt
         });
       }
+      if (parameters.spacingAfterPipeExcerpt) {
+        this._spacingAfterPipeExcerpt = new DocExcerpt({
+          configuration: this.configuration,
+          excerptKind: ExcerptKind.Spacing,
+          content: parameters.spacingAfterPipeExcerpt
+        });
+      }
 
       if (parameters.linkTextExcerpt) {
         this._linkTextExcerpt = new DocExcerpt({
           configuration: this.configuration,
           excerptKind: ExcerptKind.LinkTag_LinkText,
           content: parameters.linkTextExcerpt
+        });
+      }
+      if (parameters.spacingAfterLinkTextExcerpt) {
+        this._spacingAfterLinkTextExcerpt = new DocExcerpt({
+          configuration: this.configuration,
+          excerptKind: ExcerptKind.Spacing,
+          content: parameters.spacingAfterLinkTextExcerpt
         });
       }
     } else {
@@ -143,6 +162,23 @@ export class DocLinkTag extends DocInlineTagBase {
    * An optional text string that is the hyperlink text.  If omitted, the documentation
    * renderer will use a default string based on the link itself (e.g. the URL text
    * or the declaration identifier).
+   *
+   * @remarks
+   *
+   * In HTML, the hyperlink can include leading/trailing space characters around the link text.
+   * For example, this HTML will cause a web browser to `y` and also the space character before
+   * and after it:
+   *
+   * ```html
+   * x<a href="#Button"> y </a> z
+   * ```
+   *
+   * Unlike HTML, TSDoc trims leading/trailing spaces.  For example, this TSDoc will be
+   * displayed `xy z` and underline only the `y` character:
+   *
+   * ```
+   * x{@link Button | y } z
+   * ```
    */
   public get linkText(): string | undefined {
     if (this._linkText === undefined) {
@@ -160,7 +196,9 @@ export class DocLinkTag extends DocInlineTagBase {
       this._urlDestinationExcerpt,
       this._spacingAfterDestinationExcerpt,
       this._pipeExcerpt,
-      this._linkTextExcerpt
+      this._spacingAfterPipeExcerpt,
+      this._linkTextExcerpt,
+      this._spacingAfterLinkTextExcerpt
     ];
   }
 }

--- a/tsdoc/src/parser/NodeParser.ts
+++ b/tsdoc/src/parser/NodeParser.ts
@@ -785,6 +785,7 @@ export class NodeParser {
               embeddedTokenReader.extractAccumulatedSequence(), errorTag);
             return errorTag;
           case TokenKind.Spacing:
+          case TokenKind.Newline:
             embeddedTokenReader.readToken();
             break;
           default:

--- a/tsdoc/src/parser/NodeParser.ts
+++ b/tsdoc/src/parser/NodeParser.ts
@@ -826,7 +826,7 @@ export class NodeParser {
 
     if (urlDestination.length === 0) {
       // This should be impossible since the caller ensures that peekTokenKind() === TokenKind.AsciiWord
-      throw new Error('Missing URL in _parseLinkTagUrl()');
+      throw new Error('Missing URL in _parseLinkTagUrlDestination()');
     }
 
     const urlDestinationExcerpt: TokenSequence = embeddedTokenReader.extractAccumulatedSequence();

--- a/tsdoc/src/parser/__tests__/NodeParserLinkTag.test.ts
+++ b/tsdoc/src/parser/__tests__/NodeParserLinkTag.test.ts
@@ -6,9 +6,9 @@ test('00 Link text: positive examples', () => {
     ' * {@link http://example1.com}',
     ' * {@link http://example2.com|}',
     ' * {@link http://example3.com| }',
-    ' * {@link http://example4.com| link text}',
-    ' * {@link http://example5.com| link',
-    ' * text}',
+    ' * {@link http://example4.com|link text}',
+    ' * x{@link http://example5.com| link',
+    ' * text }y',
     ' */'
   ].join('\n'));
 });

--- a/tsdoc/src/parser/__tests__/NodeParserLinkTag.test.ts
+++ b/tsdoc/src/parser/__tests__/NodeParserLinkTag.test.ts
@@ -7,8 +7,11 @@ test('00 Link text: positive examples', () => {
     ' * {@link http://example2.com|}',
     ' * {@link http://example3.com| }',
     ' * {@link http://example4.com|link text}',
-    ' * x{@link http://example5.com| link',
-    ' * text }y',
+    ' * 1{@link http://example5.com| link',
+    ' * text }2',
+    ' * 3{@link http://example5.com| ',
+    ' * link text ',
+    ' *  }4',
     ' */'
   ].join('\n'));
 });

--- a/tsdoc/src/parser/__tests__/__snapshots__/NodeParserLinkTag.test.ts.snap
+++ b/tsdoc/src/parser/__tests__/__snapshots__/NodeParserLinkTag.test.ts.snap
@@ -2,15 +2,15 @@
 
 exports[`00 Link text: positive examples 1`] = `
 Object {
-  "buffer": "/**[n] * {@link http://example1.com}[n] * {@link http://example2.com|}[n] * {@link http://example3.com| }[n] * {@link http://example4.com| link text}[n] * {@link http://example5.com| link[n] * text}[n] */",
+  "buffer": "/**[n] * {@link http://example1.com}[n] * {@link http://example2.com|}[n] * {@link http://example3.com| }[n] * {@link http://example4.com|link text}[n] * x{@link http://example5.com| link[n] * text }y[n] */",
   "gaps": Array [],
   "lines": Array [
     "{@link http://example1.com}",
     "{@link http://example2.com|}",
     "{@link http://example3.com| }",
-    "{@link http://example4.com| link text}",
-    "{@link http://example5.com| link",
-    "text}",
+    "{@link http://example4.com|link text}",
+    "x{@link http://example5.com| link",
+    "text }y",
   ],
   "logMessages": Array [],
   "nodes": Object {
@@ -161,7 +161,7 @@ Object {
                   },
                   Object {
                     "kind": "Excerpt: LinkTag_LinkText",
-                    "nodeExcerpt": " link text",
+                    "nodeExcerpt": "link text",
                   },
                   Object {
                     "kind": "Excerpt: InlineTag_ClosingDelimiter",
@@ -175,6 +175,15 @@ Object {
                   Object {
                     "kind": "Excerpt: SoftBreak",
                     "nodeExcerpt": "[n]",
+                  },
+                ],
+              },
+              Object {
+                "kind": "PlainText",
+                "nodes": Array [
+                  Object {
+                    "kind": "Excerpt: PlainText",
+                    "nodeExcerpt": "x",
                   },
                 ],
               },
@@ -203,11 +212,20 @@ Object {
                   },
                   Object {
                     "kind": "Excerpt: LinkTag_LinkText",
-                    "nodeExcerpt": " link[n]text",
+                    "nodeExcerpt": " link[n]text ",
                   },
                   Object {
                     "kind": "Excerpt: InlineTag_ClosingDelimiter",
                     "nodeExcerpt": "}",
+                  },
+                ],
+              },
+              Object {
+                "kind": "PlainText",
+                "nodes": Array [
+                  Object {
+                    "kind": "Excerpt: PlainText",
+                    "nodeExcerpt": "y",
                   },
                 ],
               },

--- a/tsdoc/src/parser/__tests__/__snapshots__/NodeParserLinkTag.test.ts.snap
+++ b/tsdoc/src/parser/__tests__/__snapshots__/NodeParserLinkTag.test.ts.snap
@@ -2,15 +2,18 @@
 
 exports[`00 Link text: positive examples 1`] = `
 Object {
-  "buffer": "/**[n] * {@link http://example1.com}[n] * {@link http://example2.com|}[n] * {@link http://example3.com| }[n] * {@link http://example4.com|link text}[n] * x{@link http://example5.com| link[n] * text }y[n] */",
+  "buffer": "/**[n] * {@link http://example1.com}[n] * {@link http://example2.com|}[n] * {@link http://example3.com| }[n] * {@link http://example4.com|link text}[n] * 1{@link http://example5.com| link[n] * text }2[n] * 3{@link http://example5.com| [n] * link text [n] *  }4[n] */",
   "gaps": Array [],
   "lines": Array [
     "{@link http://example1.com}",
     "{@link http://example2.com|}",
     "{@link http://example3.com| }",
     "{@link http://example4.com|link text}",
-    "x{@link http://example5.com| link",
-    "text }y",
+    "1{@link http://example5.com| link",
+    "text }2",
+    "3{@link http://example5.com|",
+    "link text",
+    " }4",
   ],
   "logMessages": Array [],
   "nodes": Object {
@@ -183,7 +186,7 @@ Object {
                 "nodes": Array [
                   Object {
                     "kind": "Excerpt: PlainText",
-                    "nodeExcerpt": "x",
+                    "nodeExcerpt": "1",
                   },
                 ],
               },
@@ -233,7 +236,75 @@ Object {
                 "nodes": Array [
                   Object {
                     "kind": "Excerpt: PlainText",
-                    "nodeExcerpt": "y",
+                    "nodeExcerpt": "2",
+                  },
+                ],
+              },
+              Object {
+                "kind": "SoftBreak",
+                "nodes": Array [
+                  Object {
+                    "kind": "Excerpt: SoftBreak",
+                    "nodeExcerpt": "[n]",
+                  },
+                ],
+              },
+              Object {
+                "kind": "PlainText",
+                "nodes": Array [
+                  Object {
+                    "kind": "Excerpt: PlainText",
+                    "nodeExcerpt": "3",
+                  },
+                ],
+              },
+              Object {
+                "kind": "LinkTag",
+                "nodes": Array [
+                  Object {
+                    "kind": "Excerpt: InlineTag_OpeningDelimiter",
+                    "nodeExcerpt": "{",
+                  },
+                  Object {
+                    "kind": "Excerpt: InlineTag_TagName",
+                    "nodeExcerpt": "@link",
+                  },
+                  Object {
+                    "kind": "Excerpt: Spacing",
+                    "nodeExcerpt": " ",
+                  },
+                  Object {
+                    "kind": "Excerpt: LinkTag_UrlDestination",
+                    "nodeExcerpt": "http://example5.com",
+                  },
+                  Object {
+                    "kind": "Excerpt: LinkTag_Pipe",
+                    "nodeExcerpt": "|",
+                  },
+                  Object {
+                    "kind": "Excerpt: Spacing",
+                    "nodeExcerpt": "[n]",
+                  },
+                  Object {
+                    "kind": "Excerpt: LinkTag_LinkText",
+                    "nodeExcerpt": "link text",
+                  },
+                  Object {
+                    "kind": "Excerpt: Spacing",
+                    "nodeExcerpt": "[n] ",
+                  },
+                  Object {
+                    "kind": "Excerpt: InlineTag_ClosingDelimiter",
+                    "nodeExcerpt": "}",
+                  },
+                ],
+              },
+              Object {
+                "kind": "PlainText",
+                "nodes": Array [
+                  Object {
+                    "kind": "Excerpt: PlainText",
+                    "nodeExcerpt": "4",
                   },
                 ],
               },

--- a/tsdoc/src/parser/__tests__/__snapshots__/NodeParserLinkTag.test.ts.snap
+++ b/tsdoc/src/parser/__tests__/__snapshots__/NodeParserLinkTag.test.ts.snap
@@ -118,7 +118,7 @@ Object {
                     "nodeExcerpt": "|",
                   },
                   Object {
-                    "kind": "Excerpt: LinkTag_LinkText",
+                    "kind": "Excerpt: Spacing",
                     "nodeExcerpt": " ",
                   },
                   Object {
@@ -211,8 +211,16 @@ Object {
                     "nodeExcerpt": "|",
                   },
                   Object {
+                    "kind": "Excerpt: Spacing",
+                    "nodeExcerpt": " ",
+                  },
+                  Object {
                     "kind": "Excerpt: LinkTag_LinkText",
-                    "nodeExcerpt": " link[n]text ",
+                    "nodeExcerpt": "link[n]text",
+                  },
+                  Object {
+                    "kind": "Excerpt: Spacing",
+                    "nodeExcerpt": " ",
                   },
                   Object {
                     "kind": "Excerpt: InlineTag_ClosingDelimiter",
@@ -257,7 +265,7 @@ Object {
   ],
   "logMessages": Array [
     "(2,5): The @link tag content is missing",
-    "(3,31): The \\"|\\" character may not be used in the link text without escaping it",
+    "(3,32): The \\"|\\" character may not be used in the link text without escaping it",
   ],
   "nodes": Object {
     "kind": "Comment",

--- a/tsdoc/src/parser/__tests__/__snapshots__/NodeParserLinkTag2.test.ts.snap
+++ b/tsdoc/src/parser/__tests__/__snapshots__/NodeParserLinkTag2.test.ts.snap
@@ -231,8 +231,12 @@ Object {
                     "nodeExcerpt": "|",
                   },
                   Object {
+                    "kind": "Excerpt: Spacing",
+                    "nodeExcerpt": " ",
+                  },
+                  Object {
                     "kind": "Excerpt: LinkTag_LinkText",
-                    "nodeExcerpt": " link text",
+                    "nodeExcerpt": "link text",
                   },
                   Object {
                     "kind": "Excerpt: InlineTag_ClosingDelimiter",
@@ -1775,8 +1779,12 @@ Object {
                     "nodeExcerpt": "|",
                   },
                   Object {
+                    "kind": "Excerpt: Spacing",
+                    "nodeExcerpt": " ",
+                  },
+                  Object {
                     "kind": "Excerpt: LinkTag_LinkText",
-                    "nodeExcerpt": " link text",
+                    "nodeExcerpt": "link text",
                   },
                   Object {
                     "kind": "Excerpt: InlineTag_ClosingDelimiter",

--- a/tsdoc/src/parser/__tests__/__snapshots__/NodeParserLinkTag3.test.ts.snap
+++ b/tsdoc/src/parser/__tests__/__snapshots__/NodeParserLinkTag3.test.ts.snap
@@ -285,8 +285,12 @@ Object {
                     "nodeExcerpt": "|",
                   },
                   Object {
+                    "kind": "Excerpt: Spacing",
+                    "nodeExcerpt": " ",
+                  },
+                  Object {
                     "kind": "Excerpt: LinkTag_LinkText",
-                    "nodeExcerpt": " link text",
+                    "nodeExcerpt": "link text",
                   },
                   Object {
                     "kind": "Excerpt: InlineTag_ClosingDelimiter",


### PR DESCRIPTION
Consider this input:

```ts
/**
 * x{@link Button | y }z
 */
```

Before this PR, the `DocLinkTag.linkText` would be `" y "` (including the spaces), and it was left the documentation generator to decide whether to render `xyz` or `x y z`, and whether the hyperlink underlining should include the spaces around `y`.  

We realized that when text is adjacent to `{` and `}`, the author almost certainly did not intend to have spacing around the link, and also the author will almost certainly not want hanging spaces to be underlined.  You can do this in HTML ( <a href="#">&nbsp;&nbsp;&nbsp;x&nbsp;&nbsp;&nbsp;</a> ) but it's almost never useful in a doc authoring context.  So it's better for TSDoc to handle this in a uniform way.

If an author really wanted to underline spaces for some reason, we could add support for that later by requiring them to escape the spaces or somesuch.