### PR TITLE
Add support for `$` character in identifiers

### DIFF
--- a/common/changes/@microsoft/tsdoc/pgonzal-dollar-signs_2019-01-29-02-37.json
+++ b/common/changes/@microsoft/tsdoc/pgonzal-dollar-signs_2019-01-29-02-37.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/tsdoc",
+      "comment": "Update parser to allow `$` character in `@param` names, since ECMAScript allows this in unquoted identifiers",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@microsoft/tsdoc",
+  "email": "pgonzal@users.noreply.github.com"
+}

--- a/common/changes/@microsoft/tsdoc/pgonzal-dollar-signs_2019-01-29-02-38.json
+++ b/common/changes/@microsoft/tsdoc/pgonzal-dollar-signs_2019-01-29-02-38.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/tsdoc",
+      "comment": "Allow `$` character in declaration reference member identifiers (Example: `{@link Button.$render}`)",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@microsoft/tsdoc",
+  "email": "pgonzal@users.noreply.github.com"
+}

--- a/tsdoc/src/__tests__/ParsingBasics.test.ts
+++ b/tsdoc/src/__tests__/ParsingBasics.test.ts
@@ -49,8 +49,8 @@ test('02 A basic TSDoc comment with common components', () => {
     ' * This is a custom block containing an @undefinedBlockTag',
     ' *',
     ' * @param x - The first input number',
-    ' * @param y - The second input number',
-    ' * @returns The arithmetic mean of `x` and `y`',
+    ' * @param y$_ - The second input number',
+    ' * @returns The arithmetic mean of `x` and `y$_`',
     ' *',
     ' * @beta @customModifier',
     ' */'

--- a/tsdoc/src/__tests__/__snapshots__/ParsingBasics.test.ts.snap
+++ b/tsdoc/src/__tests__/__snapshots__/ParsingBasics.test.ts.snap
@@ -129,8 +129,8 @@ Object {
     "This is a custom block containing an @undefinedBlockTag",
     "",
     "@param x - The first input number",
-    "@param y - The second input number",
-    "@returns The arithmetic mean of [c]x[c] and [c]y[c]",
+    "@param y$_ - The second input number",
+    "@returns The arithmetic mean of [c]x[c] and [c]y$_[c]",
     "",
     "@beta @customModifier",
   ],
@@ -388,7 +388,7 @@ Object {
         },
         Object {
           "kind": "Excerpt: ParamBlock_ParameterName",
-          "nodeExcerpt": "y",
+          "nodeExcerpt": "y$_",
         },
         Object {
           "kind": "Excerpt: Spacing",
@@ -496,7 +496,7 @@ Object {
                   },
                   Object {
                     "kind": "Excerpt: CodeSpan_Code",
-                    "nodeExcerpt": "y",
+                    "nodeExcerpt": "y$_",
                   },
                   Object {
                     "kind": "Excerpt: CodeSpan_ClosingDelimiter",

--- a/tsdoc/src/parser/StringChecks.ts
+++ b/tsdoc/src/parser/StringChecks.ts
@@ -11,9 +11,18 @@ export class StringChecks {
   // https://html.spec.whatwg.org/multipage/custom-elements.html#valid-custom-element-name
   private static readonly _htmlNameRegExp: RegExp = /^[a-z]+(\-[a-z]+)*$/i;
 
-  private static readonly _identifierNotWordCharRegExp: RegExp = /\W/u;
-  private static readonly _identifierNumberStartRegExp: RegExp = /^[0-9]/u;
+  // Note: In addition to letters, numbers, underscores, and dollar signs, modern ECMAScript
+  // also allows Unicode categories such as letters, combining marks, digits, and connector punctuation.
+  // These are mostly supported in all environments except IE11, so if someone wants it, we would accept
+  // a PR to allow them (although the test surface might be somewhat large).
+  private static readonly _identifierBadCharRegExp: RegExp = /[^a-z0-9_$]/i;
 
+  // Identifiers most not start with a number.
+  private static readonly _identifierNumberStartRegExp: RegExp = /^[0-9]/;
+
+  // For detailed notes about NPM package name syntax, see:
+  // tslint:disable-next-line:max-line-length
+  // https://github.com/Microsoft/web-build-tools/blob/a417ca25c63aca31dba43a34d39cc9cd529b9c78/libraries/node-core-library/src/PackageName.ts
   private static readonly _validPackageNameRegExp: RegExp = /^(?:@[a-z0-9\-_\.]+\/)?[a-z0-9\-_\.]+$/i;
 
   private static readonly _systemSelectors: Set<string> = new Set<string>([
@@ -147,7 +156,7 @@ export class StringChecks {
       return 'The identifier cannot be an empty string';
     }
 
-    if (StringChecks._identifierNotWordCharRegExp.test(identifier)) {
+    if (StringChecks._identifierBadCharRegExp.test(identifier)) {
       return 'The identifier cannot non-word characters';
     }
 

--- a/tsdoc/src/parser/Token.ts
+++ b/tsdoc/src/parser/Token.ts
@@ -168,7 +168,13 @@ export enum TokenKind {
    * The plus character ("+").
    * The Token.range will always be a string of length 1.
    */
-  Plus = 2028
+  Plus = 2028,
+
+  /**
+   * The dollar sign character ("$").
+   * The Token.range will always be a string of length 1.
+   */
+  DollarSign = 2029
 }
 
 /**

--- a/tsdoc/src/parser/Tokenizer.ts
+++ b/tsdoc/src/parser/Tokenizer.ts
@@ -146,7 +146,8 @@ export class Tokenizer {
       '('  : TokenKind.LeftParenthesis,
       ')'  : TokenKind.RightParenthesis,
       '#'  : TokenKind.PoundSymbol,
-      '+'  : TokenKind.Plus
+      '+'  : TokenKind.Plus,
+      '$'  : TokenKind.DollarSign
     };
     for (const key of Object.getOwnPropertyNames(specialMap)) {
       Tokenizer._charCodeMap[key.charCodeAt(0)] = specialMap[key];

--- a/tsdoc/src/parser/__tests__/NodeParserLinkTag2.test.ts
+++ b/tsdoc/src/parser/__tests__/NodeParserLinkTag2.test.ts
@@ -80,7 +80,23 @@ test('07 Index selectors: negative examples', () => {
   ].join('\n'));
 });
 
-test('08 Quoted identifiers: positive examples', () => {
+test('08 Unusual identifiers: positive examples', () => {
+  TestHelpers.parseAndMatchNodeParserSnapshot([
+    '/**',
+    ' * {@link Class$_1 . $_1member}',
+    ' */'
+  ].join('\n'));
+});
+
+test('09 Unusual identifiers: negative examples', () => {
+  TestHelpers.parseAndMatchNodeParserSnapshot([
+    '/**',
+    ' * {@link Class-1}',
+    ' */'
+  ].join('\n'));
+});
+
+test('10 Quoted identifiers: positive examples', () => {
   TestHelpers.parseAndMatchNodeParserSnapshot([
     '/**',
     ' * {@link "static"}',
@@ -90,7 +106,7 @@ test('08 Quoted identifiers: positive examples', () => {
   ].join('\n'));
 });
 
-test('09 Quoted identifiers: negative examples', () => {
+test('11 Quoted identifiers: negative examples', () => {
   TestHelpers.parseAndMatchNodeParserSnapshot([
     '/**',
     ' * {@link "static}',

--- a/tsdoc/src/parser/__tests__/__snapshots__/NodeParserLinkTag2.test.ts.snap
+++ b/tsdoc/src/parser/__tests__/__snapshots__/NodeParserLinkTag2.test.ts.snap
@@ -1551,7 +1551,170 @@ Object {
 }
 `;
 
-exports[`08 Quoted identifiers: positive examples 1`] = `
+exports[`08 Unusual identifiers: positive examples 1`] = `
+Object {
+  "buffer": "/**[n] * {@link Class$_1 . $_1member}[n] */",
+  "gaps": Array [],
+  "lines": Array [
+    "{@link Class$_1 . $_1member}",
+  ],
+  "logMessages": Array [],
+  "nodes": Object {
+    "kind": "Comment",
+    "nodes": Array [
+      Object {
+        "kind": "Section",
+        "nodes": Array [
+          Object {
+            "kind": "Paragraph",
+            "nodes": Array [
+              Object {
+                "kind": "LinkTag",
+                "nodes": Array [
+                  Object {
+                    "kind": "Excerpt: InlineTag_OpeningDelimiter",
+                    "nodeExcerpt": "{",
+                  },
+                  Object {
+                    "kind": "Excerpt: InlineTag_TagName",
+                    "nodeExcerpt": "@link",
+                  },
+                  Object {
+                    "kind": "Excerpt: Spacing",
+                    "nodeExcerpt": " ",
+                  },
+                  Object {
+                    "kind": "DeclarationReference",
+                    "nodes": Array [
+                      Object {
+                        "kind": "MemberReference",
+                        "nodes": Array [
+                          Object {
+                            "kind": "MemberIdentifier",
+                            "nodes": Array [
+                              Object {
+                                "kind": "Excerpt: MemberIdentifier_Identifier",
+                                "nodeExcerpt": "Class$_1",
+                              },
+                            ],
+                          },
+                          Object {
+                            "kind": "Excerpt: Spacing",
+                            "nodeExcerpt": " ",
+                          },
+                        ],
+                      },
+                      Object {
+                        "kind": "MemberReference",
+                        "nodes": Array [
+                          Object {
+                            "kind": "Excerpt: MemberReference_Dot",
+                            "nodeExcerpt": ".",
+                          },
+                          Object {
+                            "kind": "Excerpt: Spacing",
+                            "nodeExcerpt": " ",
+                          },
+                          Object {
+                            "kind": "MemberIdentifier",
+                            "nodes": Array [
+                              Object {
+                                "kind": "Excerpt: MemberIdentifier_Identifier",
+                                "nodeExcerpt": "$_1member",
+                              },
+                            ],
+                          },
+                        ],
+                      },
+                    ],
+                  },
+                  Object {
+                    "kind": "Excerpt: InlineTag_ClosingDelimiter",
+                    "nodeExcerpt": "}",
+                  },
+                ],
+              },
+              Object {
+                "kind": "SoftBreak",
+                "nodes": Array [
+                  Object {
+                    "kind": "Excerpt: SoftBreak",
+                    "nodeExcerpt": "[n]",
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      },
+    ],
+  },
+}
+`;
+
+exports[`09 Unusual identifiers: negative examples 1`] = `
+Object {
+  "buffer": "/**[n] * {@link Class-1}[n] */",
+  "gaps": Array [],
+  "lines": Array [
+    "{@link Class-1}",
+  ],
+  "logMessages": Array [
+    "(2,16): Unexpected character after link destination",
+  ],
+  "nodes": Object {
+    "kind": "Comment",
+    "nodes": Array [
+      Object {
+        "kind": "Section",
+        "nodes": Array [
+          Object {
+            "kind": "Paragraph",
+            "nodes": Array [
+              Object {
+                "kind": "InlineTag",
+                "nodes": Array [
+                  Object {
+                    "kind": "Excerpt: InlineTag_OpeningDelimiter",
+                    "nodeExcerpt": "{",
+                  },
+                  Object {
+                    "kind": "Excerpt: InlineTag_TagName",
+                    "nodeExcerpt": "@link",
+                  },
+                  Object {
+                    "kind": "Excerpt: Spacing",
+                    "nodeExcerpt": " ",
+                  },
+                  Object {
+                    "kind": "Excerpt: InlineTag_TagContent",
+                    "nodeExcerpt": "Class-1",
+                  },
+                  Object {
+                    "kind": "Excerpt: InlineTag_ClosingDelimiter",
+                    "nodeExcerpt": "}",
+                  },
+                ],
+              },
+              Object {
+                "kind": "SoftBreak",
+                "nodes": Array [
+                  Object {
+                    "kind": "Excerpt: SoftBreak",
+                    "nodeExcerpt": "[n]",
+                  },
+                ],
+              },
+            ],
+          },
+        ],
+      },
+    ],
+  },
+}
+`;
+
+exports[`10 Quoted identifiers: positive examples 1`] = `
 Object {
   "buffer": "/**[n] * {@link [q]static[q]}[n] * {@link Class1 . [q]member[q]}[n] * {@link Class2.[q]|[q] | link text}[n] */",
   "gaps": Array [],
@@ -1810,7 +1973,7 @@ Object {
 }
 `;
 
-exports[`09 Quoted identifiers: negative examples 1`] = `
+exports[`11 Quoted identifiers: negative examples 1`] = `
 Object {
   "buffer": "/**[n] * {@link [q]static}[n] * {@link Class1.[q][q]}[n] * {@link Class2.interface}[n] * {@link Class3.1}[n] */",
   "gaps": Array [],

--- a/tsdoc/src/parser/__tests__/__snapshots__/Tokenizer.test.ts.snap
+++ b/tsdoc/src/parser/__tests__/__snapshots__/Tokenizer.test.ts.snap
@@ -136,7 +136,7 @@ Object {
       "indexOfLine": 0,
       "line": ">[b]$[b]@param<",
       "span": "   > <        ",
-      "tokenKind": "OtherPunctuation",
+      "tokenKind": "DollarSign",
     },
     Object {
       "indexOfLine": 0,
@@ -380,7 +380,7 @@ Object {
       "indexOfLine": 0,
       "line": ">![q]#$%&'()*+,-./:;[<]=[>]?@[]^_[c]{|}~<",
       "span": "     > <                                ",
-      "tokenKind": "OtherPunctuation",
+      "tokenKind": "DollarSign",
     },
     Object {
       "indexOfLine": 0,


### PR DESCRIPTION
This fixes issue https://github.com/Microsoft/tsdoc/issues/140 which requested support for ["Finnish" notation](https://medium.com/@benlesh/observables-and-finnish-notation-df8356ed1c9b).

You can now do this:

```ts
/**
 * @param x$ - a parameter with a dollar sign
 */
```

and this:

```ts
/**
 * {@link Button.$render}
 */
```

However only `$` and `_` are allowed in ECMAScript identifiers, so e.g. quoting is still required for other names such as this:
```ts
/**
 * {@link Button."!render"}
 */
```
