### PR TITLE
Improve parsing of JSDoc optional parameter declarations

### DIFF
--- a/common/changes/@microsoft/tsdoc/octogonz-param-tag-fixes_2020-02-22-05-41.json
+++ b/common/changes/@microsoft/tsdoc/octogonz-param-tag-fixes_2020-02-22-05-41.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/tsdoc",
+      "comment": "Fix an issue where JSDoc optional params were not parsed correctly",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@microsoft/tsdoc",
+  "email": "4673363+octogonz@users.noreply.github.com"
+}

--- a/tsdoc/src/__tests__/__snapshots__/ParsingBasics.test.ts.snap
+++ b/tsdoc/src/__tests__/__snapshots__/ParsingBasics.test.ts.snap
@@ -2321,6 +2321,22 @@ Object {
           "nodeExcerpt": "k",
         },
         Object {
+          "kind": "Excerpt: ErrorText",
+          "nodeExcerpt": "]",
+        },
+        Object {
+          "kind": "Excerpt: Spacing",
+          "nodeExcerpt": " ",
+        },
+        Object {
+          "kind": "Excerpt: ParamBlock_Hyphen",
+          "nodeExcerpt": "-",
+        },
+        Object {
+          "kind": "Excerpt: Spacing",
+          "nodeExcerpt": " ",
+        },
+        Object {
           "kind": "Section",
           "nodes": Array [
             Object {
@@ -2331,7 +2347,7 @@ Object {
                   "nodes": Array [
                     Object {
                       "kind": "Excerpt: PlainText",
-                      "nodeExcerpt": "] - description",
+                      "nodeExcerpt": "description",
                     },
                   ],
                 },
@@ -2648,7 +2664,6 @@ Object {
     "(10,15): The @param block should not include a JSDoc-style '{type}'",
     "(11,15): The @param block should not include a JSDoc-style '{type}'",
     "(12,11): The @param should not include a JSDoc-style optional name; it must not be enclosed in '[ ]' brackets.",
-    "(12,4): The @param block should be followed by a parameter name and then a hyphen",
     "(13,11): The @param should not include a JSDoc-style optional name; it must not be enclosed in '[ ]' brackets.",
     "(14,11): The @param should not include a JSDoc-style optional name; it must not be enclosed in '[ ]' brackets.",
     "(15,11): The @param should not include a JSDoc-style optional name; it must not be enclosed in '[ ]' brackets.",

--- a/tsdoc/src/__tests__/__snapshots__/ParsingBasics.test.ts.snap
+++ b/tsdoc/src/__tests__/__snapshots__/ParsingBasics.test.ts.snap
@@ -1653,7 +1653,7 @@ Object {
           "nodeExcerpt": " ",
         },
         Object {
-          "kind": "Excerpt: ErrorText",
+          "kind": "Excerpt: NonstandardText",
           "nodeExcerpt": "{type} ",
         },
         Object {
@@ -1719,7 +1719,7 @@ Object {
           "nodeExcerpt": " ",
         },
         Object {
-          "kind": "Excerpt: ErrorText",
+          "kind": "Excerpt: NonstandardText",
           "nodeExcerpt": "{{}} ",
         },
         Object {
@@ -1785,7 +1785,7 @@ Object {
           "nodeExcerpt": " ",
         },
         Object {
-          "kind": "Excerpt: ErrorText",
+          "kind": "Excerpt: NonstandardText",
           "nodeExcerpt": "{[q]{[q]} ",
         },
         Object {
@@ -1851,7 +1851,7 @@ Object {
           "nodeExcerpt": " ",
         },
         Object {
-          "kind": "Excerpt: ErrorText",
+          "kind": "Excerpt: NonstandardText",
           "nodeExcerpt": "{[q][b][q][q]} ",
         },
         Object {
@@ -1925,7 +1925,7 @@ Object {
           "nodeExcerpt": " ",
         },
         Object {
-          "kind": "Excerpt: ErrorText",
+          "kind": "Excerpt: NonstandardText",
           "nodeExcerpt": "{type} ",
         },
         Object {
@@ -1991,7 +1991,7 @@ Object {
           "nodeExcerpt": " ",
         },
         Object {
-          "kind": "Excerpt: ErrorText",
+          "kind": "Excerpt: NonstandardText",
           "nodeExcerpt": "{{}} ",
         },
         Object {
@@ -2057,7 +2057,7 @@ Object {
           "nodeExcerpt": " ",
         },
         Object {
-          "kind": "Excerpt: ErrorText",
+          "kind": "Excerpt: NonstandardText",
           "nodeExcerpt": "{[q]{[q]} ",
         },
         Object {
@@ -2131,7 +2131,7 @@ Object {
           "nodeExcerpt": " ",
         },
         Object {
-          "kind": "Excerpt: ErrorText",
+          "kind": "Excerpt: NonstandardText",
           "nodeExcerpt": "{type} ",
         },
         Object {
@@ -2197,7 +2197,7 @@ Object {
           "nodeExcerpt": " ",
         },
         Object {
-          "kind": "Excerpt: ErrorText",
+          "kind": "Excerpt: NonstandardText",
           "nodeExcerpt": "{{}} ",
         },
         Object {
@@ -2263,7 +2263,7 @@ Object {
           "nodeExcerpt": " ",
         },
         Object {
-          "kind": "Excerpt: ErrorText",
+          "kind": "Excerpt: NonstandardText",
           "nodeExcerpt": "{[q]{[q]} ",
         },
         Object {
@@ -2313,7 +2313,7 @@ Object {
           "nodeExcerpt": " ",
         },
         Object {
-          "kind": "Excerpt: ErrorText",
+          "kind": "Excerpt: NonstandardText",
           "nodeExcerpt": "[",
         },
         Object {
@@ -2321,7 +2321,7 @@ Object {
           "nodeExcerpt": "k",
         },
         Object {
-          "kind": "Excerpt: ErrorText",
+          "kind": "Excerpt: NonstandardText",
           "nodeExcerpt": "]",
         },
         Object {
@@ -2383,7 +2383,7 @@ Object {
           "nodeExcerpt": " ",
         },
         Object {
-          "kind": "Excerpt: ErrorText",
+          "kind": "Excerpt: NonstandardText",
           "nodeExcerpt": "[",
         },
         Object {
@@ -2391,7 +2391,7 @@ Object {
           "nodeExcerpt": "l",
         },
         Object {
-          "kind": "Excerpt: ErrorText",
+          "kind": "Excerpt: NonstandardText",
           "nodeExcerpt": "=]",
         },
         Object {
@@ -2453,7 +2453,7 @@ Object {
           "nodeExcerpt": " ",
         },
         Object {
-          "kind": "Excerpt: ErrorText",
+          "kind": "Excerpt: NonstandardText",
           "nodeExcerpt": "[",
         },
         Object {
@@ -2461,7 +2461,7 @@ Object {
           "nodeExcerpt": "m",
         },
         Object {
-          "kind": "Excerpt: ErrorText",
+          "kind": "Excerpt: NonstandardText",
           "nodeExcerpt": "=[]]",
         },
         Object {
@@ -2523,7 +2523,7 @@ Object {
           "nodeExcerpt": " ",
         },
         Object {
-          "kind": "Excerpt: ErrorText",
+          "kind": "Excerpt: NonstandardText",
           "nodeExcerpt": "[",
         },
         Object {
@@ -2531,7 +2531,7 @@ Object {
           "nodeExcerpt": "n",
         },
         Object {
-          "kind": "Excerpt: ErrorText",
+          "kind": "Excerpt: NonstandardText",
           "nodeExcerpt": "=[q][[q]]",
         },
         Object {
@@ -2593,7 +2593,7 @@ Object {
           "nodeExcerpt": " ",
         },
         Object {
-          "kind": "Excerpt: ErrorText",
+          "kind": "Excerpt: NonstandardText",
           "nodeExcerpt": "[",
         },
         Object {
@@ -2601,7 +2601,7 @@ Object {
           "nodeExcerpt": "o",
         },
         Object {
-          "kind": "Excerpt: ErrorText",
+          "kind": "Excerpt: NonstandardText",
           "nodeExcerpt": "=[q][b][q][q]]",
         },
         Object {
@@ -2741,7 +2741,7 @@ Object {
           "nodeExcerpt": " ",
         },
         Object {
-          "kind": "Excerpt: ErrorText",
+          "kind": "Excerpt: NonstandardText",
           "nodeExcerpt": "[",
         },
         Object {

--- a/tsdoc/src/nodes/DocExcerpt.ts
+++ b/tsdoc/src/nodes/DocExcerpt.ts
@@ -20,7 +20,18 @@ export const enum ExcerptKind {
   DeclarationReference_ImportPath = 'DeclarationReference_ImportPath',
   DeclarationReference_ImportHash = 'DeclarationReference_ImportHash',
 
+  /**
+   * Input characters that were reported as an error and do not appear to be part of a valid expression.
+   * A syntax highlighter might display them with an error color (e.g. red).
+   */
   ErrorText = 'ErrorText',
+
+  /**
+   * Input characters that do not conform to the TSDoc specification, but were recognized by the parser, for example
+   * as a known JSDoc pattern.  A syntax highlighter should not display them with an error color (e.g. red)
+   * because the error reporting may be suppressed for "lax" parsing of legacy source code.
+   */
+  NonstandardText = 'NonstandardText',
 
   EscapedText = 'EscapedText',
 

--- a/tsdoc/src/nodes/DocParamBlock.ts
+++ b/tsdoc/src/nodes/DocParamBlock.ts
@@ -80,7 +80,7 @@ export class DocParamBlock extends DocBlock {
       if (parameters.unsupportedJsdocTypeBeforeParameterNameExcerpt) {
         this._unsupportedJsdocTypeBeforeParameterNameExcerpt = new DocExcerpt({
           configuration: this.configuration,
-          excerptKind: ExcerptKind.ErrorText,
+          excerptKind: ExcerptKind.NonstandardText,
           content: parameters.unsupportedJsdocTypeBeforeParameterNameExcerpt
         });
       }
@@ -88,7 +88,7 @@ export class DocParamBlock extends DocBlock {
       if (parameters.unsupportedJsdocOptionalNameOpenBracketExcerpt) {
         this._unsupportedJsdocOptionalNameOpenBracketExcerpt = new DocExcerpt({
           configuration: this.configuration,
-          excerptKind: ExcerptKind.ErrorText,
+          excerptKind: ExcerptKind.NonstandardText,
           content: parameters.unsupportedJsdocOptionalNameOpenBracketExcerpt
         });
       }
@@ -102,7 +102,7 @@ export class DocParamBlock extends DocBlock {
       if (parameters.unsupportedJsdocOptionalNameRestExcerpt) {
         this._unsupportedJsdocOptionalNameRestExcerpt = new DocExcerpt({
           configuration: this.configuration,
-          excerptKind: ExcerptKind.ErrorText,
+          excerptKind: ExcerptKind.NonstandardText,
           content: parameters.unsupportedJsdocOptionalNameRestExcerpt
         });
       }
@@ -118,7 +118,7 @@ export class DocParamBlock extends DocBlock {
       if (parameters.unsupportedJsdocTypeAfterParameterNameExcerpt) {
         this._unsupportedJsdocTypeAfterParameterNameExcerpt = new DocExcerpt({
           configuration: this.configuration,
-          excerptKind: ExcerptKind.ErrorText,
+          excerptKind: ExcerptKind.NonstandardText,
           content: parameters.unsupportedJsdocTypeAfterParameterNameExcerpt
         });
       }
@@ -142,7 +142,7 @@ export class DocParamBlock extends DocBlock {
       if (parameters.unsupportedJsdocTypeAfterHyphenExcerpt) {
         this._unsupportedJsdocTypeAfterHyphenExcerpt = new DocExcerpt({
           configuration: this.configuration,
-          excerptKind: ExcerptKind.ErrorText,
+          excerptKind: ExcerptKind.NonstandardText,
           content: parameters.unsupportedJsdocTypeAfterHyphenExcerpt
         });
       }

--- a/tsdoc/src/parser/NodeParser.ts
+++ b/tsdoc/src/parser/NodeParser.ts
@@ -339,8 +339,8 @@ export class NodeParser {
    * an input like `@param {string} [x="]"] - the X value`.  It detects nested balanced pairs of delimiters
    * and escaped string literals.
    */
-  private _tryParseJSDocTypeOrValueRest(tokenReader: TokenReader, openKind: TokenKind, closeKind: TokenKind): TokenSequence | undefined {
-    const startMarker: number = tokenReader.createMarker();
+  private _tryParseJSDocTypeOrValueRest(tokenReader: TokenReader, openKind: TokenKind, closeKind: TokenKind,
+    startMarker: number): TokenSequence | undefined {
 
     let quoteKind: TokenKind | undefined;
     let openCount: number = 1;
@@ -398,9 +398,13 @@ export class NodeParser {
       tokenReader.peekTokenAfterKind() === TokenKind.AtSign) {
       return undefined;
     }
+
+    const startMarker: number = tokenReader.createMarker();
     tokenReader.readToken(); // read the "{"
 
-    let jsdocTypeExcerpt: TokenSequence | undefined = this._tryParseJSDocTypeOrValueRest(tokenReader, TokenKind.LeftCurlyBracket, TokenKind.RightCurlyBracket);
+    let jsdocTypeExcerpt: TokenSequence | undefined = this._tryParseJSDocTypeOrValueRest(tokenReader,
+      TokenKind.LeftCurlyBracket, TokenKind.RightCurlyBracket, startMarker);
+
     if (jsdocTypeExcerpt) {
       this._parserContext.log.addMessageForTokenSequence(
         TSDocMessageId.ParamTagWithInvalidType,
@@ -427,7 +431,9 @@ export class NodeParser {
   private _tryParseJSDocOptionalNameRest(tokenReader: TokenReader): TokenSequence | undefined {
     tokenReader.assertAccumulatedSequenceIsEmpty();
     if (tokenReader.peekTokenKind() !== TokenKind.EndOfInput) {
-      return this._tryParseJSDocTypeOrValueRest(tokenReader, TokenKind.LeftSquareBracket, TokenKind.RightSquareBracket);
+      const startMarker: number = tokenReader.createMarker();
+      return this._tryParseJSDocTypeOrValueRest(tokenReader,
+        TokenKind.LeftSquareBracket, TokenKind.RightSquareBracket, startMarker);
     }
     return undefined;
   }

--- a/tsdoc/src/parser/NodeParser.ts
+++ b/tsdoc/src/parser/NodeParser.ts
@@ -334,9 +334,13 @@ export class NodeParser {
     }
   }
 
+  /**
+   * Used by `_parseParamBlock()`, this parses a JSDoc expression remainder like `string}` or `="]"]` from
+   * an input like `@param {string} [x="]"] - the X value`.  It detects nested balanced pairs of delimiters
+   * and escaped string literals.
+   */
   private _tryParseJSDocTypeOrValueRest(tokenReader: TokenReader, openKind: TokenKind, closeKind: TokenKind): TokenSequence | undefined {
     const startMarker: number = tokenReader.createMarker();
-    tokenReader.readToken();
 
     let quoteKind: TokenKind | undefined;
     let openCount: number = 1;
@@ -382,6 +386,10 @@ export class NodeParser {
     return tokenReader.tryExtractAccumulatedSequence();
   }
 
+  /**
+   * Used by `_parseParamBlock()`, this parses a JSDoc expression like `{string}` from
+   * an input like `@param {string} x - the X value`.
+   */
   private _tryParseUnsupportedJSDocType(tokenReader: TokenReader, docBlockTag: DocBlockTag, tagName: string): TokenSequence | undefined {
     tokenReader.assertAccumulatedSequenceIsEmpty();
 
@@ -390,6 +398,7 @@ export class NodeParser {
       tokenReader.peekTokenAfterKind() === TokenKind.AtSign) {
       return undefined;
     }
+    tokenReader.readToken(); // read the "{"
 
     let jsdocTypeExcerpt: TokenSequence | undefined = this._tryParseJSDocTypeOrValueRest(tokenReader, TokenKind.LeftCurlyBracket, TokenKind.RightCurlyBracket);
     if (jsdocTypeExcerpt) {
@@ -411,6 +420,10 @@ export class NodeParser {
     return jsdocTypeExcerpt;
   }
 
+  /**
+   * Used by `_parseParamBlock()`, this parses a JSDoc expression remainder like `=[]]` from
+   * an input like `@param {string} [x=[]] - the X value`.
+   */
   private _tryParseJSDocOptionalNameRest(tokenReader: TokenReader): TokenSequence | undefined {
     tokenReader.assertAccumulatedSequenceIsEmpty();
     if (tokenReader.peekTokenKind() !== TokenKind.EndOfInput) {
@@ -431,7 +444,7 @@ export class NodeParser {
     // Parse opening of invalid JSDoc optional parameter name (e.g., '[')
     let unsupportedJsdocOptionalNameOpenBracketExcerpt: TokenSequence | undefined;
     if (tokenReader.peekTokenKind() === TokenKind.LeftSquareBracket) {
-      tokenReader.readToken();
+      tokenReader.readToken(); // read the "["
       unsupportedJsdocOptionalNameOpenBracketExcerpt = tokenReader.extractAccumulatedSequence();
     }
 


### PR DESCRIPTION
This input did not parse correctly because `] -` was considered to be part of the description.

```ts
/**
 * @param [x] - an optional parameter
 */
```

@rbuckton