### PR TITLE
Add a definition for the `@throws` block tag

### DIFF
--- a/common/changes/@microsoft/tsdoc/octogonz-throws-tag_2019-07-30-05-42.json
+++ b/common/changes/@microsoft/tsdoc/octogonz-throws-tag_2019-07-30-05-42.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/tsdoc",
+      "comment": "Add a definition for the `@throws` block tag (RFC 171)",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@microsoft/tsdoc",
+  "email": "4673363+octogonz@users.noreply.github.com"
+}

--- a/tsdoc/src/details/StandardTags.ts
+++ b/tsdoc/src/details/StandardTags.ts
@@ -317,6 +317,44 @@ export class StandardTags {
   });
 
   /**
+   * (Extended)
+   *
+   * Used to document an exception type that may be thrown by a function or property.
+   *
+   * @remarks
+   *
+   * A separate `@throws` block should be used to document each exception type.  This tag is for informational
+   * purposes only, and does not restrict other types from being thrown.  It is suggested, but not required,
+   * for the `@throws` block to start with a line containing only the name of the exception.
+   *
+   * For example:
+   *
+   * ```ts
+   * /**
+   *  * Retrieves metadata about a book from the catalog.
+   *  *
+   *  * @param isbnCode - the ISBN number for the book
+   *  * @returns the retrieved book
+   *  *
+   *  * @throws {@link IsbnSyntaxError}
+   *  * Thrown if the input is not a valid ISBN number.
+   *  *
+   *  * @throws {@link BookNotFound}
+   *  * Thrown if the ISBN number is valid, but no such book was found.
+   *  *
+   *  * @public
+   *  &#42;/
+   * function fetchBookByIsbn(isbnCode: string): Book;
+   * ```
+   */
+  public static readonly throws: TSDocTagDefinition = StandardTags._defineTag({
+    tagName: '@throws',
+    syntaxKind: TSDocTagSyntaxKind.BlockTag,
+    allowMultiple: true,
+    standardization: Standardization.Extended
+  });
+
+  /**
    * (Core)
    *
    * Used to document a generic parameter.  The `@typeParam` tag is followed by a parameter
@@ -370,6 +408,7 @@ export class StandardTags {
     StandardTags.remarks,
     StandardTags.returns,
     StandardTags.sealed,
+    StandardTags.throws,
     StandardTags.typeParam,
     StandardTags.virtual
   ];

--- a/tsdoc/src/details/StandardTags.ts
+++ b/tsdoc/src/details/StandardTags.ts
@@ -334,13 +334,13 @@ export class StandardTags {
    *  * Retrieves metadata about a book from the catalog.
    *  *
    *  * @param isbnCode - the ISBN number for the book
-   *  * @returns the retrieved book
+   *  * @returns the retrieved book object
    *  *
    *  * @throws {@link IsbnSyntaxError}
-   *  * Thrown if the input is not a valid ISBN number.
+   *  * This exception is thrown if the input is not a valid ISBN number.
    *  *
-   *  * @throws {@link BookNotFound}
-   *  * Thrown if the ISBN number is valid, but no such book was found.
+   *  * @throws {@link book-lib#BookNotFoundError}
+   *  * Thrown if the ISBN number is valid, but no such book exists in the catalog.
    *  *
    *  * @public
    *  &#42;/


### PR DESCRIPTION
Add the `@throws` tag as discussed in [RFC 171](https://github.com/microsoft/tsdoc/issues/171)

Example syntax:
```ts
   /**
    * Retrieves metadata about a book from the catalog.
    *    
    * @param isbnCode - the ISBN number for the book
    * @returns the retrieved book object
    *
    * @throws {@link IsbnSyntaxError}
    * This exception is thrown if the input is not a valid ISBN number.
    *
    * @throws {@link book-lib#BookNotFoundError}
    * Thrown if the ISBN number is valid, but no such book exists in the catalog.
    *
    * @public
    */
    function fetchBookByIsbn(isbnCode: string): Book;
```

@aciccarello FYI