### PR TITLE
Improve parse for module sources

### DIFF
--- a/common/changes/@microsoft/tsdoc/declarationReferenceUpdate3_2019-08-02-22-40.json
+++ b/common/changes/@microsoft/tsdoc/declarationReferenceUpdate3_2019-08-02-22-40.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/tsdoc",
+      "comment": "Improve DeclarationReference.parse for module sources",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@microsoft/tsdoc",
+  "email": "ron.buckton@microsoft.com"
+}

--- a/tsdoc/src/beta/DeclarationReference.grammarkdown
+++ b/tsdoc/src/beta/DeclarationReference.grammarkdown
@@ -42,7 +42,7 @@ Punctuator:: one of
   `{` `}` `(` `)` `[` `]` `!` `.` `#` `~` `:` `,`
 
 FutureReservedPunctuator:: one of
-  `{` `}`
+  `{` `}` `@`
 
 NavigationPunctuator: one of
   `.`                                           // Navigate via 'exports' of symbol
@@ -107,6 +107,17 @@ Hex4Digits::
 CodePoint::
   > |HexDigits| but only if MV of |HexDigits| ≤ 0x10FFFF
 
+// Represents the path for a module
+ModuleSource::
+  String
+  ModuleSourceCharacters
+
+ModuleSourceCharacters::
+  ModuleSourceCharacter ModuleSourceCharacters?
+
+ModuleSourceCharacter::
+  SourceCharacter but not one of `"` or `!` or LineTerminator
+
 Component::
   String
   ComponentCharacters
@@ -130,12 +141,8 @@ DeclarationReference:
   SymbolReference                               // Shorthand reference to symbol
   ModuleSource `!`                              // Reference to a module
   ModuleSource `!` SymbolReference              // Reference to an export of a module
-  ModuleSource `|` `~` SymbolReference          // Reference to a local of a module
+  ModuleSource `!` `~` SymbolReference          // Reference to a local of a module
   `!` SymbolReference                           // Reference to global symbol
-
-// Represents the path for a module
-ModuleSource:
-  Component
 
 SymbolReference:
   ComponentPath Meaning?

--- a/tsdoc/src/beta/__tests__/DeclarationReference.test.ts
+++ b/tsdoc/src/beta/__tests__/DeclarationReference.test.ts
@@ -32,47 +32,62 @@ describe('parser', () => {
     expect(ref.symbol!.componentPath).toBeDefined();
     expect(ref.symbol!.componentPath!.component.toString()).toBe('[abc.[def]]');
   });
