### PR TITLE
Add IStringBuilder interface

### DIFF
--- a/common/changes/@microsoft/tsdoc/pgonzal-istringbuilder_2018-11-20-20-08.json
+++ b/common/changes/@microsoft/tsdoc/pgonzal-istringbuilder_2018-11-20-20-08.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/tsdoc",
+      "comment": "Add new interface `IStringBuilder`",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@microsoft/tsdoc",
+  "email": "pgonzal@users.noreply.github.com"
+}

--- a/tsdoc/src/emitters/StringBuilder.ts
+++ b/tsdoc/src/emitters/StringBuilder.ts
@@ -13,9 +13,13 @@ export interface IStringBuilder {
   append(text: string): void;
 
   /**
-   * Renders the text as a string.
+   * Returns a single string containing all the text that was appended to the buffer so far.
+   *
+   * @remarks
+   *
+   * This is a potentially expensive operation.
    */
-  getText(): string;
+  toString(): string;
 }
 
 /**
@@ -41,8 +45,8 @@ export class StringBuilder implements IStringBuilder {
     this._chunks.push(text);
   }
 
-  /** {@inheritdoc IStringBuilder.getText} */
-  public getText(): string {
+  /** {@inheritdoc IStringBuilder.toString} */
+  public toString(): string {
     if (this._chunks.length === 0) {
       return '';
     }
@@ -54,17 +58,5 @@ export class StringBuilder implements IStringBuilder {
     }
 
     return this._chunks[0];
-  }
-
-  /**
-   * A shorthand for `StringBuilder.getText()`.
-   *
-   * @remarks
-   *
-   * The `getText()` method is preferred in TypeScript, since the type system allows `Object.toString()` to be called
-   * for many objects that do not provide a useful implementation.
-   */
-  public toString(): string {
-    return this.getText();
   }
 }

--- a/tsdoc/src/emitters/StringBuilder.ts
+++ b/tsdoc/src/emitters/StringBuilder.ts
@@ -1,26 +1,48 @@
 /**
+ * An interface for a builder object that allows a large text string to be constructed incrementally by appending
+ * small chunks.
+ *
+ * @remarks
+ *
+ * {@link StringBuilder} is the default implementation of this contract.
+ */
+export interface IStringBuilder {
+  /**
+   * Append the specified text to the buffer.
+   */
+  append(text: string): void;
+
+  /**
+   * Renders the text as a string.
+   */
+  getText(): string;
+}
+
+/**
  * This class allows a large text string to be constructed incrementally by appending small chunks.  The final
  * string can be obtained by calling StringBuilder.toString().
  *
  * @remarks
- * A naive approach might use the "+=" operator to append strings:  This would have the downside of copying
- * the entire string each time a chunk is appended, resulting in O(n^2) bytes of memory being allocated
+ * A naive approach might use the `+=` operator to append strings:  This would have the downside of copying
+ * the entire string each time a chunk is appended, resulting in `O(n^2)` bytes of memory being allocated
  * (and later freed by the garbage  collector), and many of the allocations could be very large objects.
  * StringBuilder avoids this overhead by accumulating the chunks in an array, and efficiently joining them
- * when toString() is finally called.
+ * when `getText()` is finally called.
  */
-export class StringBuilder {
+export class StringBuilder implements IStringBuilder {
   private _chunks: string[];
 
   constructor() {
     this._chunks = [];
   }
 
+  /** {@inheritdoc IStringBuilder.append} */
   public append(text: string): void {
     this._chunks.push(text);
   }
 
-  public toString(): string {
+  /** {@inheritdoc IStringBuilder.getText} */
+  public getText(): string {
     if (this._chunks.length === 0) {
       return '';
     }
@@ -32,5 +54,17 @@ export class StringBuilder {
     }
 
     return this._chunks[0];
+  }
+
+  /**
+   * A shorthand for `StringBuilder.getText()`.
+   *
+   * @remarks
+   *
+   * The `getText()` method is preferred in TypeScript, since the type system allows `Object.toString()` to be called
+   * for many objects that do not provide a useful implementation.
+   */
+  public toString(): string {
+    return this.getText();
   }
 }

--- a/tsdoc/src/emitters/TSDocEmitter.ts
+++ b/tsdoc/src/emitters/TSDocEmitter.ts
@@ -25,7 +25,7 @@ import {
   DocMemberSelector,
   DocParamBlock
 } from '../nodes';
-import { StringBuilder } from './StringBuilder';
+import { IStringBuilder } from './StringBuilder';
 import { DocNodeTransforms } from '../transforms/DocNodeTransforms';
 import { StandardTags } from '../details/StandardTags';
 import { DocParamCollection } from '../nodes/DocParamCollection';
@@ -45,7 +45,7 @@ export class TSDocEmitter {
   // Whether to emit the /** */ framing
   private _emitCommentFraming: boolean = true;
 
-  private _output: StringBuilder | undefined;
+  private _output: IStringBuilder | undefined;
 
   // This state machine is used by the writer functions to generate the /** */ framing around the emitted lines
   private _lineState: LineState = LineState.Closed;
@@ -58,22 +58,22 @@ export class TSDocEmitter {
   // an "@param" block.  Setting _hangingParagraph=true accomplishes that.
   private _hangingParagraph: boolean = false;
 
-  public renderComment(output: StringBuilder, docComment: DocComment): void {
+  public renderComment(output: IStringBuilder, docComment: DocComment): void {
     this._emitCommentFraming = true;
     this._renderCompleteObject(output, docComment);
   }
 
-  public renderHtmlTag(output: StringBuilder, htmlTag: DocHtmlStartTag | DocHtmlEndTag): void {
+  public renderHtmlTag(output: IStringBuilder, htmlTag: DocHtmlStartTag | DocHtmlEndTag): void {
     this._emitCommentFraming = false;
     this._renderCompleteObject(output, htmlTag);
   }
 
-  public renderDeclarationReference(output: StringBuilder, declarationReference: DocDeclarationReference): void {
+  public renderDeclarationReference(output: IStringBuilder, declarationReference: DocDeclarationReference): void {
     this._emitCommentFraming = false;
     this._renderCompleteObject(output, declarationReference);
   }
 
-  private _renderCompleteObject(output: StringBuilder, docNode: DocNode): void {
+  private _renderCompleteObject(output: IStringBuilder, docNode: DocNode): void {
     this._output = output;
 
     this._lineState = LineState.Closed;

--- a/tsdoc/src/index.ts
+++ b/tsdoc/src/index.ts
@@ -18,7 +18,7 @@ export { StandardModifierTagSet } from './details/StandardModifierTagSet';
 export { ModifierTagSet } from './details/ModifierTagSet';
 
 export { PlainTextEmitter } from './emitters/PlainTextEmitter';
-export { StringBuilder } from './emitters/StringBuilder';
+export { StringBuilder, IStringBuilder } from './emitters/StringBuilder';
 export { TSDocEmitter } from './emitters/TSDocEmitter';
 
 export * from './nodes';


### PR DESCRIPTION
This allows TSDoc's `StringBuilder` API to interoperate with the [similar utility](https://github.com/Microsoft/web-build-tools/blob/master/libraries/node-core-library/src/StringBuilder.ts) from **`@microsoft/node-core-library**.