### PR TITLE
Add a new API PlainTextEmitter.hasAnyTextContent()

### DIFF
--- a/common/changes/@microsoft/tsdoc/pgonzal-plain-text-emitter_2018-11-15-10-31.json
+++ b/common/changes/@microsoft/tsdoc/pgonzal-plain-text-emitter_2018-11-15-10-31.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/tsdoc",
+      "comment": "Add a new API `PlainTextEmitter.hasAnyTextContent()`",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@microsoft/tsdoc",
+  "email": "pgonzal@users.noreply.github.com"
+}

--- a/tsdoc/src/index.ts
+++ b/tsdoc/src/index.ts
@@ -17,6 +17,7 @@ export { Standardization } from './details/Standardization';
 export { StandardModifierTagSet } from './details/StandardModifierTagSet';
 export { ModifierTagSet } from './details/ModifierTagSet';
 
+export { PlainTextEmitter } from './emitters/PlainTextEmitter';
 export { StringBuilder } from './emitters/StringBuilder';
 export { TSDocEmitter } from './emitters/TSDocEmitter';
 


### PR DESCRIPTION
This API is used to flag doc comments that contain insufficient documentation.