### PR TITLE
Introduce message IDs for selective suppressing of TSDoc parser errors, as well as lookups

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ ehthumbs.db
 .Spotlight-V100
 .Trashes
 ._*
+/.project
 
 # Package files
 app

--- a/common/changes/@microsoft/tsdoc/octogonz-message-id_2019-02-27-04-57.json
+++ b/common/changes/@microsoft/tsdoc/octogonz-message-id_2019-02-27-04-57.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/tsdoc",
+      "comment": "Add a new API ParserMessage.messageId with a unique ID useful for filtering and searching for errors",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@microsoft/tsdoc",
+  "email": "4673363+octogonz@users.noreply.github.com"
+}

--- a/playground/src/PlaygroundView.tsx
+++ b/playground/src/PlaygroundView.tsx
@@ -146,7 +146,7 @@ export class PlaygroundView extends React.Component<IPlaygroundViewProps, IPlayg
     const syntaxStyles: IStyledRange[] = [];
     if (this.state.parserContext) {
       for (const message of this.state.parserContext.log.messages) {
-        const text: string = message.unformattedText;
+        const text: string = `[${message.messageId}]\n\n${message.unformattedText}`;
         if (message.tokenSequence) {
           for (const token of message.tokenSequence.tokens) {
             if (!token.range.isEmpty()) {

--- a/tsdoc/src/index.ts
+++ b/tsdoc/src/index.ts
@@ -29,6 +29,7 @@ export { ParserMessageLog } from './parser/ParserMessageLog';
 export { TextRange, ITextLocation } from './parser/TextRange';
 export { Token, TokenKind } from './parser/Token';
 export { TokenSequence, ITokenSequenceParameters } from './parser/TokenSequence';
+export { TSDocMessageId } from './parser/TSDocMessageId';
 export { TSDocParser } from './parser/TSDocParser';
 
 export { DocNodeTransforms } from './transforms/DocNodeTransforms';

--- a/tsdoc/src/nodes/DocErrorText.ts
+++ b/tsdoc/src/nodes/DocErrorText.ts
@@ -1,6 +1,7 @@
 import { DocNodeKind, DocNode, IDocNodeParsedParameters } from './DocNode';
 import { TokenSequence } from '../parser/TokenSequence';
 import { DocExcerpt, ExcerptKind } from './DocExcerpt';
+import { TSDocMessageId } from '../parser/TSDocMessageId';
 
 /**
  * Constructor parameters for {@link DocErrorText}.
@@ -8,6 +9,7 @@ import { DocExcerpt, ExcerptKind } from './DocExcerpt';
 export interface IDocErrorTextParsedParameters extends IDocNodeParsedParameters {
   textExcerpt: TokenSequence;
 
+  messageId: TSDocMessageId;
   errorMessage: string;
   errorLocation: TokenSequence;
 }
@@ -20,6 +22,7 @@ export class DocErrorText extends DocNode {
   private _text: string | undefined;
   private readonly _textExcerpt: DocExcerpt;
 
+  private readonly _messageId: TSDocMessageId;
   private readonly _errorMessage: string;
   private readonly _errorLocation: TokenSequence;
 
@@ -36,6 +39,7 @@ export class DocErrorText extends DocNode {
       content: parameters.textExcerpt
     });
 
+    this._messageId = parameters.messageId;
     this._errorMessage = parameters.errorMessage;
     this._errorLocation = parameters.errorLocation;
   }
@@ -62,6 +66,13 @@ export class DocErrorText extends DocNode {
     } else {
       return undefined;
     }
+  }
+
+  /**
+   * The TSDoc error message identifier.
+   */
+  public get messageId(): TSDocMessageId {
+    return this._messageId;
   }
 
   /**

--- a/tsdoc/src/parser/LineExtractor.ts
+++ b/tsdoc/src/parser/LineExtractor.ts
@@ -1,5 +1,6 @@
 import { TextRange } from './TextRange';
 import { ParserContext } from './ParserContext';
+import { TSDocMessageId } from './TSDocMessageId';
 
 // Internal parser state
 enum State {
@@ -50,10 +51,14 @@ export class LineExtractor {
         switch (state) {
           case State.BeginComment1:
           case State.BeginComment2:
-            parserContext.log.addMessageForTextRange('Expecting a "/**" comment', range);
+            parserContext.log.addMessageForTextRange(
+              TSDocMessageId.CommentNotFound,
+              'Expecting a "/**" comment', range);
             return false;
           default:
-            parserContext.log.addMessageForTextRange('Unexpected end of input', range);
+            parserContext.log.addMessageForTextRange(
+              TSDocMessageId.CommentMissingClosingDelimiter,
+              'Unexpected end of input', range);
             return false;
         }
       }
@@ -70,7 +75,9 @@ export class LineExtractor {
             ++nextIndex; // skip the star
             state = State.BeginComment2;
           } else if (!LineExtractor._whitespaceCharacterRegExp.test(current)) {
-            parserContext.log.addMessageForTextRange('Expecting a leading "/**"',
+            parserContext.log.addMessageForTextRange(
+              TSDocMessageId.CommentOpeningDelimiterSyntax,
+              'Expecting a leading "/**"',
               range.getNewRange(currentIndex, currentIndex + 1));
             return false;
           }
@@ -84,7 +91,9 @@ export class LineExtractor {
             collectingLineEnd = nextIndex;
             state = State.CollectingFirstLine;
           } else {
-            parserContext.log.addMessageForTextRange('Expecting a leading "/**"',
+            parserContext.log.addMessageForTextRange(
+              TSDocMessageId.CommentOpeningDelimiterSyntax,
+              'Expecting a leading "/**"',
               range.getNewRange(currentIndex, currentIndex + 1));
             return false;
           }

--- a/tsdoc/src/parser/NodeParser.ts
+++ b/tsdoc/src/parser/NodeParser.ts
@@ -985,7 +985,7 @@ export class NodeParser {
       // We saw characters that will be a syntax error if interpreted as a member reference,
       // but would make sense as a package name or import path, but we did not find a "#"
       this._parserContext.log.addMessageForTokenSequence(
-        TSDocMessageId.DReferenceMissingHash,
+        TSDocMessageId.ReferenceMissingHash,
         'The declaration reference appears to contain a package name or import path,'
           + ' but it is missing the "#" delimiter',
         tokenReader.extractAccumulatedSequence(), nodeForErrorContext);
@@ -1039,7 +1039,7 @@ export class NodeParser {
             packageNameExcerpt.toString());
           if (explanation) {
             this._parserContext.log.addMessageForTokenSequence(
-              TSDocMessageId.DReferenceMalformedPackageName,
+              TSDocMessageId.ReferenceMalformedPackageName,
               explanation,
               packageNameExcerpt, nodeForErrorContext);
             return undefined;
@@ -1070,7 +1070,7 @@ export class NodeParser {
           importPathExcerpt.toString(), !!packageNameExcerpt);
         if (explanation) {
           this._parserContext.log.addMessageForTokenSequence(
-            TSDocMessageId.DReferenceMalformedImportPath,
+            TSDocMessageId.ReferenceMalformedImportPath,
             explanation,
             importPathExcerpt, nodeForErrorContext);
           return undefined;
@@ -1089,7 +1089,7 @@ export class NodeParser {
 
       if (packageNameExcerpt === undefined && importPathExcerpt === undefined) {
         this._parserContext.log.addMessageForTokenSequence(
-          TSDocMessageId.DReferenceHashSyntax,
+          TSDocMessageId.ReferenceHashSyntax,
           'The hash character must be preceded by a package name or import path',
           importHashExcerpt, nodeForErrorContext);
         return undefined;
@@ -1126,7 +1126,7 @@ export class NodeParser {
     if (packageNameExcerpt === undefined && importPathExcerpt === undefined && memberReferences.length === 0) {
       // We didn't find any parts of a declaration reference
       this._parserContext.log.addMessageForTokenSequence(
-        TSDocMessageId.MissingDReference,
+        TSDocMessageId.MissingReference,
         'Expecting a declaration reference',
         tokenSequenceForErrorContext, nodeForErrorContext);
       return undefined;
@@ -1158,7 +1158,7 @@ export class NodeParser {
     if (expectingDot) {
       if (tokenReader.peekTokenKind() !== TokenKind.Period) {
         this._parserContext.log.addMessageForTokenSequence(
-          TSDocMessageId.DReferenceMissingDot,
+          TSDocMessageId.ReferenceMissingDot,
           'Expecting a period before the next component of a declaration reference',
           tokenSequenceForErrorContext, nodeForErrorContext);
         return undefined;
@@ -1206,7 +1206,7 @@ export class NodeParser {
         // It would be reasonable to make the parentheses optional, and we are contemplating simplifying the
         // notation in the future.  But for now the parentheses are required.
         this._parserContext.log.addMessageForTokenSequence(
-          TSDocMessageId.DReferenceSelectorMissingParens,
+          TSDocMessageId.ReferenceSelectorMissingParens,
           'Syntax error in declaration reference: the member selector must be enclosed in parentheses',
           parameters.colonExcerpt, nodeForErrorContext);
         return undefined;
@@ -1222,7 +1222,7 @@ export class NodeParser {
     } else {
       if (parameters.leftParenthesisExcerpt) {
         this._parserContext.log.addMessageForTokenSequence(
-          TSDocMessageId.DReferenceMissingColon,
+          TSDocMessageId.ReferenceMissingColon,
           'Expecting a colon after the identifier because the expression is in parentheses',
           parameters.leftParenthesisExcerpt, nodeForErrorContext);
         return undefined;
@@ -1233,7 +1233,7 @@ export class NodeParser {
     if (parameters.leftParenthesisExcerpt) {
       if (tokenReader.peekTokenKind() !== TokenKind.RightParenthesis) {
         this._parserContext.log.addMessageForTokenSequence(
-          TSDocMessageId.DReferenceMissingRightParen,
+          TSDocMessageId.ReferenceMissingRightParen,
           'Expecting a matching right parenthesis',
         parameters.leftParenthesisExcerpt, nodeForErrorContext);
         return undefined;
@@ -1269,7 +1269,7 @@ export class NodeParser {
 
     if (!declarationReference) {
       this._parserContext.log.addMessageForTokenSequence(
-        TSDocMessageId.DReferenceSymbolSyntax,
+        TSDocMessageId.ReferenceSymbolSyntax,
         'Missing declaration reference in symbol reference',
         leftBracketExcerpt, nodeForErrorContext);
 
@@ -1281,7 +1281,7 @@ export class NodeParser {
     // Read the "]"
     if (tokenReader.peekTokenKind() !== TokenKind.RightSquareBracket) {
       this._parserContext.log.addMessageForTokenSequence(
-        TSDocMessageId.DReferenceMissingRightBracket,
+        TSDocMessageId.ReferenceMissingRightBracket,
         'Missing closing square bracket for symbol reference',
         leftBracketExcerpt, nodeForErrorContext);
 
@@ -1319,7 +1319,7 @@ export class NodeParser {
       while (tokenReader.peekTokenKind() !== TokenKind.DoubleQuote) {
         if (tokenReader.peekTokenKind() === TokenKind.EndOfInput) {
           this._parserContext.log.addMessageForTokenSequence(
-            TSDocMessageId.DReferenceMissingQuote,
+            TSDocMessageId.ReferenceMissingQuote,
             'Unexpected end of input inside quoted member identifier',
             leftQuoteExcerpt, nodeForErrorContext);
           return undefined;
@@ -1330,7 +1330,7 @@ export class NodeParser {
 
       if (tokenReader.isAccumulatedSequenceEmpty()) {
         this._parserContext.log.addMessageForTokenSequence(
-          TSDocMessageId.DReferenceEmptyIdentifier,
+          TSDocMessageId.ReferenceEmptyIdentifier,
           'The quoted identifier cannot be empty',
           leftQuoteExcerpt, nodeForErrorContext);
         return undefined;
@@ -1368,7 +1368,7 @@ export class NodeParser {
 
       if (tokenReader.isAccumulatedSequenceEmpty()) {
         this._parserContext.log.addMessageForTokenSequence(
-          TSDocMessageId.DReferenceMissingIdentifier,
+          TSDocMessageId.ReferenceMissingIdentifier,
           'Syntax error in declaration reference: expecting a member identifier',
           tokenSequenceForErrorContext, nodeForErrorContext);
         return undefined;
@@ -1380,7 +1380,7 @@ export class NodeParser {
       const explanation: string | undefined = StringChecks.explainIfInvalidUnquotedIdentifier(identifier);
       if (explanation) {
         this._parserContext.log.addMessageForTokenSequence(
-          TSDocMessageId.DReferenceUnquotedIdentifier,
+          TSDocMessageId.ReferenceUnquotedIdentifier,
           explanation,
           identifierExcerpt, nodeForErrorContext);
         return undefined;
@@ -1402,7 +1402,7 @@ export class NodeParser {
 
     if (tokenReader.peekTokenKind() !== TokenKind.AsciiWord) {
       this._parserContext.log.addMessageForTokenSequence(
-        TSDocMessageId.DReferenceMissingLabel,
+        TSDocMessageId.ReferenceMissingLabel,
         'Expecting a selector label after the colon',
         tokenSequenceForErrorContext, nodeForErrorContext);
     }
@@ -1420,7 +1420,7 @@ export class NodeParser {
 
     if (docMemberSelector.errorMessage) {
       this._parserContext.log.addMessageForTokenSequence(
-        TSDocMessageId.DReferenceSelectorSyntax,
+        TSDocMessageId.ReferenceSelectorSyntax,
         docMemberSelector.errorMessage,
         selectorExcerpt, nodeForErrorContext);
       return undefined;

--- a/tsdoc/src/parser/ParserMessage.ts
+++ b/tsdoc/src/parser/ParserMessage.ts
@@ -1,11 +1,13 @@
 import { TextRange, ITextLocation } from './TextRange';
 import { TokenSequence } from './TokenSequence';
 import { DocNode } from '../nodes/DocNode';
+import { TSDocMessageId } from './TSDocMessageId';
 
 /**
  * Constructor parameters for {@link ParserMessage}.
  */
 export interface IParserMessageParameters {
+  messageId: TSDocMessageId;
   messageText: string;
   textRange: TextRange;
   tokenSequence?: TokenSequence;
@@ -16,6 +18,7 @@ export interface IParserMessageParameters {
  * Represents an error or warning that occurred during parsing.
  */
 export class ParserMessage {
+  public readonly messageId: TSDocMessageId;
 
   /**
    * The message text without the default prefix that shows line/column information.
@@ -54,6 +57,7 @@ export class ParserMessage {
   }
 
   public constructor(parameters: IParserMessageParameters) {
+    this.messageId = parameters.messageId;
     this.unformattedText = parameters.messageText;
     this.textRange = parameters.textRange;
     this.tokenSequence = parameters.tokenSequence;

--- a/tsdoc/src/parser/ParserMessageLog.ts
+++ b/tsdoc/src/parser/ParserMessageLog.ts
@@ -3,6 +3,7 @@ import { TextRange } from './TextRange';
 import { TokenSequence } from './TokenSequence';
 import { DocNode } from '../nodes/DocNode';
 import { DocErrorText } from '../nodes/DocErrorText';
+import { TSDocMessageId } from './TSDocMessageId';
 
 /**
  * Used to report errors and warnings that occurred during parsing.
@@ -27,8 +28,9 @@ export class ParserMessageLog {
   /**
    * Append a message associated with a TextRange.
    */
-  public addMessageForTextRange(messageText: string, textRange: TextRange): void {
+  public addMessageForTextRange(messageId: TSDocMessageId, messageText: string, textRange: TextRange): void {
     this.addMessage(new ParserMessage({
+      messageId,
       messageText,
       textRange
     }));
@@ -37,8 +39,10 @@ export class ParserMessageLog {
   /**
    * Append a message associated with a TokenSequence.
    */
-  public addMessageForTokenSequence(messageText: string, tokenSequence: TokenSequence, docNode?: DocNode): void {
+  public addMessageForTokenSequence(messageId: TSDocMessageId, messageText: string, tokenSequence: TokenSequence,
+    docNode?: DocNode): void {
     this.addMessage(new ParserMessage({
+      messageId,
       messageText,
       textRange: tokenSequence.getContainingTextRange(),
       tokenSequence,
@@ -62,6 +66,7 @@ export class ParserMessageLog {
     }
 
     this.addMessage(new ParserMessage({
+      messageId: docErrorText.messageId,
       messageText: docErrorText.errorMessage,
       textRange: tokenSequence.getContainingTextRange(),
       tokenSequence: tokenSequence,

--- a/tsdoc/src/parser/TSDocMessageId.ts
+++ b/tsdoc/src/parser/TSDocMessageId.ts
@@ -1,0 +1,328 @@
+
+/**
+ * Message IDs for messages rpoted by the TSDoc parser.
+ *
+ * @remarks
+ *
+ * These strings are possible values for the {@link ParserMessage.messageId} property.
+ * @public
+ */
+export const enum TSDocMessageId {
+  /**
+   * Expecting a `/**` comment.
+   * Unexpected end of input.
+   */
+  CommentNotFound = 'tsdoc-comment-not-found',
+
+  /**
+   * Expecting a leading `/**`
+   */
+  CommentOpeningDelimiterSyntax = 'tsdoc-comment-missing-opening-delimiter',
+
+  /**
+   * Unexpected end of input.
+   */
+  CommentMissingClosingDelimiter = 'tsdoc-comment-missing-closing-delimiter',
+
+  /**
+   * A doc comment cannot have more than one `@inheritDoc` tag
+   */
+  ExtraInheritDocTag = 'tsdoc-extra-inheritdoc-tag',
+
+  /**
+   * The `}` character should be escaped using a backslash to avoid confusion with a TSDoc inline tag.
+   */
+  EscapeRightBrace = 'tsdoc-escape-right-brace',
+
+  /**
+   * The `>` character should be escaped using a backslash to avoid confusion with an HTML tag.
+   */
+  EscapeGreaterThan = 'tsdoc-escape-greater-than',
+
+  /**
+   * The ___ block must include a deprecation message, e.g. describing the recommended alternative.
+   */
+  MissingDeprecationMessage = 'tsdoc-missing-deprecation-message',
+
+  /**
+   * A ___ block must not be used, because that content is provided by the `@inheritDoc` tag.
+   */
+  InheritDocIncompatibleTag = 'tsdoc-inheritdoc-incompatible-tag',
+
+  /**
+   * The summary section must not have any content, because that content is provided by the `@inheritDoc` tag.
+   */
+  InheritDocIncompatibleSummary = 'tsdoc-inheritdoc-incompatible-summary',
+
+  /**
+   * The TSDoc tag ___ is an inline tag; it must be enclosed in `{ }` braces.
+   */
+  InlineTagMissingBraces = 'tsdoc-inline-tag-missing-braces',
+
+  /**
+   * The TSDoc tag ___ is not an inline tag; it must not be enclosed in `{ }` braces.
+   */
+  TagShouldNotHaveBraces = 'tsdoc-tag-should-not-have-braces',
+
+  /**
+   * The TSDoc tag ___ is not supported by this tool.
+   */
+  UnsupportedTag = 'tsdoc-unsupported-tag',
+
+  /**
+   * The TSDoc tag ___ is not defined in this configuration.
+   */
+  UndefinedTag = 'tsdoc-undefined-tag',
+
+  /**
+   * The `@param` block should be followed by a parameter name.
+   */
+  ParamTagWithInvalidName = 'tsdoc-param-tag-with-invalid-name',
+
+  /**
+   * The `@param` block should be followed by a parameter name and then a hyphen.
+   */
+  ParamTagMissingHyphen = 'tsdoc-param-tag-missing-hyphen',
+
+  /**
+   * A backslash must precede another character that is being escaped.  OR
+   * A backslash can only be used to escape a punctuation character.
+   */
+  UnnecessaryBackslash = 'tsdoc-unnecessary-backslash',
+
+  /**
+   * Expecting a TSDoc tag starting with `@`.  OR
+   * Expecting a TSDoc tag starting with `{`.
+   */
+  MissingTag = 'tsdoc-missing-tag',
+
+  /**
+   * A TSDoc tag must be preceded by whitespace.
+   */
+  AtSignInWord = 'tsdoc-at-sign-in-word',
+
+  /**
+   * Expecting a TSDoc tag name after the `@` character (or use a backslash to escape this character).
+   */
+  AtSignWithoutTagName = 'tsdoc-at-sign-without-tag-name',
+
+  /**
+   * Expecting an inline TSDoc tag name immediately after `{@`.  OR
+   * Expecting a TSDoc inline tag name after the `{@` characters.
+   */
+  MalformedInlineTag = 'tsdoc-malformed-inline-tag',
+
+  /**
+   * A TSDoc tag name must start with a letter and contain only letters and numbers.
+   */
+  MalformedTagName = 'tsdoc-malformed-tag-name',
+
+  /**
+   * A TSDoc tag must be followed by whitespace.
+   */
+  TextAfterTag = 'tsdoc-text-after-tag',
+
+  /**
+   * The TSDoc inline tag name is missing its closing `}`.
+   */
+  InlineTagMissingRightBrace = 'tsdoc-inline-tag-missing-right-brace',
+
+  /**
+   * The `{` character must be escaped with a backslash when used inside a TSDoc inline tag.
+   */
+  InlineTagUnescapedBrace = 'tsdoc-inline-tag-unescaped-brace',
+
+  /**
+   * Unexpected character after declaration reference.
+   */
+  InheritDocTagSyntax = 'tsdoc-inheritdoc-tag-syntax',
+
+  /**
+   * The `@link` tag content is missing.
+   */
+  LinkTagEmpty = 'tsdoc-link-tag-empty',
+
+  /**
+   * The ___ character may not be used in the link text without escaping it.
+   */
+  LinkTagUnescapedText = 'tsdoc-link-tag-unescaped-text',
+
+  /**
+   * Unexpected character after link destination.
+   */
+  LinkTagDestinationSyntax = 'tsdoc-link-tag-destination-syntax',
+
+  /**
+   * The URL cannot be empty.  OR
+   * An `@link` URL must begin with a scheme comprised only of letters and numbers followed by `://`.  OR
+   * An `@link` URL must have at least one character after `://`.
+   */
+  LinkTagInvalidUrl = 'tsdoc-link-tag-invalid-url',
+
+  /**
+   * The declaration reference appears to contain a package name or import path, but it is missing the `#` delimiter.
+   */
+  DReferenceMissingHash = 'tsdoc-dreference-missing-hash',
+
+  /**
+   * The hash character must be preceded by a package name or import path.
+   */
+  DReferenceHashSyntax = 'tsdoc-dreference-hash-syntax',
+
+  /**
+   * The package name cannot be an empty string.  OR
+   * The package name ___ is not a valid package name.
+   */
+  DReferenceMalformedPackageName = 'tsdoc-dreference-malformed-package-name',
+
+  /**
+   * An import path must not contain `//`.  OR
+   * An import path must not end with `/`.  OR
+   * An import path must not start with `/` unless prefixed by a package name.
+   */
+  DReferenceMalformedImportPath = 'tsdoc-dreference-malformed-import-path',
+
+  /**
+   * Expecting a declaration reference.
+   */
+  MissingDReference = 'tsdoc-missing-dreference',
+
+  /**
+   * Expecting a period before the next component of a declaration reference
+   */
+  DReferenceMissingDot = 'tsdoc-dreference-missing-dot',
+
+  /**
+   * Syntax error in declaration reference: the member selector must be enclosed in parentheses.
+   */
+  DReferenceSelectorMissingParens = 'tsdoc-dreference-selector-missing-parens',
+
+  /**
+   * Expecting a colon after the identifier because the expression is in parentheses.
+   */
+  DReferenceMissingColon = 'tsdoc-dreference-missing-colon',
+
+  /**
+   * Expecting a matching right parenthesis.
+   */
+  DReferenceMissingRightParen = 'tsdoc-dreference-missing-right-paren',
+
+  /**
+   * Missing declaration reference in symbol reference
+   */
+  DReferenceSymbolSyntax = 'tsdoc-dreference-symbol-syntax',
+
+  /**
+   * Missing closing square bracket for symbol reference
+   */
+  DReferenceMissingRightBracket = 'tsdoc-dreference-missing-right-bracket',
+
+  /**
+   * Unexpected end of input inside quoted member identifier.
+   */
+  DReferenceMissingQuote = 'tsdoc-dreference-missing-quote',
+
+  /**
+   * The quoted identifier cannot be empty.
+   */
+  DReferenceEmptyIdentifier = 'tsdoc-dreference-empty-identifier',
+
+  /**
+   * Syntax error in declaration reference: expecting a member identifier.
+   */
+  DReferenceMissingIdentifier = 'tsdoc-dreference-missing-identifier',
+
+  /**
+   * The identifier cannot be an empty string. OR
+   * The identifier cannot non-word characters. OR
+   * The identifier must not start with a number. OR
+   * The identifier ___ must be quoted because it is a TSDoc system selector name.
+   */
+  DReferenceUnquotedIdentifier = 'tsdoc-dreference-unquoted-identifier',
+
+  /**
+   * Expecting a selector label after the colon.
+   */
+  DReferenceMissingLabel = 'tsdoc-dreference-missing-label',
+
+  /**
+   * The selector cannot be an empty string.  OR
+   * If the selector begins with a number, it must be a positive integer value.  OR
+   * A label selector must be comprised of upper case letters, numbers, and underscores
+   * and must not start with a number.  OR
+   * The selector ___ is not a recognized TSDoc system selector name.
+   */
+  DReferenceSelectorSyntax = 'tsdoc-dreference-selector-syntax',
+
+  /**
+   * Expecting an attribute or `>` or `/>`.
+   */
+  HtmlTagMissingGreaterThan = 'tsdoc-html-tag-missing-greater-than',
+
+  /**
+   * Expecting `=` after HTML attribute name.
+   */
+  HtmlTagMissingEquals = 'tsdoc-html-tag-missing-equals',
+
+  /**
+   * Expecting an HTML string starting with a single-quote or double-quote character.
+   */
+  HtmlTagMissingString = 'tsdoc-html-tag-missing-string',
+
+  /**
+   * The HTML string is missing its closing quote.
+   */
+  HtmlStringMissingQuote = 'tsdoc-html-string-missing-quote',
+
+  /**
+   * The next character after a closing quote must be spacing or punctuation.
+   */
+  TextAfterHtmlString = 'tsdoc-text-after-html-string',
+
+  /**
+   * Expecting an HTML tag starting with `</`.
+   */
+  MissingHtmlEndTag = 'tsdoc-missing-html-end-tag',
+
+  /**
+   * A space is not allowed here.  OR
+   * Expecting an HTML name.  OR
+   * An HTML name must be a sequence of letters separated by hyphens.
+   */
+  MalformedHtmlName = 'tsdoc-malformed-html-name',
+
+  /**
+   * The opening backtick for a code fence must appear at the start of the line.
+   */
+  CodeFenceOpeningIndent = 'tsdoc-code-fence-opening-indent',
+
+  /**
+   * The language specifier cannot contain backtick characters.
+   */
+  CodeFenceSpecifierSyntax = 'tsdoc-code-fence-specifier-syntax',
+
+  /**
+   * The closing delimiter for a code fence must not be indented.
+   */
+  CodeFenceClosingIndent = 'tsdoc-code-fence-closing-indent',
+
+  /**
+   * Missing closing delimiter.
+   */
+  CodeFenceMissingDelimiter = 'tsdoc-code-fence-missing-delimiter',
+
+  /**
+   * Unexpected characters after closing delimiter for code fence.
+   */
+  CodeFenceClosingSyntax = 'tsdoc-code-fence-closing-syntax',
+
+  /**
+   * A code span must contain at least one character between the backticks.
+   */
+  CodeSpanEmpty = 'tsdoc-code-span-empty',
+
+  /**
+   * The code span is missing its closing backtick.
+   */
+  CodeSpanMissingDelimiter = 'tsdoc-code-span-missing-delimiter'
+}

--- a/tsdoc/src/parser/TSDocMessageId.ts
+++ b/tsdoc/src/parser/TSDocMessageId.ts
@@ -162,75 +162,75 @@ export const enum TSDocMessageId {
   /**
    * The declaration reference appears to contain a package name or import path, but it is missing the `#` delimiter.
    */
-  DReferenceMissingHash = 'tsdoc-dreference-missing-hash',
+  ReferenceMissingHash = 'tsdoc-reference-missing-hash',
 
   /**
    * The hash character must be preceded by a package name or import path.
    */
-  DReferenceHashSyntax = 'tsdoc-dreference-hash-syntax',
+  ReferenceHashSyntax = 'tsdoc-reference-hash-syntax',
 
   /**
    * The package name cannot be an empty string.  OR
    * The package name ___ is not a valid package name.
    */
-  DReferenceMalformedPackageName = 'tsdoc-dreference-malformed-package-name',
+  ReferenceMalformedPackageName = 'tsdoc-reference-malformed-package-name',
 
   /**
    * An import path must not contain `//`.  OR
    * An import path must not end with `/`.  OR
    * An import path must not start with `/` unless prefixed by a package name.
    */
-  DReferenceMalformedImportPath = 'tsdoc-dreference-malformed-import-path',
+  ReferenceMalformedImportPath = 'tsdoc-reference-malformed-import-path',
 
   /**
    * Expecting a declaration reference.
    */
-  MissingDReference = 'tsdoc-missing-dreference',
+  MissingReference = 'tsdoc-missing-reference',
 
   /**
    * Expecting a period before the next component of a declaration reference
    */
-  DReferenceMissingDot = 'tsdoc-dreference-missing-dot',
+  ReferenceMissingDot = 'tsdoc-reference-missing-dot',
 
   /**
    * Syntax error in declaration reference: the member selector must be enclosed in parentheses.
    */
-  DReferenceSelectorMissingParens = 'tsdoc-dreference-selector-missing-parens',
+  ReferenceSelectorMissingParens = 'tsdoc-reference-selector-missing-parens',
 
   /**
    * Expecting a colon after the identifier because the expression is in parentheses.
    */
-  DReferenceMissingColon = 'tsdoc-dreference-missing-colon',
+  ReferenceMissingColon = 'tsdoc-reference-missing-colon',
 
   /**
    * Expecting a matching right parenthesis.
    */
-  DReferenceMissingRightParen = 'tsdoc-dreference-missing-right-paren',
+  ReferenceMissingRightParen = 'tsdoc-reference-missing-right-paren',
 
   /**
    * Missing declaration reference in symbol reference
    */
-  DReferenceSymbolSyntax = 'tsdoc-dreference-symbol-syntax',
+  ReferenceSymbolSyntax = 'tsdoc-reference-symbol-syntax',
 
   /**
    * Missing closing square bracket for symbol reference
    */
-  DReferenceMissingRightBracket = 'tsdoc-dreference-missing-right-bracket',
+  ReferenceMissingRightBracket = 'tsdoc-reference-missing-right-bracket',
 
   /**
    * Unexpected end of input inside quoted member identifier.
    */
-  DReferenceMissingQuote = 'tsdoc-dreference-missing-quote',
+  ReferenceMissingQuote = 'tsdoc-reference-missing-quote',
 
   /**
    * The quoted identifier cannot be empty.
    */
-  DReferenceEmptyIdentifier = 'tsdoc-dreference-empty-identifier',
+  ReferenceEmptyIdentifier = 'tsdoc-reference-empty-identifier',
 
   /**
    * Syntax error in declaration reference: expecting a member identifier.
    */
-  DReferenceMissingIdentifier = 'tsdoc-dreference-missing-identifier',
+  ReferenceMissingIdentifier = 'tsdoc-reference-missing-identifier',
 
   /**
    * The identifier cannot be an empty string. OR
@@ -238,12 +238,12 @@ export const enum TSDocMessageId {
    * The identifier must not start with a number. OR
    * The identifier ___ must be quoted because it is a TSDoc system selector name.
    */
-  DReferenceUnquotedIdentifier = 'tsdoc-dreference-unquoted-identifier',
+  ReferenceUnquotedIdentifier = 'tsdoc-reference-unquoted-identifier',
 
   /**
    * Expecting a selector label after the colon.
    */
-  DReferenceMissingLabel = 'tsdoc-dreference-missing-label',
+  ReferenceMissingLabel = 'tsdoc-reference-missing-label',
 
   /**
    * The selector cannot be an empty string.  OR
@@ -252,7 +252,7 @@ export const enum TSDocMessageId {
    * and must not start with a number.  OR
    * The selector ___ is not a recognized TSDoc system selector name.
    */
-  DReferenceSelectorSyntax = 'tsdoc-dreference-selector-syntax',
+  ReferenceSelectorSyntax = 'tsdoc-reference-selector-syntax',
 
   /**
    * Expecting an attribute or `>` or `/>`.


### PR DESCRIPTION
This PR annotates every parser error message with a unique ID string.  Some examples from the `TSDocMessageId` enum:

```ts
  /**
   * A ___ block must not be used, because that content is provided by the `@inheritDoc` tag.
   */
  InheritDocIncompatibleTag = 'tsdoc-inheritdoc-incompatible-tag',

  /**
   * The summary section must not have any content, because that content is provided by the `@inheritDoc` tag.
   */
  InheritDocIncompatibleSummary = 'tsdoc-inheritdoc-incompatible-summary',

  /**
   * The TSDoc tag ___ is an inline tag; it must be enclosed in `{ }` braces.
   */
  InlineTagMissingBraces = 'tsdoc-inline-tag-missing-braces',

  /**
   * The TSDoc tag ___ is not an inline tag; it must not be enclosed in `{ }` braces.
   */
  TagShouldNotHaveBraces = 'tsdoc-tag-should-not-have-braces',
```

Tools can use these IDs to allow parser checks to be selectively suppressed.  They can also be included in error messages, to make it easier to Google for information about particular errors.

### Questions to consider for this review
1. Do the enum ID strings make sense, and is the naming consistent across the various error messages?
2. Should any of the IDs be merged (because their differences would never be interesting)?
3. Is TSDocMessageId a good name for the enum itself?
