### PR TITLE
Flexible param parsing

### DIFF
--- a/common/changes/@microsoft/tsdoc/flexibleParamParsing_2020-02-22-06-13.json
+++ b/common/changes/@microsoft/tsdoc/flexibleParamParsing_2020-02-22-06-13.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/tsdoc",
+      "comment": "Fix parsing issue with jsdoc optional names.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@microsoft/tsdoc",
+  "email": "ron.buckton@microsoft.com"
+}

--- a/tsdoc/src/__tests__/__snapshots__/ParsingBasics.test.ts.snap
+++ b/tsdoc/src/__tests__/__snapshots__/ParsingBasics.test.ts.snap
@@ -2321,6 +2321,22 @@ Object {
           "nodeExcerpt": "k",
         },
         Object {
+          "kind": "Excerpt: ErrorText",
+          "nodeExcerpt": "]",
+        },
+        Object {
+          "kind": "Excerpt: Spacing",
+          "nodeExcerpt": " ",
+        },
+        Object {
+          "kind": "Excerpt: ParamBlock_Hyphen",
+          "nodeExcerpt": "-",
+        },
+        Object {
+          "kind": "Excerpt: Spacing",
+          "nodeExcerpt": " ",
+        },
+        Object {
           "kind": "Section",
           "nodes": Array [
             Object {
@@ -2331,7 +2347,7 @@ Object {
                   "nodes": Array [
                     Object {
                       "kind": "Excerpt: PlainText",
-                      "nodeExcerpt": "] - description",
+                      "nodeExcerpt": "description",
                     },
                   ],
                 },
@@ -2648,7 +2664,6 @@ Object {
     "(10,15): The @param block should not include a JSDoc-style '{type}'",
     "(11,15): The @param block should not include a JSDoc-style '{type}'",
     "(12,11): The @param should not include a JSDoc-style optional name; it must not be enclosed in '[ ]' brackets.",
-    "(12,4): The @param block should be followed by a parameter name and then a hyphen",
     "(13,11): The @param should not include a JSDoc-style optional name; it must not be enclosed in '[ ]' brackets.",
     "(14,11): The @param should not include a JSDoc-style optional name; it must not be enclosed in '[ ]' brackets.",
     "(15,11): The @param should not include a JSDoc-style optional name; it must not be enclosed in '[ ]' brackets.",

--- a/tsdoc/src/parser/NodeParser.ts
+++ b/tsdoc/src/parser/NodeParser.ts
@@ -334,10 +334,7 @@ export class NodeParser {
     }
   }
 
-  private _tryParseJSDocTypeOrValueRest(tokenReader: TokenReader, openKind: TokenKind, closeKind: TokenKind): TokenSequence | undefined {
-    const startMarker: number = tokenReader.createMarker();
-    tokenReader.readToken();
-
+  private _tryParseJSDocTypeOrValueRest(tokenReader: TokenReader, openKind: TokenKind, closeKind: TokenKind, startMarker: number): TokenSequence | undefined {
     let quoteKind: TokenKind | undefined;
     let openCount: number = 1;
     while (openCount > 0) {
@@ -391,7 +388,10 @@ export class NodeParser {
       return undefined;
     }
 
-    let jsdocTypeExcerpt: TokenSequence | undefined = this._tryParseJSDocTypeOrValueRest(tokenReader, TokenKind.LeftCurlyBracket, TokenKind.RightCurlyBracket);
+    const startMarker: number = tokenReader.createMarker();
+    tokenReader.readToken();
+
+    let jsdocTypeExcerpt: TokenSequence | undefined = this._tryParseJSDocTypeOrValueRest(tokenReader, TokenKind.LeftCurlyBracket, TokenKind.RightCurlyBracket, startMarker);
     if (jsdocTypeExcerpt) {
       this._parserContext.log.addMessageForTokenSequence(
         TSDocMessageId.ParamTagWithInvalidType,
@@ -414,7 +414,8 @@ export class NodeParser {
   private _tryParseJSDocOptionalNameRest(tokenReader: TokenReader): TokenSequence | undefined {
     tokenReader.assertAccumulatedSequenceIsEmpty();
     if (tokenReader.peekTokenKind() !== TokenKind.EndOfInput) {
-      return this._tryParseJSDocTypeOrValueRest(tokenReader, TokenKind.LeftSquareBracket, TokenKind.RightSquareBracket);
+      const startMarker: number = tokenReader.createMarker();
+      return this._tryParseJSDocTypeOrValueRest(tokenReader, TokenKind.LeftSquareBracket, TokenKind.RightSquareBracket, startMarker);
     }
     return undefined;
   }


### PR DESCRIPTION
Fixes an issue when parsing `@param [k] - description`.