### PR TITLE
Remove invalid label from interface member

### DIFF
--- a/spec/code-snippets/DeclarationReferences.ts
+++ b/spec/code-snippets/DeclarationReferences.ts
@@ -385,7 +385,7 @@ export class ClassI1 {
 export interface InterfaceJ1 {
   /**
    * Shortest name:  {@link InterfaceJ1."abc. def"}
-   * Full name:      {@link (InterfaceJ1:interface).("abc. def":static)}
+   * Full name:      {@link (InterfaceJ1:interface)."abc. def"}
    */
   'abc. def': string;
 


### PR DESCRIPTION
I can't run Rush as instructed due to my environment (Node & Python are both to new), but as far as I can tell the effected file isn't used anywhere, so nothing should be changed.

Ref: https://github.com/microsoft/tsdoc/issues/9#issuecomment-492011725