-  it('parse module source', () => {
-    const ref: DeclarationReference = DeclarationReference.parse('abc!');
+  it.each`
+    text                                      | path                                    | navigation   | symbol
+    ${'abc!'}                                 | ${'abc'}                                | ${undefined} | ${undefined}
+    ${'"abc"!'}                               | ${'"abc"'}                              | ${undefined} | ${undefined}
+    ${'@microsoft/rush-stack-compiler-3.5!'}  | ${'@microsoft/rush-stack-compiler-3.5'} | ${undefined} | ${undefined}
+    ${'abc!def'}                              | ${'abc'}                                | ${'.'}       | ${'def'}
+    ${'abc!~def'}                             | ${'abc'}                                | ${'~'}       | ${'def'}
+  `('parse module source $text', ({ text, path, navigation, symbol }) => {
+    const ref: DeclarationReference = DeclarationReference.parse(text);
     expect(ref.source).toBeInstanceOf(ModuleSource);
-    expect(ref.symbol).toBeUndefined();
-    expect((ref.source as ModuleSource).path).toBe('abc');
+    expect((ref.source as ModuleSource).escapedPath).toBe(path);
+    expect(ref.navigation).toBe(navigation);
+    if (symbol) {
+      expect(ref.symbol).toBeInstanceOf(SymbolReference);
+      expect(ref.symbol!.componentPath).toBeDefined();
+      expect(ref.symbol!.componentPath!.component.toString()).toBe(symbol);
+    } else {
+      expect(ref.symbol).toBeUndefined();
+    }
   });
-  it('parse global source', () => {
-    const ref: DeclarationReference = DeclarationReference.parse('!abc');
+  it.each`
+    text      | symbol
+    ${'!abc'} | ${'abc'}
+  `('parse global source $text', ({ text, symbol }) => {
+    const ref: DeclarationReference = DeclarationReference.parse(text);
     expect(ref.source).toBe(GlobalSource.instance);
     expect(ref.symbol).toBeInstanceOf(SymbolReference);
     expect(ref.symbol!.componentPath).toBeDefined();
-    expect(ref.symbol!.componentPath!.component.toString()).toBe('abc');
+    expect(ref.symbol!.componentPath!.component.toString()).toBe(symbol);
   });
-  const meanings: Meaning[] = [
-    Meaning.Class,
-    Meaning.Interface,
-    Meaning.TypeAlias,
-    Meaning.Enum,
-    Meaning.Namespace,
-    Meaning.Function,
-    Meaning.Variable,
-    Meaning.Constructor,
-    Meaning.Member,
-    Meaning.Event,
-    Meaning.CallSignature,
-    Meaning.ConstructSignature,
-    Meaning.IndexSignature,
-    Meaning.ComplexType
-  ];
-  for (const s of meanings) {
-    it(`parse meaning ':${s}'`, () => {
-      const ref: DeclarationReference = DeclarationReference.parse(`a:${s}`);
-      expect(ref.symbol!.meaning).toBe(s);
-    });
-  }
+  it.each`
+    text                | meaning
+    ${'a:class'}        | ${Meaning.Class}
+    ${'a:interface'}    | ${Meaning.Interface}
+    ${'a:type'}         | ${Meaning.TypeAlias}
+    ${'a:enum'}         | ${Meaning.Enum}
+    ${'a:namespace'}    | ${Meaning.Namespace}
+    ${'a:function'}     | ${Meaning.Function}
+    ${'a:var'}          | ${Meaning.Variable}
+    ${'a:constructor'}  | ${Meaning.Constructor}
+    ${'a:member'}       | ${Meaning.Member}
+    ${'a:event'}        | ${Meaning.Event}
+    ${'a:call'}         | ${Meaning.CallSignature}
+    ${'a:new'}          | ${Meaning.ConstructSignature}
+    ${'a:index'}        | ${Meaning.IndexSignature}
+    ${'a:complex'}      | ${Meaning.ComplexType}
+  `('parse meaning $meaning', ({ text, meaning }) => {
+    const ref: DeclarationReference = DeclarationReference.parse(text);
+    expect(ref.symbol!.meaning).toBe(meaning);
+  });
   it('parse complex', () => {
     const ref: DeclarationReference = DeclarationReference.parse('foo/bar!N.C#z:member(1)');
 
     const source: ModuleSource = ref.source as ModuleSource;
     expect(source).toBeInstanceOf(ModuleSource);
-    expect(source.path).toBe('foo/bar');
+    expect(source.escapedPath).toBe('foo/bar');
 
     expect(ref.navigation).toBe(Navigation.Exports);
 
@@ -97,6 +112,11 @@ describe('parser', () => {
 
     expect(ref.toString()).toBe('foo/bar!N.C#z:member(1)');
   });
+  it('parse invalid module reference', () => {
+    expect(() => {
+      DeclarationReference.parse('@scope/foo');
+    }).toThrow();
+  });
 });
 it('add navigation step', () => {
   const ref: DeclarationReference = DeclarationReference.empty()
@@ -105,4 +125,204 @@ it('add navigation step', () => {
   expect(symbol).toBeInstanceOf(SymbolReference);
   expect(symbol.componentPath).toBeDefined();
   expect(symbol.componentPath!.component.toString()).toBe('[Symbol.iterator]');
+});
+describe('DeclarationReference', () => {
+  it.each`
+    text            | expected
+    ${''}           | ${true}
+    ${'a'}          | ${true}
+    ${'a.b'}        | ${false}
+    ${'a~b'}        | ${false}
+    ${'a#b'}        | ${false}
+    ${'a:class'}    | ${false}
+    ${'a!'}         | ${false}
+    ${'@a'}         | ${false}
+    ${'a@'}         | ${false}
+    ${'['}          | ${false}
+    ${']'}          | ${false}
+    ${'{'}          | ${false}
+    ${'}'}          | ${false}
+    ${'('}          | ${false}
+    ${')'}          | ${false}
+    ${'[a]'}        | ${false}
+    ${'[a.b]'}      | ${false}
+    ${'[a!b]'}      | ${false}
+    ${'""'}         | ${true}
+    ${'"a"'}        | ${true}
+    ${'"a.b"'}      | ${true}
+    ${'"a~b"'}      | ${true}
+    ${'"a#b"'}      | ${true}
+    ${'"a:class"'}  | ${true}
+    ${'"a!"'}       | ${true}
+    ${'"@a"'}       | ${true}
+    ${'"a@"'}       | ${true}
+    ${'"["'}        | ${true}
+    ${'"]"'}        | ${true}
+    ${'"{"'}        | ${true}
+    ${'"}"'}        | ${true}
+    ${'"("'}        | ${true}
+    ${'")"'}        | ${true}
+  `('isWellFormedComponentString($text)', ({ text, expected }) => {
+    expect(DeclarationReference.isWellFormedComponentString(text)).toBe(expected);
+  });
+  it.each`
+    text            | expected
+    ${''}           | ${'""'}
+    ${'a'}          | ${'a'}
+    ${'a.b'}        | ${'"a.b"'}
+    ${'a~b'}        | ${'"a~b"'}
+    ${'a#b'}        | ${'"a#b"'}
+    ${'a:class'}    | ${'"a:class"'}
+    ${'a!'}         | ${'"a!"'}
+    ${'@a'}         | ${'"@a"'}
+    ${'a@'}         | ${'"a@"'}
+    ${'['}          | ${'"["'}
+    ${']'}          | ${'"]"'}
+    ${'{'}          | ${'"{"'}
+    ${'}'}          | ${'"}"'}
+    ${'('}          | ${'"("'}
+    ${')'}          | ${'")"'}
+    ${'[a]'}        | ${'"[a]"'}
+    ${'[a.b]'}      | ${'"[a.b]"'}
+    ${'[a!b]'}      | ${'"[a!b]"'}
+    ${'""'}         | ${'"\\\"\\\""'}
+    ${'"a"'}        | ${'"\\\"a\\\""'}
+  `('escapeComponentString($text)', ({ text, expected }) => {
+    expect(DeclarationReference.escapeComponentString(text)).toBe(expected);
+  });
+  it.each`
+    text              | expected
+    ${''}             | ${''}
+    ${'""'}           | ${''}
+    ${'a'}            | ${'a'}
+    ${'"a"'}          | ${'a'}
+    ${'"a.b"'}        | ${'a.b'}
+    ${'"\\"\\""'}     | ${'""'}
+    ${'"\\"a\\""'}    | ${'"a"'}
+  `('unescapeComponentString($text)', ({ text, expected }) => {
+    if (expected === undefined) {
+      expect(() => DeclarationReference.unescapeComponentString(text)).toThrow();
+    } else {
+      expect(DeclarationReference.unescapeComponentString(text)).toBe(expected);
+    }
+  });
+  it.each`
+    text            | expected
+    ${''}           | ${false}
+    ${'a'}          | ${true}
+    ${'a.b'}        | ${true}
+    ${'a~b'}        | ${true}
+    ${'a#b'}        | ${true}
+    ${'a:class'}    | ${true}
+    ${'a!'}         | ${false}
+    ${'@a'}         | ${true}
+    ${'a@'}         | ${true}
+    ${'['}          | ${true}
+    ${']'}          | ${true}
+    ${'{'}          | ${true}
+    ${'}'}          | ${true}
+    ${'('}          | ${true}
+    ${')'}          | ${true}
+    ${'[a]'}        | ${true}
+    ${'[a.b]'}      | ${true}
+    ${'[a!b]'}      | ${false}
+    ${'""'}         | ${true}
+    ${'"a"'}        | ${true}
+    ${'"a.b"'}      | ${true}
+    ${'"a~b"'}      | ${true}
+    ${'"a#b"'}      | ${true}
+    ${'"a:class"'}  | ${true}
+    ${'"a!"'}       | ${true}
+    ${'"@a"'}       | ${true}
+    ${'"a@"'}       | ${true}
+    ${'"["'}        | ${true}
+    ${'"]"'}        | ${true}
+    ${'"{"'}        | ${true}
+    ${'"}"'}        | ${true}
+    ${'"("'}        | ${true}
+    ${'")"'}        | ${true}
+    ${'"[a!b]"'}    | ${true}
+  `('isWellFormedModuleSourceString($text)', ({ text, expected }) => {
+    expect(DeclarationReference.isWellFormedModuleSourceString(text)).toBe(expected);
+  });
+  it.each`
+    text            | expected
+    ${''}           | ${'""'}
+    ${'a'}          | ${'a'}
+    ${'a.b'}        | ${'a.b'}
+    ${'a~b'}        | ${'a~b'}
+    ${'a#b'}        | ${'a#b'}
+    ${'a:class'}    | ${'a:class'}
+    ${'a!'}         | ${'"a!"'}
+    ${'@a'}         | ${'@a'}
+    ${'a@'}         | ${'a@'}
+    ${'['}          | ${'['}
+    ${']'}          | ${']'}
+    ${'{'}          | ${'{'}
+    ${'}'}          | ${'}'}
+    ${'('}          | ${'('}
+    ${')'}          | ${')'}
+    ${'[a]'}        | ${'[a]'}
+    ${'[a.b]'}      | ${'[a.b]'}
+    ${'[a!b]'}      | ${'"[a!b]"'}
+    ${'""'}         | ${'"\\\"\\\""'}
+    ${'"a"'}        | ${'"\\\"a\\\""'}
+  `('escapeModuleSourceString($text)', ({ text, expected }) => {
+    expect(DeclarationReference.escapeModuleSourceString(text)).toBe(expected);
+  });
+  it.each`
+    text              | expected
+    ${''}             | ${undefined}
+    ${'""'}           | ${''}
+    ${'a'}            | ${'a'}
+    ${'"a"'}          | ${'a'}
+    ${'"a!"'}         | ${'a!'}
+    ${'"a.b"'}        | ${'a.b'}
+    ${'"\\"\\""'}     | ${'""'}
+    ${'"\\"a\\""'}    | ${'"a"'}
+  `('unescapeModuleSourceString($text)', ({ text, expected }) => {
+    if (expected === undefined) {
+      expect(() => DeclarationReference.unescapeModuleSourceString(text)).toThrow();
+    } else {
+      expect(DeclarationReference.unescapeModuleSourceString(text)).toBe(expected);
+    }
+  });
+});
+describe('ModuleSource', () => {
+  it.each`
+    text        | packageName | scopeName | unscopedPackageName | importPath
+    ${'a'}      | ${'a'}      | ${''}     | ${'a'}              | ${''}
+    ${'a/b'}    | ${'a'}      | ${''}     | ${'a'}              | ${'b'}
+    ${'@a/b'}   | ${'@a/b'}   | ${'@a'}   | ${'b'}              | ${''}
+    ${'@a/b/c'} | ${'@a/b'}   | ${'@a'}   | ${'b'}              | ${'c'}
+  `('package parts of $text', ({ text, packageName, scopeName, unscopedPackageName, importPath }) => {
+    const source: ModuleSource = new ModuleSource(text);
+    expect(source.packageName).toBe(packageName);
+    expect(source.scopeName).toBe(scopeName);
+    expect(source.unscopedPackageName).toBe(unscopedPackageName);
+    expect(source.importPath).toBe(importPath);
+  });
+  it.each`
+    packageName | importPath    | text
+    ${'a'}      | ${undefined}  | ${'a'}
+    ${'a'}      | ${'b'}        | ${'a/b'}
+    ${'@a/b'}   | ${undefined}  | ${'@a/b'}
+    ${'@a/b'}   | ${'c'}        | ${'@a/b/c'}
+  `('fromPackage($packageName, $importPath)', ({ packageName, importPath, text }) => {
+    const source: ModuleSource = ModuleSource.fromPackage(packageName, importPath);
+    expect(source.path).toBe(text);
+  });
+  it.each`
+    scopeName | unscopedPackageName | importPath    | text
+    ${''}     | ${'a'}              | ${undefined}  | ${'a'}
+    ${''}     | ${'a'}              | ${'b'}        | ${'a/b'}
+    ${'a'}    | ${'b'}              | ${undefined}  | ${'@a/b'}
+    ${'@a'}   | ${'b'}              | ${undefined}  | ${'@a/b'}
+    ${'a'}    | ${'b'}              | ${'c'}        | ${'@a/b/c'}
+    ${'@a'}   | ${'b'}              | ${'c'}        | ${'@a/b/c'}
+  `('fromScopedPackage($scopeName, $unscopedPackageName, $importPath)',
+    ({ scopeName, unscopedPackageName, importPath, text }) => {
+    const source: ModuleSource = ModuleSource.fromScopedPackage(scopeName, unscopedPackageName, importPath);
+    expect(source.path).toBe(text);
+  });
 });


### PR DESCRIPTION
This changes the parsing behavior of `DeclarationReference.parse` when parsing module sources and components:

- `@` is not allowed in an un-quoted symbol component (i.e. `@a` is not valid, but `"@a"` is).
- `@microsoft/rush-stack-compiler-3.5` will throw, as `@` and `5` are not valid identifiers and there is no trailing `!` token.
  - NOTE: While we could detect the leading `@` and treat it as a path, I believe it is better to be unambiguous. An `@` is only allowed if we scan ahead and find a `!` token.
- `@microsoft/rush-stack-compiler-3.5!` *will* parse with a module source of `@microsoft/rush-stack-compiler-3.5` as we will scan ahead and find the `!` token.
- If for some reason a module source includes a `!` token in its text, the module source must be quoted (i.e. `a!b!c` is an error, but `"a!b"!c` is valid, with `"a!b"` as the module source).

Also there are a few additional changes to make the API easier to use:

- `DeclarationReference.isWellFormedModuleSourceString(text)` - Returns whether the text is a valid module source.
- `DeclarationReference.escapeModuleSourceString(text)` - Surrounds a module source in quotemarks if it is not well-formed. 
- `DeclarationReference.unescapeModuleSourceString(text)` - Unquotes a module source if necessary.
- `ModuleSource#escapedPath` - Preserves the module source as written (including quotemarks). This was previously the value for `ModuleSource#path`
- `ModuleSource#path` - The unescaped module source.
- `ModuleSource#scopeName` - The scope name for the module, if it has one. Includes the leading `@`.
- `ModuleSource#unscopedPackageName` - The package name excluding the scope name.
- `ModuleSource.fromScopedPacage(scopeName, unscopedPackageName, importPath)` - Create a module source from a scope.

I've also added several suites of tests for various behaviors.

Fixes #174 