### PR TITLE
Fix issue with ESLint command on Mac

### DIFF
--- a/api-demo/build.js
+++ b/api-demo/build.js
@@ -18,7 +18,7 @@ try {
 
   console.log('-- ESLINT --\n');
   child_process.execSync(path.join(baseDir, 'node_modules/.bin/eslint')
-    + ' -f unix src/**/*.{ts,tsx}',
+    + ' -f unix \"src/**/*.{ts,tsx}\"',
     { stdio: 'inherit' });
 
   process.exitCode = 0;

--- a/api-demo/package.json
+++ b/api-demo/package.json
@@ -19,6 +19,6 @@
     "build": "node ./build.js",
     "simple": "node ./lib/start.js simple",
     "advanced": "node ./lib/start.js advanced",
-    "lint": "eslint -f unix src/**/*.{ts,tsx}"
+    "lint": "eslint -f unix \"src/**/*.{ts,tsx}\""
   }
 }

--- a/common/changes/@microsoft/tsdoc/octogonz-fix-eslint-cli_2019-10-22-22-32.json
+++ b/common/changes/@microsoft/tsdoc/octogonz-fix-eslint-cli_2019-10-22-22-32.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "comment": "",
+      "packageName": "@microsoft/tsdoc",
+      "type": "none"
+    }
+  ],
+  "packageName": "@microsoft/tsdoc",
+  "email": "4673363+octogonz@users.noreply.github.com"
+}

--- a/playground/package.json
+++ b/playground/package.json
@@ -6,7 +6,7 @@
   "license": "MIT",
   "scripts": {
     "build": "node build.js --production",
-    "lint": "eslint -f unix src/**/*.{ts,tsx}",
+    "lint": "eslint -f unix \"src/**/*.{ts,tsx}\"",
     "start": "node node_modules/webpack-dev-server/bin/webpack-dev-server --config webpack.dev.config.js --open"
   },
   "dependencies": {

--- a/tsdoc/build.js
+++ b/tsdoc/build.js
@@ -18,7 +18,7 @@ try {
 
   console.log('-- ESLINT --\n');
   child_process.execSync(path.join(baseDir, 'node_modules/.bin/eslint')
-    + ' -f unix src/**/*.{ts,tsx}',
+    + ' -f unix \"src/**/*.{ts,tsx}\"',
     { stdio: 'inherit' });
 
   if (production) {

--- a/tsdoc/package.json
+++ b/tsdoc/package.json
@@ -34,7 +34,7 @@
     "build": "node ./build.js",
     "test": "jest",
     "watch": "jest --watch",
-    "lint": "eslint -f unix src/**/*.{ts,tsx}"
+    "lint": "eslint -f unix \"src/**/*.{ts,tsx}\""
   },
   "jest": {
     "moduleFileExtensions": [


### PR DESCRIPTION
The Unix shell expands `src/**/*.{ts,tsx}` whereas the Windows shell does not.

@jackfreelanderhbo