### PR TITLE
Flexible parsing of param/typeParam

### DIFF
--- a/common/changes/@microsoft/tsdoc/flexibleParamParsing_2019-12-20-01-20.json
+++ b/common/changes/@microsoft/tsdoc/flexibleParamParsing_2019-12-20-01-20.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/tsdoc",
+      "comment": "Improve parse for param/typeParam",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@microsoft/tsdoc",
+  "email": "ron.buckton@microsoft.com"
+}

--- a/common/changes/@microsoft/tsdoc/flexibleParamParsing_2019-12-20-01-20.json
+++ b/common/changes/@microsoft/tsdoc/flexibleParamParsing_2019-12-20-01-20.json
@@ -2,8 +2,8 @@
   "changes": [
     {
       "packageName": "@microsoft/tsdoc",
-      "comment": "Improve parse for param/typeParam",
-      "type": "minor"
+      "comment": "Improve the parsing of `@param` and `@typeParam` tags to recognize legacy syntaxes",
+      "type": "patch"
     }
   ],
   "packageName": "@microsoft/tsdoc",

--- a/common/changes/@microsoft/tsdoc/flexibleParamParsing_2019-12-20-01-20.json
+++ b/common/changes/@microsoft/tsdoc/flexibleParamParsing_2019-12-20-01-20.json
@@ -3,7 +3,7 @@
     {
       "packageName": "@microsoft/tsdoc",
       "comment": "Improve parse for param/typeParam",
-      "type": "patch"
+      "type": "minor"
     }
   ],
   "packageName": "@microsoft/tsdoc",

--- a/tsdoc/.npmrc
+++ b/tsdoc/.npmrc
@@ -1,2 +1,3 @@
 registry=https://registry.npmjs.org/
 always-auth=false
+package-lock=false

--- a/tsdoc/.vscode/launch.json
+++ b/tsdoc/.vscode/launch.json
@@ -18,7 +18,11 @@
       "request": "launch",
       "name": "Jest Current File",
       "program": "${workspaceFolder}/node_modules/jest/bin/jest",
-      "args": ["${relativeFile}"],
+      "args": [
+        "--runInBand",
+        "--testPathPattern",
+        "${fileBasename}"
+      ],
       "console": "integratedTerminal",
       "internalConsoleOptions": "neverOpen"
     }

--- a/tsdoc/src/__tests__/ParsingBasics.test.ts
+++ b/tsdoc/src/__tests__/ParsingBasics.test.ts
@@ -111,3 +111,26 @@ test('04 typeParam blocks', () => {
     ' */'
   ].join('\n'));
 });
+
+test('05 Invalid JSDoc syntax in @param blocks', () => {
+  TestHelpers.parseAndMatchDocCommentSnapshot([
+    '/**',
+    ' * @param {type} a - description',
+    ' * @param {{}} b - description',
+    ' * @param {"{"} c - description',
+    ' * @param {"\\""} d - description',
+    ' * @param e {type} - description',
+    ' * @param f {{}} - description',
+    ' * @param g {"{"} - description',
+    ' * @param h - {type} description',
+    ' * @param i - {{}} description',
+    ' * @param j - {"{"} description',
+    ' * @param [k] - description',
+    ' * @param [l=] - description',
+    ' * @param [m=[]] - description',
+    ' * @param [n="["] - description',
+    ' * @param [o="\\""] - description',
+    ' */'
+  ].join('\n'));
+});
+

--- a/tsdoc/src/__tests__/ParsingBasics.test.ts
+++ b/tsdoc/src/__tests__/ParsingBasics.test.ts
@@ -134,3 +134,27 @@ test('05 Invalid JSDoc syntax in @param blocks', () => {
   ].join('\n'));
 });
 
+test('06 Invalid JSDoc optional name', () => {
+  TestHelpers.parseAndMatchDocCommentSnapshot([
+    '/**',
+    ' * Example 1',
+    ' *',
+    ' * @param [n - this is',
+    ' * the description',
+    ' *',
+    ' * @public',
+    ' */'
+  ].join('\n'));
+});
+
+test('07 Invalid JSDoc type', () => {
+  TestHelpers.parseAndMatchDocCommentSnapshot([
+    '/**',
+    ' * Example 1',
+    ' *',
+    ' * @param { test',
+    ' *',
+    ' * @public',
+    ' */'
+  ].join('\n'));
+});

