### PR TITLE
eslint-plugin-tsdoc: set docs url to eslint-plugin/README.md

### DIFF
--- a/common/changes/eslint-plugin-tsdoc/eslint-plugin-url_2020-03-27-01-03.json
+++ b/common/changes/eslint-plugin-tsdoc/eslint-plugin-url_2020-03-27-01-03.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "eslint-plugin-tsdoc",
+      "comment": "Improve plugin documentation URL in ESLint metadata",
+      "type": "patch"
+    }
+  ],
+  "packageName": "eslint-plugin-tsdoc",
+  "email": "bitjson@users.noreply.github.com"
+}

--- a/eslint-plugin/src/index.ts
+++ b/eslint-plugin/src/index.ts
@@ -39,7 +39,7 @@ const plugin: IPlugin = {
           category: "Stylistic Issues",
           // This package is experimental
           recommended: false,
-          url: "https://github.com/microsoft/tsdoc"
+          url: "https://github.com/microsoft/tsdoc/blob/master/eslint-plugin/README.md"
         }
       },
       create: (context: eslint.Rule.RuleContext) => {


### PR DESCRIPTION
Just a small quality of life improvement – when a user selects `Show documentation for tsdoc/syntax` in a supporting editor, this takes them to the GitHub-formatted readme for `eslint-plugin-tsdoc` rather than the top-level of this GitHub repo. (Same strategy as [several](https://github.com/typescript-eslint/typescript-eslint/blob/fbf1640c5ab67770a1ace5a9bad2bddfa35bd88d/packages/eslint-plugin/src/util/createRule.ts#L8) [other](https://github.com/benmosher/eslint-plugin-import/blob/adbced7cde1818f23677384868e17380b886683e/src/docsUrl.js#L6) [eslint plugins](https://github.com/sindresorhus/eslint-plugin-unicorn/blob/ae983e29d1cbc769f5c1b079cc709cd431103898/rules/utils/get-documentation-url.js#L9).)