--- a/tsdoc/src/__tests__/__snapshots__/ParsingBasics.test.ts.snap
+++ b/tsdoc/src/__tests__/__snapshots__/ParsingBasics.test.ts.snap
@@ -714,6 +714,18 @@ Object {
           ],
         },
         Object {
+          "kind": "Excerpt: Spacing",
+          "nodeExcerpt": " ",
+        },
+        Object {
+          "kind": "Excerpt: ParamBlock_ParameterName",
+          "nodeExcerpt": "y",
+        },
+        Object {
+          "kind": "Excerpt: Spacing",
+          "nodeExcerpt": " ",
+        },
+        Object {
           "kind": "Section",
           "nodes": Array [
             Object {
@@ -724,7 +736,7 @@ Object {
                   "nodes": Array [
                     Object {
                       "kind": "Excerpt: PlainText",
-                      "nodeExcerpt": " y The second input number",
+                      "nodeExcerpt": "The second input number",
                     },
                   ],
                 },
@@ -1594,5 +1606,1009 @@ Object {
   "_10_inheritDocTag": undefined,
   "_11_modifierTags": Array [],
   "_12_logMessages": Array [],
+}
+`;
+
+exports[`05 Invalid JSDoc syntax in @param blocks 1`] = `
+Object {
+  "_00_lines": Array [
+    "@param {type} a - description",
+    "@param {{}} b - description",
+    "@param {[q]{[q]} c - description",
+    "@param {[q][b][q][q]} d - description",
+    "@param e {type} - description",
+    "@param f {{}} - description",
+    "@param g {[q]{[q]} - description",
+    "@param h - {type} description",
+    "@param i - {{}} description",
+    "@param j - {[q]{[q]} description",
+    "@param [k] - description",
+    "@param [l=] - description",
+    "@param [m=[]] - description",
+    "@param [n=[q][[q]] - description",
+    "@param [o=[q][b][q][q]] - description",
+  ],
+  "_01_gaps": Array [
+    "{type} ",
+    "{{}} ",
+    "{\\"{\\"} ",
+    "{\\"\\\\\\"\\"} ",
+    "{type} ",
+    "{{}} ",
+    "{\\"{\\"} ",
+    "{type} ",
+    "{{}} ",
+    "{\\"{\\"} ",
+    "[",
+    "]",
+    "[",
+    "=]",
+    "[",
+    "=[]]",
+    "[",
+    "=\\"[\\"]",
+    "[",
+    "=\\"\\\\\\"\\"]",
+  ],
+  "_02_summarySection": Object {
+    "kind": "Section",
+  },
+  "_03_remarksBlock": undefined,
+  "_04_privateRemarksBlock": undefined,
+  "_05_deprecatedBlock": undefined,
+  "_06_paramBlocks": Array [
+    Object {
+      "kind": "ParamBlock",
+      "nodes": Array [
+        Object {
+          "kind": "BlockTag",
+          "nodes": Array [
+            Object {
+              "kind": "Excerpt: BlockTag",
+              "nodeExcerpt": "@param",
+            },
+          ],
+        },
+        Object {
+          "kind": "Excerpt: Spacing",
+          "nodeExcerpt": " ",
+        },
+        Object {
+          "kind": "Excerpt: ParamBlock_ParameterName",
+          "nodeExcerpt": "a",
+        },
+        Object {
+          "kind": "Excerpt: Spacing",
+          "nodeExcerpt": " ",
+        },
+        Object {
+          "kind": "Excerpt: ParamBlock_Hyphen",
+          "nodeExcerpt": "-",
+        },
+        Object {
+          "kind": "Excerpt: Spacing",
+          "nodeExcerpt": " ",
+        },
+        Object {
+          "kind": "Section",
+          "nodes": Array [
+            Object {
+              "kind": "Paragraph",
+              "nodes": Array [
+                Object {
+                  "kind": "PlainText",
+                  "nodes": Array [
+                    Object {
+                      "kind": "Excerpt: PlainText",
+                      "nodeExcerpt": "description",
+                    },
+                  ],
+                },
+                Object {
+                  "kind": "SoftBreak",
+                  "nodes": Array [
+                    Object {
+                      "kind": "Excerpt: SoftBreak",
+                      "nodeExcerpt": "[n]",
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    },
+    Object {
+      "kind": "ParamBlock",
+      "nodes": Array [
+        Object {
+          "kind": "BlockTag",
+          "nodes": Array [
+            Object {
+              "kind": "Excerpt: BlockTag",
+              "nodeExcerpt": "@param",
+            },
+          ],
+        },
+        Object {
+          "kind": "Excerpt: Spacing",
+          "nodeExcerpt": " ",
+        },
+        Object {
+          "kind": "Excerpt: ParamBlock_ParameterName",
+          "nodeExcerpt": "b",
+        },
+        Object {
+          "kind": "Excerpt: Spacing",
+          "nodeExcerpt": " ",
+        },
+        Object {
+          "kind": "Excerpt: ParamBlock_Hyphen",
+          "nodeExcerpt": "-",
+        },
+        Object {
+          "kind": "Excerpt: Spacing",
+          "nodeExcerpt": " ",
+        },
+        Object {
+          "kind": "Section",
+          "nodes": Array [
+            Object {
+              "kind": "Paragraph",
+              "nodes": Array [
+                Object {
+                  "kind": "PlainText",
+                  "nodes": Array [
+                    Object {
+                      "kind": "Excerpt: PlainText",
+                      "nodeExcerpt": "description",
+                    },
+                  ],
+                },
+                Object {
+                  "kind": "SoftBreak",
+                  "nodes": Array [
+                    Object {
+                      "kind": "Excerpt: SoftBreak",
+                      "nodeExcerpt": "[n]",
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    },
+    Object {
+      "kind": "ParamBlock",
+      "nodes": Array [
+        Object {
+          "kind": "BlockTag",
+          "nodes": Array [
+            Object {
+              "kind": "Excerpt: BlockTag",
+              "nodeExcerpt": "@param",
+            },
+          ],
+        },
+        Object {
+          "kind": "Excerpt: Spacing",
+          "nodeExcerpt": " ",
+        },
+        Object {
+          "kind": "Excerpt: ParamBlock_ParameterName",
+          "nodeExcerpt": "c",
+        },
+        Object {
+          "kind": "Excerpt: Spacing",
+          "nodeExcerpt": " ",
+        },
+        Object {
+          "kind": "Excerpt: ParamBlock_Hyphen",
+          "nodeExcerpt": "-",
+        },
+        Object {
+          "kind": "Excerpt: Spacing",
+          "nodeExcerpt": " ",
+        },
+        Object {
+          "kind": "Section",
+          "nodes": Array [
+            Object {
+              "kind": "Paragraph",
+              "nodes": Array [
+                Object {
+                  "kind": "PlainText",
+                  "nodes": Array [
+                    Object {
+                      "kind": "Excerpt: PlainText",
+                      "nodeExcerpt": "description",
+                    },
+                  ],
+                },
+                Object {
+                  "kind": "SoftBreak",
+                  "nodes": Array [
+                    Object {
+                      "kind": "Excerpt: SoftBreak",
+                      "nodeExcerpt": "[n]",
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    },
+    Object {
+      "kind": "ParamBlock",
+      "nodes": Array [
+        Object {
+          "kind": "BlockTag",
+          "nodes": Array [
+            Object {
+              "kind": "Excerpt: BlockTag",
+              "nodeExcerpt": "@param",
+            },
+          ],
+        },
+        Object {
+          "kind": "Excerpt: Spacing",
+          "nodeExcerpt": " ",
+        },
+        Object {
+          "kind": "Excerpt: ParamBlock_ParameterName",
+          "nodeExcerpt": "d",
+        },
+        Object {
+          "kind": "Excerpt: Spacing",
+          "nodeExcerpt": " ",
+        },
+        Object {
+          "kind": "Excerpt: ParamBlock_Hyphen",
+          "nodeExcerpt": "-",
+        },
+        Object {
+          "kind": "Excerpt: Spacing",
+          "nodeExcerpt": " ",
+        },
+        Object {
+          "kind": "Section",
+          "nodes": Array [
+            Object {
+              "kind": "Paragraph",
+              "nodes": Array [
+                Object {
+                  "kind": "PlainText",
+                  "nodes": Array [
+                    Object {
+                      "kind": "Excerpt: PlainText",
+                      "nodeExcerpt": "description",
+                    },
+                  ],
+                },
+                Object {
+                  "kind": "SoftBreak",
+                  "nodes": Array [
+                    Object {
+                      "kind": "Excerpt: SoftBreak",
+                      "nodeExcerpt": "[n]",
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    },
+    Object {
+      "kind": "ParamBlock",
+      "nodes": Array [
+        Object {
+          "kind": "BlockTag",
+          "nodes": Array [
+            Object {
+              "kind": "Excerpt: BlockTag",
+              "nodeExcerpt": "@param",
+            },
+          ],
+        },
+        Object {
+          "kind": "Excerpt: Spacing",
+          "nodeExcerpt": " ",
+        },
+        Object {
+          "kind": "Excerpt: ParamBlock_ParameterName",
+          "nodeExcerpt": "e",
+        },
+        Object {
+          "kind": "Excerpt: Spacing",
+          "nodeExcerpt": " ",
+        },
+        Object {
+          "kind": "Excerpt: ParamBlock_Hyphen",
+          "nodeExcerpt": "-",
+        },
+        Object {
+          "kind": "Excerpt: Spacing",
+          "nodeExcerpt": " ",
+        },
+        Object {
+          "kind": "Section",
+          "nodes": Array [
+            Object {
+              "kind": "Paragraph",
+              "nodes": Array [
+                Object {
+                  "kind": "PlainText",
+                  "nodes": Array [
+                    Object {
+                      "kind": "Excerpt: PlainText",
+                      "nodeExcerpt": "description",
+                    },
+                  ],
+                },
+                Object {
+                  "kind": "SoftBreak",
+                  "nodes": Array [
+                    Object {
+                      "kind": "Excerpt: SoftBreak",
+                      "nodeExcerpt": "[n]",
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    },
+    Object {
+      "kind": "ParamBlock",
+      "nodes": Array [
+        Object {
+          "kind": "BlockTag",
+          "nodes": Array [
+            Object {
+              "kind": "Excerpt: BlockTag",
+              "nodeExcerpt": "@param",
+            },
+          ],
+        },
+        Object {
+          "kind": "Excerpt: Spacing",
+          "nodeExcerpt": " ",
+        },
+        Object {
+          "kind": "Excerpt: ParamBlock_ParameterName",
+          "nodeExcerpt": "f",
+        },
+        Object {
+          "kind": "Excerpt: Spacing",
+          "nodeExcerpt": " ",
+        },
+        Object {
+          "kind": "Excerpt: ParamBlock_Hyphen",
+          "nodeExcerpt": "-",
+        },
+        Object {
+          "kind": "Excerpt: Spacing",
+          "nodeExcerpt": " ",
+        },
+        Object {
+          "kind": "Section",
+          "nodes": Array [
+            Object {
+              "kind": "Paragraph",
+              "nodes": Array [
+                Object {
+                  "kind": "PlainText",
+                  "nodes": Array [
+                    Object {
+                      "kind": "Excerpt: PlainText",
+                      "nodeExcerpt": "description",
+                    },
+                  ],
+                },
+                Object {
+                  "kind": "SoftBreak",
+                  "nodes": Array [
+                    Object {
+                      "kind": "Excerpt: SoftBreak",
+                      "nodeExcerpt": "[n]",
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    },
+    Object {
+      "kind": "ParamBlock",
+      "nodes": Array [
+        Object {
+          "kind": "BlockTag",
+          "nodes": Array [
+            Object {
+              "kind": "Excerpt: BlockTag",
+              "nodeExcerpt": "@param",
+            },
+          ],
+        },
+        Object {
+          "kind": "Excerpt: Spacing",
+          "nodeExcerpt": " ",
+        },
+        Object {
+          "kind": "Excerpt: ParamBlock_ParameterName",
+          "nodeExcerpt": "g",
+        },
+        Object {
+          "kind": "Excerpt: Spacing",
+          "nodeExcerpt": " ",
+        },
+        Object {
+          "kind": "Excerpt: ParamBlock_Hyphen",
+          "nodeExcerpt": "-",
+        },
+        Object {
+          "kind": "Excerpt: Spacing",
+          "nodeExcerpt": " ",
+        },
+        Object {
+          "kind": "Section",
+          "nodes": Array [
+            Object {
+              "kind": "Paragraph",
+              "nodes": Array [
+                Object {
+                  "kind": "PlainText",
+                  "nodes": Array [
+                    Object {
+                      "kind": "Excerpt: PlainText",
+                      "nodeExcerpt": "description",
+                    },
+                  ],
+                },
+                Object {
+                  "kind": "SoftBreak",
+                  "nodes": Array [
+                    Object {
+                      "kind": "Excerpt: SoftBreak",
+                      "nodeExcerpt": "[n]",
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    },
+    Object {
+      "kind": "ParamBlock",
+      "nodes": Array [
+        Object {
+          "kind": "BlockTag",
+          "nodes": Array [
+            Object {
+              "kind": "Excerpt: BlockTag",
+              "nodeExcerpt": "@param",
+            },
+          ],
+        },
+        Object {
+          "kind": "Excerpt: Spacing",
+          "nodeExcerpt": " ",
+        },
+        Object {
+          "kind": "Excerpt: ParamBlock_ParameterName",
+          "nodeExcerpt": "h",
+        },
+        Object {
+          "kind": "Excerpt: Spacing",
+          "nodeExcerpt": " ",
+        },
+        Object {
+          "kind": "Excerpt: ParamBlock_Hyphen",
+          "nodeExcerpt": "-",
+        },
+        Object {
+          "kind": "Excerpt: Spacing",
+          "nodeExcerpt": " ",
+        },
+        Object {
+          "kind": "Section",
+          "nodes": Array [
+            Object {
+              "kind": "Paragraph",
+              "nodes": Array [
+                Object {
+                  "kind": "PlainText",
+                  "nodes": Array [
+                    Object {
+                      "kind": "Excerpt: PlainText",
+                      "nodeExcerpt": "description",
+                    },
+                  ],
+                },
+                Object {
+                  "kind": "SoftBreak",
+                  "nodes": Array [
+                    Object {
+                      "kind": "Excerpt: SoftBreak",
+                      "nodeExcerpt": "[n]",
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    },
+    Object {
+      "kind": "ParamBlock",
+      "nodes": Array [
+        Object {
+          "kind": "BlockTag",
+          "nodes": Array [
+            Object {
+              "kind": "Excerpt: BlockTag",
+              "nodeExcerpt": "@param",
+            },
+          ],
+        },
+        Object {
+          "kind": "Excerpt: Spacing",
+          "nodeExcerpt": " ",
+        },
+        Object {
+          "kind": "Excerpt: ParamBlock_ParameterName",
+          "nodeExcerpt": "i",
+        },
+        Object {
+          "kind": "Excerpt: Spacing",
+          "nodeExcerpt": " ",
+        },
+        Object {
+          "kind": "Excerpt: ParamBlock_Hyphen",
+          "nodeExcerpt": "-",
+        },
+        Object {
+          "kind": "Excerpt: Spacing",
+          "nodeExcerpt": " ",
+        },
+        Object {
+          "kind": "Section",
+          "nodes": Array [
+            Object {
+              "kind": "Paragraph",
+              "nodes": Array [
+                Object {
+                  "kind": "PlainText",
+                  "nodes": Array [
+                    Object {
+                      "kind": "Excerpt: PlainText",
+                      "nodeExcerpt": "description",
+                    },
+                  ],
+                },
+                Object {
+                  "kind": "SoftBreak",
+                  "nodes": Array [
+                    Object {
+                      "kind": "Excerpt: SoftBreak",
+                      "nodeExcerpt": "[n]",
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    },
+    Object {
+      "kind": "ParamBlock",
+      "nodes": Array [
+        Object {
+          "kind": "BlockTag",
+          "nodes": Array [
+            Object {
+              "kind": "Excerpt: BlockTag",
+              "nodeExcerpt": "@param",
+            },
+          ],
+        },
+        Object {
+          "kind": "Excerpt: Spacing",
+          "nodeExcerpt": " ",
+        },
+        Object {
+          "kind": "Excerpt: ParamBlock_ParameterName",
+          "nodeExcerpt": "j",
+        },
+        Object {
+          "kind": "Excerpt: Spacing",
+          "nodeExcerpt": " ",
+        },
+        Object {
+          "kind": "Excerpt: ParamBlock_Hyphen",
+          "nodeExcerpt": "-",
+        },
+        Object {
+          "kind": "Excerpt: Spacing",
+          "nodeExcerpt": " ",
+        },
+        Object {
+          "kind": "Section",
+          "nodes": Array [
+            Object {
+              "kind": "Paragraph",
+              "nodes": Array [
+                Object {
+                  "kind": "PlainText",
+                  "nodes": Array [
+                    Object {
+                      "kind": "Excerpt: PlainText",
+                      "nodeExcerpt": "description",
+                    },
+                  ],
+                },
+                Object {
+                  "kind": "SoftBreak",
+                  "nodes": Array [
+                    Object {
+                      "kind": "Excerpt: SoftBreak",
+                      "nodeExcerpt": "[n]",
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    },
+    Object {
+      "kind": "ParamBlock",
+      "nodes": Array [
+        Object {
+          "kind": "BlockTag",
+          "nodes": Array [
+            Object {
+              "kind": "Excerpt: BlockTag",
+              "nodeExcerpt": "@param",
+            },
+          ],
+        },
+        Object {
+          "kind": "Excerpt: Spacing",
+          "nodeExcerpt": " ",
+        },
+        Object {
+          "kind": "Excerpt: ParamBlock_ParameterName",
+          "nodeExcerpt": "k",
+        },
+        Object {
+          "kind": "Excerpt: Spacing",
+          "nodeExcerpt": " ",
+        },
+        Object {
+          "kind": "Excerpt: ParamBlock_Hyphen",
+          "nodeExcerpt": "-",
+        },
+        Object {
+          "kind": "Excerpt: Spacing",
+          "nodeExcerpt": " ",
+        },
+        Object {
+          "kind": "Section",
+          "nodes": Array [
+            Object {
+              "kind": "Paragraph",
+              "nodes": Array [
+                Object {
+                  "kind": "PlainText",
+                  "nodes": Array [
+                    Object {
+                      "kind": "Excerpt: PlainText",
+                      "nodeExcerpt": "description",
+                    },
+                  ],
+                },
+                Object {
+                  "kind": "SoftBreak",
+                  "nodes": Array [
+                    Object {
+                      "kind": "Excerpt: SoftBreak",
+                      "nodeExcerpt": "[n]",
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    },
+    Object {
+      "kind": "ParamBlock",
+      "nodes": Array [
+        Object {
+          "kind": "BlockTag",
+          "nodes": Array [
+            Object {
+              "kind": "Excerpt: BlockTag",
+              "nodeExcerpt": "@param",
+            },
+          ],
+        },
+        Object {
+          "kind": "Excerpt: Spacing",
+          "nodeExcerpt": " ",
+        },
+        Object {
+          "kind": "Excerpt: ParamBlock_ParameterName",
+          "nodeExcerpt": "l",
+        },
+        Object {
+          "kind": "Excerpt: Spacing",
+          "nodeExcerpt": " ",
+        },
+        Object {
+          "kind": "Excerpt: ParamBlock_Hyphen",
+          "nodeExcerpt": "-",
+        },
+        Object {
+          "kind": "Excerpt: Spacing",
+          "nodeExcerpt": " ",
+        },
+        Object {
+          "kind": "Section",
+          "nodes": Array [
+            Object {
+              "kind": "Paragraph",
+              "nodes": Array [
+                Object {
+                  "kind": "PlainText",
+                  "nodes": Array [
+                    Object {
+                      "kind": "Excerpt: PlainText",
+                      "nodeExcerpt": "description",
+                    },
+                  ],
+                },
+                Object {
+                  "kind": "SoftBreak",
+                  "nodes": Array [
+                    Object {
+                      "kind": "Excerpt: SoftBreak",
+                      "nodeExcerpt": "[n]",
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    },
+    Object {
+      "kind": "ParamBlock",
+      "nodes": Array [
+        Object {
+          "kind": "BlockTag",
+          "nodes": Array [
+            Object {
+              "kind": "Excerpt: BlockTag",
+              "nodeExcerpt": "@param",
+            },
+          ],
+        },
+        Object {
+          "kind": "Excerpt: Spacing",
+          "nodeExcerpt": " ",
+        },
+        Object {
+          "kind": "Excerpt: ParamBlock_ParameterName",
+          "nodeExcerpt": "m",
+        },
+        Object {
+          "kind": "Excerpt: Spacing",
+          "nodeExcerpt": " ",
+        },
+        Object {
+          "kind": "Excerpt: ParamBlock_Hyphen",
+          "nodeExcerpt": "-",
+        },
+        Object {
+          "kind": "Excerpt: Spacing",
+          "nodeExcerpt": " ",
+        },
+        Object {
+          "kind": "Section",
+          "nodes": Array [
+            Object {
+              "kind": "Paragraph",
+              "nodes": Array [
+                Object {
+                  "kind": "PlainText",
+                  "nodes": Array [
+                    Object {
+                      "kind": "Excerpt: PlainText",
+                      "nodeExcerpt": "description",
+                    },
+                  ],
+                },
+                Object {
+                  "kind": "SoftBreak",
+                  "nodes": Array [
+                    Object {
+                      "kind": "Excerpt: SoftBreak",
+                      "nodeExcerpt": "[n]",
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    },
+    Object {
+      "kind": "ParamBlock",
+      "nodes": Array [
+        Object {
+          "kind": "BlockTag",
+          "nodes": Array [
+            Object {
+              "kind": "Excerpt: BlockTag",
+              "nodeExcerpt": "@param",
+            },
+          ],
+        },
+        Object {
+          "kind": "Excerpt: Spacing",
+          "nodeExcerpt": " ",
+        },
+        Object {
+          "kind": "Excerpt: ParamBlock_ParameterName",
+          "nodeExcerpt": "n",
+        },
+        Object {
+          "kind": "Excerpt: Spacing",
+          "nodeExcerpt": " ",
+        },
+        Object {
+          "kind": "Excerpt: ParamBlock_Hyphen",
+          "nodeExcerpt": "-",
+        },
+        Object {
+          "kind": "Excerpt: Spacing",
+          "nodeExcerpt": " ",
+        },
+        Object {
+          "kind": "Section",
+          "nodes": Array [
+            Object {
+              "kind": "Paragraph",
+              "nodes": Array [
+                Object {
+                  "kind": "PlainText",
+                  "nodes": Array [
+                    Object {
+                      "kind": "Excerpt: PlainText",
+                      "nodeExcerpt": "description",
+                    },
+                  ],
+                },
+                Object {
+                  "kind": "SoftBreak",
+                  "nodes": Array [
+                    Object {
+                      "kind": "Excerpt: SoftBreak",
+                      "nodeExcerpt": "[n]",
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    },
+    Object {
+      "kind": "ParamBlock",
+      "nodes": Array [
+        Object {
+          "kind": "BlockTag",
+          "nodes": Array [
+            Object {
+              "kind": "Excerpt: BlockTag",
+              "nodeExcerpt": "@param",
+            },
+          ],
+        },
+        Object {
+          "kind": "Excerpt: Spacing",
+          "nodeExcerpt": " ",
+        },
+        Object {
+          "kind": "Excerpt: ParamBlock_ParameterName",
+          "nodeExcerpt": "o",
+        },
+        Object {
+          "kind": "Excerpt: Spacing",
+          "nodeExcerpt": " ",
+        },
+        Object {
+          "kind": "Excerpt: ParamBlock_Hyphen",
+          "nodeExcerpt": "-",
+        },
+        Object {
+          "kind": "Excerpt: Spacing",
+          "nodeExcerpt": " ",
+        },
+        Object {
+          "kind": "Section",
+          "nodes": Array [
+            Object {
+              "kind": "Paragraph",
+              "nodes": Array [
+                Object {
+                  "kind": "PlainText",
+                  "nodes": Array [
+                    Object {
+                      "kind": "Excerpt: PlainText",
+                      "nodeExcerpt": "description",
+                    },
+                  ],
+                },
+                Object {
+                  "kind": "SoftBreak",
+                  "nodes": Array [
+                    Object {
+                      "kind": "Excerpt: SoftBreak",
+                      "nodeExcerpt": "[n]",
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    },
+  ],
+  "_07_typeParamBlocks": Array [],
+  "_08_returnsBlock": undefined,
+  "_09_customBlocks": Array [],
+  "_10_inheritDocTag": undefined,
+  "_11_modifierTags": Array [],
+  "_12_logMessages": Array [
+    "(2,11): The @param block should not include a JSDoc-style '{type}'",
+    "(3,11): The @param block should not include a JSDoc-style '{type}'",
+    "(4,11): The @param block should not include a JSDoc-style '{type}'",
+    "(5,11): The @param block should not include a JSDoc-style '{type}'",
+    "(6,13): The @param block should not include a JSDoc-style '{type}'",
+    "(7,13): The @param block should not include a JSDoc-style '{type}'",
+    "(8,13): The @param block should not include a JSDoc-style '{type}'",
+    "(9,15): The @param block should not include a JSDoc-style '{type}'",
+    "(10,15): The @param block should not include a JSDoc-style '{type}'",
+    "(11,15): The @param block should not include a JSDoc-style '{type}'",
+    "(12,11): The @param should not include a JSDoc-style optional name; it must not be enclosed in '[ ]' brackets.",
+    "(13,11): The @param should not include a JSDoc-style optional name; it must not be enclosed in '[ ]' brackets.",
+    "(14,11): The @param should not include a JSDoc-style optional name; it must not be enclosed in '[ ]' brackets.",
+    "(15,11): The @param should not include a JSDoc-style optional name; it must not be enclosed in '[ ]' brackets.",
+    "(16,11): The @param should not include a JSDoc-style optional name; it must not be enclosed in '[ ]' brackets.",
+  ],
 }
 `;

--- a/tsdoc/src/__tests__/__snapshots__/ParsingBasics.test.ts.snap
+++ b/tsdoc/src/__tests__/__snapshots__/ParsingBasics.test.ts.snap
@@ -1628,28 +1628,7 @@ Object {
     "@param [n=[q][[q]] - description",
     "@param [o=[q][b][q][q]] - description",
   ],
-  "_01_gaps": Array [
-    "{type} ",
-    "{{}} ",
-    "{\\"{\\"} ",
-    "{\\"\\\\\\"\\"} ",
-    "{type} ",
-    "{{}} ",
-    "{\\"{\\"} ",
-    "{type} ",
-    "{{}} ",
-    "{\\"{\\"} ",
-    "[",
-    "]",
-    "[",
-    "=]",
-    "[",
-    "=[]]",
-    "[",
-    "=\\"[\\"]",
-    "[",
-    "=\\"\\\\\\"\\"]",
-  ],
+  "_01_gaps": Array [],
   "_02_summarySection": Object {
     "kind": "Section",
   },
@@ -1672,6 +1651,10 @@ Object {
         Object {
           "kind": "Excerpt: Spacing",
           "nodeExcerpt": " ",
+        },
+        Object {
+          "kind": "Excerpt: ErrorText",
+          "nodeExcerpt": "{type} ",
         },
         Object {
           "kind": "Excerpt: ParamBlock_ParameterName",
@@ -1736,6 +1719,10 @@ Object {
           "nodeExcerpt": " ",
         },
         Object {
+          "kind": "Excerpt: ErrorText",
+          "nodeExcerpt": "{{}} ",
+        },
+        Object {
           "kind": "Excerpt: ParamBlock_ParameterName",
           "nodeExcerpt": "b",
         },
@@ -1798,6 +1785,10 @@ Object {
           "nodeExcerpt": " ",
         },
         Object {
+          "kind": "Excerpt: ErrorText",
+          "nodeExcerpt": "{[q]{[q]} ",
+        },
+        Object {
           "kind": "Excerpt: ParamBlock_ParameterName",
           "nodeExcerpt": "c",
         },
@@ -1858,6 +1849,10 @@ Object {
         Object {
           "kind": "Excerpt: Spacing",
           "nodeExcerpt": " ",
+        },
+        Object {
+          "kind": "Excerpt: ErrorText",
+          "nodeExcerpt": "{[q][b][q][q]} ",
         },
         Object {
           "kind": "Excerpt: ParamBlock_ParameterName",
@@ -1930,6 +1925,10 @@ Object {
           "nodeExcerpt": " ",
         },
         Object {
+          "kind": "Excerpt: ErrorText",
+          "nodeExcerpt": "{type} ",
+        },
+        Object {
           "kind": "Excerpt: ParamBlock_Hyphen",
           "nodeExcerpt": "-",
         },
@@ -1992,6 +1991,10 @@ Object {
           "nodeExcerpt": " ",
         },
         Object {
+          "kind": "Excerpt: ErrorText",
+          "nodeExcerpt": "{{}} ",
+        },
+        Object {
           "kind": "Excerpt: ParamBlock_Hyphen",
           "nodeExcerpt": "-",
         },
@@ -2052,6 +2055,10 @@ Object {
         Object {
           "kind": "Excerpt: Spacing",
           "nodeExcerpt": " ",
+        },
+        Object {
+          "kind": "Excerpt: ErrorText",
+          "nodeExcerpt": "{[q]{[q]} ",
         },
         Object {
           "kind": "Excerpt: ParamBlock_Hyphen",
@@ -2124,6 +2131,10 @@ Object {
           "nodeExcerpt": " ",
         },
         Object {
+          "kind": "Excerpt: ErrorText",
+          "nodeExcerpt": "{type} ",
+        },
+        Object {
           "kind": "Section",
           "nodes": Array [
             Object {
@@ -2184,6 +2195,10 @@ Object {
         Object {
           "kind": "Excerpt: Spacing",
           "nodeExcerpt": " ",
+        },
+        Object {
+          "kind": "Excerpt: ErrorText",
+          "nodeExcerpt": "{{}} ",
         },
         Object {
           "kind": "Section",
@@ -2248,6 +2263,10 @@ Object {
           "nodeExcerpt": " ",
         },
         Object {
+          "kind": "Excerpt: ErrorText",
+          "nodeExcerpt": "{[q]{[q]} ",
+        },
+        Object {
           "kind": "Section",
           "nodes": Array [
             Object {
@@ -2292,24 +2311,16 @@ Object {
         Object {
           "kind": "Excerpt: Spacing",
           "nodeExcerpt": " ",
+        },
+        Object {
+          "kind": "Excerpt: ErrorText",
+          "nodeExcerpt": "[",
         },
         Object {
           "kind": "Excerpt: ParamBlock_ParameterName",
           "nodeExcerpt": "k",
         },
         Object {
-          "kind": "Excerpt: Spacing",
-          "nodeExcerpt": " ",
-        },
-        Object {
-          "kind": "Excerpt: ParamBlock_Hyphen",
-          "nodeExcerpt": "-",
-        },
-        Object {
-          "kind": "Excerpt: Spacing",
-          "nodeExcerpt": " ",
-        },
-        Object {
           "kind": "Section",
           "nodes": Array [
             Object {
@@ -2320,7 +2331,7 @@ Object {
                   "nodes": Array [
                     Object {
                       "kind": "Excerpt: PlainText",
-                      "nodeExcerpt": "description",
+                      "nodeExcerpt": "] - description",
                     },
                   ],
                 },
@@ -2354,12 +2365,20 @@ Object {
         Object {
           "kind": "Excerpt: Spacing",
           "nodeExcerpt": " ",
+        },
+        Object {
+          "kind": "Excerpt: ErrorText",
+          "nodeExcerpt": "[",
         },
         Object {
           "kind": "Excerpt: ParamBlock_ParameterName",
           "nodeExcerpt": "l",
         },
         Object {
+          "kind": "Excerpt: ErrorText",
+          "nodeExcerpt": "=]",
+        },
+        Object {
           "kind": "Excerpt: Spacing",
           "nodeExcerpt": " ",
         },
@@ -2416,12 +2435,20 @@ Object {
         Object {
           "kind": "Excerpt: Spacing",
           "nodeExcerpt": " ",
+        },
+        Object {
+          "kind": "Excerpt: ErrorText",
+          "nodeExcerpt": "[",
         },
         Object {
           "kind": "Excerpt: ParamBlock_ParameterName",
           "nodeExcerpt": "m",
         },
         Object {
+          "kind": "Excerpt: ErrorText",
+          "nodeExcerpt": "=[]]",
+        },
+        Object {
           "kind": "Excerpt: Spacing",
           "nodeExcerpt": " ",
         },
@@ -2478,12 +2505,20 @@ Object {
         Object {
           "kind": "Excerpt: Spacing",
           "nodeExcerpt": " ",
+        },
+        Object {
+          "kind": "Excerpt: ErrorText",
+          "nodeExcerpt": "[",
         },
         Object {
           "kind": "Excerpt: ParamBlock_ParameterName",
           "nodeExcerpt": "n",
         },
         Object {
+          "kind": "Excerpt: ErrorText",
+          "nodeExcerpt": "=[q][[q]]",
+        },
+        Object {
           "kind": "Excerpt: Spacing",
           "nodeExcerpt": " ",
         },
@@ -2542,8 +2577,16 @@ Object {
           "nodeExcerpt": " ",
         },
         Object {
+          "kind": "Excerpt: ErrorText",
+          "nodeExcerpt": "[",
+        },
+        Object {
           "kind": "Excerpt: ParamBlock_ParameterName",
           "nodeExcerpt": "o",
+        },
+        Object {
+          "kind": "Excerpt: ErrorText",
+          "nodeExcerpt": "=[q][b][q][q]]",
         },
         Object {
           "kind": "Excerpt: Spacing",
@@ -2605,10 +2648,342 @@ Object {
     "(10,15): The @param block should not include a JSDoc-style '{type}'",
     "(11,15): The @param block should not include a JSDoc-style '{type}'",
     "(12,11): The @param should not include a JSDoc-style optional name; it must not be enclosed in '[ ]' brackets.",
+    "(12,4): The @param block should be followed by a parameter name and then a hyphen",
     "(13,11): The @param should not include a JSDoc-style optional name; it must not be enclosed in '[ ]' brackets.",
     "(14,11): The @param should not include a JSDoc-style optional name; it must not be enclosed in '[ ]' brackets.",
     "(15,11): The @param should not include a JSDoc-style optional name; it must not be enclosed in '[ ]' brackets.",
     "(16,11): The @param should not include a JSDoc-style optional name; it must not be enclosed in '[ ]' brackets.",
+  ],
+}
+`;
+
+exports[`06 Invalid JSDoc optional name 1`] = `
+Object {
+  "_00_lines": Array [
+    "Example 1",
+    "",
+    "@param [n - this is",
+    "the description",
+    "",
+    "@public",
+  ],
+  "_01_gaps": Array [],
+  "_02_summarySection": Object {
+    "kind": "Section",
+    "nodes": Array [
+      Object {
+        "kind": "Paragraph",
+        "nodes": Array [
+          Object {
+            "kind": "PlainText",
+            "nodes": Array [
+              Object {
+                "kind": "Excerpt: PlainText",
+                "nodeExcerpt": "Example 1",
+              },
+            ],
+          },
+          Object {
+            "kind": "SoftBreak",
+            "nodes": Array [
+              Object {
+                "kind": "Excerpt: SoftBreak",
+                "nodeExcerpt": "[n]",
+              },
+            ],
+          },
+          Object {
+            "kind": "SoftBreak",
+            "nodes": Array [
+              Object {
+                "kind": "Excerpt: SoftBreak",
+                "nodeExcerpt": "[n]",
+              },
+            ],
+          },
+        ],
+      },
+    ],
+  },
+  "_03_remarksBlock": undefined,
+  "_04_privateRemarksBlock": undefined,
+  "_05_deprecatedBlock": undefined,
+  "_06_paramBlocks": Array [
+    Object {
+      "kind": "ParamBlock",
+      "nodes": Array [
+        Object {
+          "kind": "BlockTag",
+          "nodes": Array [
+            Object {
+              "kind": "Excerpt: BlockTag",
+              "nodeExcerpt": "@param",
+            },
+          ],
+        },
+        Object {
+          "kind": "Excerpt: Spacing",
+          "nodeExcerpt": " ",
+        },
+        Object {
+          "kind": "Excerpt: ErrorText",
+          "nodeExcerpt": "[",
+        },
+        Object {
+          "kind": "Excerpt: ParamBlock_ParameterName",
+          "nodeExcerpt": "n",
+        },
+        Object {
+          "kind": "Excerpt: Spacing",
+          "nodeExcerpt": " ",
+        },
+        Object {
+          "kind": "Excerpt: ParamBlock_Hyphen",
+          "nodeExcerpt": "-",
+        },
+        Object {
+          "kind": "Excerpt: Spacing",
+          "nodeExcerpt": " ",
+        },
+        Object {
+          "kind": "Section",
+          "nodes": Array [
+            Object {
+              "kind": "Paragraph",
+              "nodes": Array [
+                Object {
+                  "kind": "PlainText",
+                  "nodes": Array [
+                    Object {
+                      "kind": "Excerpt: PlainText",
+                      "nodeExcerpt": "this is",
+                    },
+                  ],
+                },
+                Object {
+                  "kind": "SoftBreak",
+                  "nodes": Array [
+                    Object {
+                      "kind": "Excerpt: SoftBreak",
+                      "nodeExcerpt": "[n]",
+                    },
+                  ],
+                },
+                Object {
+                  "kind": "PlainText",
+                  "nodes": Array [
+                    Object {
+                      "kind": "Excerpt: PlainText",
+                      "nodeExcerpt": "the description",
+                    },
+                  ],
+                },
+                Object {
+                  "kind": "SoftBreak",
+                  "nodes": Array [
+                    Object {
+                      "kind": "Excerpt: SoftBreak",
+                      "nodeExcerpt": "[n]",
+                    },
+                  ],
+                },
+                Object {
+                  "kind": "SoftBreak",
+                  "nodes": Array [
+                    Object {
+                      "kind": "Excerpt: SoftBreak",
+                      "nodeExcerpt": "[n]",
+                    },
+                  ],
+                },
+                Object {
+                  "kind": "SoftBreak",
+                  "nodes": Array [
+                    Object {
+                      "kind": "Excerpt: SoftBreak",
+                      "nodeExcerpt": "[n]",
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    },
+  ],
+  "_07_typeParamBlocks": Array [],
+  "_08_returnsBlock": undefined,
+  "_09_customBlocks": Array [],
+  "_10_inheritDocTag": undefined,
+  "_11_modifierTags": Array [
+    Object {
+      "kind": "BlockTag",
+      "nodes": Array [
+        Object {
+          "kind": "Excerpt: BlockTag",
+          "nodeExcerpt": "@public",
+        },
+      ],
+    },
+  ],
+  "_12_logMessages": Array [
+    "(4,11): The @param should not include a JSDoc-style optional name; it must not be enclosed in '[ ]' brackets.",
+  ],
+}
+`;
+
+exports[`07 Invalid JSDoc type 1`] = `
+Object {
+  "_00_lines": Array [
+    "Example 1",
+    "",
+    "@param { test",
+    "",
+    "@public",
+  ],
+  "_01_gaps": Array [],
+  "_02_summarySection": Object {
+    "kind": "Section",
+    "nodes": Array [
+      Object {
+        "kind": "Paragraph",
+        "nodes": Array [
+          Object {
+            "kind": "PlainText",
+            "nodes": Array [
+              Object {
+                "kind": "Excerpt: PlainText",
+                "nodeExcerpt": "Example 1",
+              },
+            ],
+          },
+          Object {
+            "kind": "SoftBreak",
+            "nodes": Array [
+              Object {
+                "kind": "Excerpt: SoftBreak",
+                "nodeExcerpt": "[n]",
+              },
+            ],
+          },
+          Object {
+            "kind": "SoftBreak",
+            "nodes": Array [
+              Object {
+                "kind": "Excerpt: SoftBreak",
+                "nodeExcerpt": "[n]",
+              },
+            ],
+          },
+        ],
+      },
+    ],
+  },
+  "_03_remarksBlock": undefined,
+  "_04_privateRemarksBlock": undefined,
+  "_05_deprecatedBlock": undefined,
+  "_06_paramBlocks": Array [
+    Object {
+      "kind": "ParamBlock",
+      "nodes": Array [
+        Object {
+          "kind": "BlockTag",
+          "nodes": Array [
+            Object {
+              "kind": "Excerpt: BlockTag",
+              "nodeExcerpt": "@param",
+            },
+          ],
+        },
+        Object {
+          "kind": "Section",
+          "nodes": Array [
+            Object {
+              "kind": "Paragraph",
+              "nodes": Array [
+                Object {
+                  "kind": "PlainText",
+                  "nodes": Array [
+                    Object {
+                      "kind": "Excerpt: PlainText",
+                      "nodeExcerpt": " ",
+                    },
+                  ],
+                },
+                Object {
+                  "errorLocation": "{",
+                  "errorLocationPrecedingToken": " ",
+                  "errorMessage": "Expecting a TSDoc tag starting with [q]{@[q]",
+                  "kind": "ErrorText",
+                  "nodes": Array [
+                    Object {
+                      "kind": "Excerpt: ErrorText",
+                      "nodeExcerpt": "{",
+                    },
+                  ],
+                },
+                Object {
+                  "kind": "PlainText",
+                  "nodes": Array [
+                    Object {
+                      "kind": "Excerpt: PlainText",
+                      "nodeExcerpt": " test",
+                    },
+                  ],
+                },
+                Object {
+                  "kind": "SoftBreak",
+                  "nodes": Array [
+                    Object {
+                      "kind": "Excerpt: SoftBreak",
+                      "nodeExcerpt": "[n]",
+                    },
+                  ],
+                },
+                Object {
+                  "kind": "SoftBreak",
+                  "nodes": Array [
+                    Object {
+                      "kind": "Excerpt: SoftBreak",
+                      "nodeExcerpt": "[n]",
+                    },
+                  ],
+                },
+                Object {
+                  "kind": "SoftBreak",
+                  "nodes": Array [
+                    Object {
+                      "kind": "Excerpt: SoftBreak",
+                      "nodeExcerpt": "[n]",
+                    },
+                  ],
+                },
+              ],
+            },
+          ],
+        },
+      ],
+    },
+  ],
+  "_07_typeParamBlocks": Array [],
+  "_08_returnsBlock": undefined,
+  "_09_customBlocks": Array [],
+  "_10_inheritDocTag": undefined,
+  "_11_modifierTags": Array [
+    Object {
+      "kind": "BlockTag",
+      "nodes": Array [
+        Object {
+          "kind": "Excerpt: BlockTag",
+          "nodeExcerpt": "@public",
+        },
+      ],
+    },
+  ],
+  "_12_logMessages": Array [
+    "(4,4): The @param block should be followed by a parameter name",
+    "(4,11): Expecting a TSDoc tag starting with \\"{@\\"",
   ],
 }
 `;

--- a/tsdoc/src/nodes/DocParamBlock.ts
+++ b/tsdoc/src/nodes/DocParamBlock.ts
@@ -16,13 +16,23 @@ export interface IDocParamBlockParameters extends IDocBlockParameters {
 export interface IDocParamBlockParsedParameters extends IDocBlockParsedParameters {
   spacingBeforeParameterNameExcerpt?: TokenSequence;
 
+  unsupportedJsdocTypeBeforeParameterNameExcerpt?: TokenSequence;
+  unsupportedJsdocOptionalNameOpenBracketExcerpt?: TokenSequence;
+
   parameterNameExcerpt: TokenSequence;
   parameterName: string;
 
+  unsupportedJsdocOptionalNameRestExcerpt?: TokenSequence;
+
   spacingAfterParameterNameExcerpt?: TokenSequence;
 
+  unsupportedJsdocTypeAfterParameterNameExcerpt?: TokenSequence;
+
   hyphenExcerpt?: TokenSequence;
+
   spacingAfterHyphenExcerpt?: TokenSequence;
+
+  unsupportedJsdocTypeAfterHyphenExcerpt?: TokenSequence;
 }
 
 /**
@@ -32,14 +42,22 @@ export interface IDocParamBlockParsedParameters extends IDocBlockParsedParameter
 export class DocParamBlock extends DocBlock {
   private readonly _spacingBeforeParameterNameExcerpt: DocExcerpt | undefined;
 
+  private readonly _unsupportedJsdocTypeBeforeParameterNameExcerpt: DocExcerpt | undefined;
+  private readonly _unsupportedJsdocOptionalNameOpenBracketExcerpt: DocExcerpt | undefined;
+
   private readonly _parameterName: string;
   private readonly _parameterNameExcerpt: DocExcerpt | undefined;
 
+  private readonly _unsupportedJsdocOptionalNameRestExcerpt: DocExcerpt | undefined;
+
   private readonly _spacingAfterParameterNameExcerpt: DocExcerpt | undefined;
 
-  private readonly _hyphenExcerpt: DocExcerpt | undefined;
+  private readonly _unsupportedJsdocTypeAfterParameterNameExcerpt: DocExcerpt | undefined;
 
+  private readonly _hyphenExcerpt: DocExcerpt | undefined;
   private readonly _spacingAfterHyphenExcerpt: DocExcerpt | undefined;
+
+  private readonly _unsupportedJsdocTypeAfterHyphenExcerpt: DocExcerpt | undefined;
 
   /**
    * Don't call this directly.  Instead use {@link TSDocParser}
@@ -59,17 +77,49 @@ export class DocParamBlock extends DocBlock {
         });
       }
 
+      if (parameters.unsupportedJsdocTypeBeforeParameterNameExcerpt) {
+        this._unsupportedJsdocTypeBeforeParameterNameExcerpt = new DocExcerpt({
+          configuration: this.configuration,
+          excerptKind: ExcerptKind.ErrorText,
+          content: parameters.unsupportedJsdocTypeBeforeParameterNameExcerpt
+        });
+      }
+
+      if (parameters.unsupportedJsdocOptionalNameOpenBracketExcerpt) {
+        this._unsupportedJsdocOptionalNameOpenBracketExcerpt = new DocExcerpt({
+          configuration: this.configuration,
+          excerptKind: ExcerptKind.ErrorText,
+          content: parameters.unsupportedJsdocOptionalNameOpenBracketExcerpt
+        });
+      }
+
       this._parameterNameExcerpt = new DocExcerpt({
         configuration: this.configuration,
         excerptKind: ExcerptKind.ParamBlock_ParameterName,
         content: parameters.parameterNameExcerpt
       });
 
+      if (parameters.unsupportedJsdocOptionalNameRestExcerpt) {
+        this._unsupportedJsdocOptionalNameRestExcerpt = new DocExcerpt({
+          configuration: this.configuration,
+          excerptKind: ExcerptKind.ErrorText,
+          content: parameters.unsupportedJsdocOptionalNameRestExcerpt
+        });
+      }
+
       if (parameters.spacingAfterParameterNameExcerpt) {
         this._spacingAfterParameterNameExcerpt = new DocExcerpt({
           configuration: this.configuration,
           excerptKind: ExcerptKind.Spacing,
           content: parameters.spacingAfterParameterNameExcerpt
+        });
+      }
+
+      if (parameters.unsupportedJsdocTypeAfterParameterNameExcerpt) {
+        this._unsupportedJsdocTypeAfterParameterNameExcerpt = new DocExcerpt({
+          configuration: this.configuration,
+          excerptKind: ExcerptKind.ErrorText,
+          content: parameters.unsupportedJsdocTypeAfterParameterNameExcerpt
         });
       }
 
@@ -88,6 +138,15 @@ export class DocParamBlock extends DocBlock {
           content: parameters.spacingAfterHyphenExcerpt
         });
       }
+
+      if (parameters.unsupportedJsdocTypeAfterHyphenExcerpt) {
+        this._unsupportedJsdocTypeAfterHyphenExcerpt = new DocExcerpt({
+          configuration: this.configuration,
+          excerptKind: ExcerptKind.ErrorText,
+          content: parameters.unsupportedJsdocTypeAfterHyphenExcerpt
+        });
+      }
+
     }
   }
 
@@ -109,10 +168,15 @@ export class DocParamBlock extends DocBlock {
     return [
       this.blockTag,
       this._spacingBeforeParameterNameExcerpt,
+      this._unsupportedJsdocTypeBeforeParameterNameExcerpt,
+      this._unsupportedJsdocOptionalNameOpenBracketExcerpt,
       this._parameterNameExcerpt,
+      this._unsupportedJsdocOptionalNameRestExcerpt,
       this._spacingAfterParameterNameExcerpt,
+      this._unsupportedJsdocTypeAfterParameterNameExcerpt,
       this._hyphenExcerpt,
       this._spacingAfterHyphenExcerpt,
+      this._unsupportedJsdocTypeAfterHyphenExcerpt,
       this.content
     ];
   }

--- a/tsdoc/src/nodes/DocParamBlock.ts
+++ b/tsdoc/src/nodes/DocParamBlock.ts
@@ -21,7 +21,7 @@ export interface IDocParamBlockParsedParameters extends IDocBlockParsedParameter
 
   spacingAfterParameterNameExcerpt?: TokenSequence;
 
-  hyphenExcerpt: TokenSequence;
+  hyphenExcerpt?: TokenSequence;
   spacingAfterHyphenExcerpt?: TokenSequence;
 }
 
@@ -73,11 +73,13 @@ export class DocParamBlock extends DocBlock {
         });
       }
 
-      this._hyphenExcerpt = new DocExcerpt({
-        configuration: this.configuration,
-        excerptKind: ExcerptKind.ParamBlock_Hyphen,
-        content: parameters.hyphenExcerpt
-      });
+      if (parameters.hyphenExcerpt) {
+        this._hyphenExcerpt = new DocExcerpt({
+          configuration: this.configuration,
+          excerptKind: ExcerptKind.ParamBlock_Hyphen,
+          content: parameters.hyphenExcerpt
+        });
+      }
 
       if (parameters.spacingAfterHyphenExcerpt) {
         this._spacingAfterHyphenExcerpt = new DocExcerpt({

--- a/tsdoc/src/parser/TSDocMessageId.ts
+++ b/tsdoc/src/parser/TSDocMessageId.ts
@@ -114,6 +114,16 @@ export const enum TSDocMessageId {
   UndefinedTag = 'tsdoc-undefined-tag',
 
   /**
+   * The `@param` block should not include a JSDoc-style `{type}`.
+   */
+  ParamTagWithInvalidType = 'tsdoc-param-tag-with-invalid-type',
+
+  /**
+   * The `@param` block should not include a JSDoc-style optional name; it must not be enclosed in `[ ]` brackets.
+   */
+  ParamTagWithInvalidOptionalName = 'tsdoc-param-tag-with-invalid-optional-name',
+
+  /**
    * The `@param` block should be followed by a parameter name.
    */
   ParamTagWithInvalidName = 'tsdoc-param-tag-with-invalid-name',


### PR DESCRIPTION
Improves parsing for `@param` and `@typeParam` blocks to handle the following cases:

```ts
 /**
   * // optional hyphens
   * // [tsdoc-param-tag-missing-hyphen]
   * @param foo This is fine.
   *
   * // JSDoc-style type annotations in various positions (with or without hyphens)
   * // [tsdoc-param-tag-with-invalid-type]
   * @param {boolean} foo This is fine.
   * @param foo {boolean} This is fine.
   * @param foo {boolean} - This is fine.
   * @param foo - {boolean} This is fine.
   *
   * // JSDoc-style optional parameter names
   * // [tsdoc-param-tag-with-invalid-optional-name]
   * @param [foo] - This is fine.
   * @param [foo=default] - This is fine.
   */
```

For each of the above cases, a warning is issued (and can be ignored via configuration). In the case of the missing hyphen, this fixes the case where the parameter name was not included in the parameter description.

When parsing out a JSDoc-style type or value (in the case of a parameter default), the parser handles balanced brackets/braces, quoted strings, and escaped quote-marks.

Fixes: #128