### PR TITLE
Add support for the `@see` tag

### DIFF
--- a/common/changes/@microsoft/tsdoc/hbergren-see-tag_2020-05-10-04-50.json
+++ b/common/changes/@microsoft/tsdoc/hbergren-see-tag_2020-05-10-04-50.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/tsdoc",
+      "comment": "Add support for `@see` tag",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@microsoft/tsdoc",
+  "email": "hansbergren@gmail.com"
+}

--- a/playground/src/DocHtmlView.tsx
+++ b/playground/src/DocHtmlView.tsx
@@ -72,6 +72,43 @@ export class DocHtmlView extends React.Component<IDocHtmlViewProps> {
       );
     }
 
+    const exampleBlocks: tsdoc.DocBlock[] = docComment.customBlocks.filter(x => x.blockTag.tagNameWithUpperCase
+      === tsdoc.StandardTags.example.tagNameWithUpperCase);
+
+    let exampleNumber: number = 1;
+    for (const exampleBlock of exampleBlocks) {
+      const heading: string = exampleBlocks.length > 1 ? `Example ${exampleNumber}` : 'Example';
+
+      outputElements.push(
+        <React.Fragment key='seeAlso'>
+          <h2 className='doc-heading'>{heading}</h2>
+          { this._renderContainer(exampleBlock.content) }
+        </React.Fragment>
+      );
+
+      ++exampleNumber;
+    }
+
+    if (docComment.seeBlocks.length > 0) {
+      const listItems: React.ReactNode[] = [];
+      for (const seeBlock of docComment.seeBlocks) {
+        listItems.push(
+          <li key={`item_${listItems.length}`}>
+            { this._renderContainer(seeBlock.content) }
+          </li>
+        );
+      }
+
+      outputElements.push(
+        <React.Fragment key='seeAlso'>
+          <h2 className='doc-heading'>See Also</h2>
+          <ul>
+            {listItems}
+          </ul>
+        </React.Fragment>
+      );
+    }
+
     const modifierTags: ReadonlyArray<tsdoc.DocBlockTag> = docComment.modifierTagSet.nodes;
 
     if (modifierTags.length > 0) {

--- a/tsdoc/src/details/StandardTags.ts
+++ b/tsdoc/src/details/StandardTags.ts
@@ -125,15 +125,15 @@ export class StandardTags {
    * separate NPM package.
    *
    * What gets copied
-   * 
-   * The `@inheritDoc` tag does not copy the entire comment body. Only the following 
+   *
+   * The `@inheritDoc` tag does not copy the entire comment body. Only the following
    * components are copied:
    * - summary section
    * - `@remarks` block
    * - `@params` blocks
    * - `@typeParam` blocks
    * - `@returns` block
-   * Other tags such as `@defaultValue` or `@example` are not copied, and need to be 
+   * Other tags such as `@defaultValue` or `@example` are not copied, and need to be
    * explicitly included after the `@inheritDoc` tag.
    *
    * TODO: The notation for API item references is still being standardized.  See this issue:
@@ -331,7 +331,8 @@ export class StandardTags {
   /**
    * (Extended)
    *
-   * Used to document another symbol or resource that may be related to the current item being documented.
+   * Used to build a list of references to an API item or other resource that may be related to the
+   * current item.
    *
    * @remarks
    *
@@ -339,18 +340,33 @@ export class StandardTags {
    *
    * ```ts
    * /**
-   *  * Link to the bar function.
-   *  * @see {@link bar}
+   *  * Parses a string containing a Uniform Resource Locator (URL).
+   *  * @see {@link ParsedUrl} for the returned data structure
+   *  * @see {@link https://tools.ietf.org/html/rfc1738|RFC 1738}
+   *  * for syntax
+   *  * @see your developer SDK for code samples
+   *  * @param url - the string to be parsed
+   *  * @returns the parsed result
    *  &#42;/
-   * function foo() {}
-
-   * // Use the inline {@link} tag to include a link within a free-form description.
-   * /**
-   *  * @see {@link foo} for further information.
-   *  * @see {@link http://github.com|GitHub}
-   *  &#42;/
-   * function bar() {}
+   * function parseURL(url: string): ParsedUrl;
    * ```
+   *
+   * `@see` is a block tag.  Each block becomes an item in the list of references.  For example, a documentation
+   * system might render the above blocks as follows:
+   *
+   * ```markdown
+   * `function parseURL(url: string): ParsedUrl;`
+   *
+   * Parses a string containing a Uniform Resource Locator (URL).
+   *
+   * ## See Also
+   * - ParsedUrl for the returned data structure
+   * - RFC 1738 for syntax
+   * - your developer SDK for code samples
+   * ```
+   *
+   * NOTE: JSDoc attempts to automatically hyperlink the text immediately after `@see`.  Because this is ambiguous
+   * with plain text, TSDoc instead requires an explicit `{@link}` tag to make hyperlinks.
    */
   public static readonly see: TSDocTagDefinition = StandardTags._defineTag({
     tagName: '@see',

--- a/tsdoc/src/details/StandardTags.ts
+++ b/tsdoc/src/details/StandardTags.ts
@@ -339,9 +339,8 @@ export class StandardTags {
    *
    * ```ts
    * /**
-   *  * Both of these will link to the bar function.
+   *  * Link to the bar function.
    *  * @see {@link bar}
-   *  * @see bar
    *  &#42;/
    * function foo() {}
 

--- a/tsdoc/src/details/StandardTags.ts
+++ b/tsdoc/src/details/StandardTags.ts
@@ -331,6 +331,37 @@ export class StandardTags {
   /**
    * (Extended)
    *
+   * Used to document another symbol or resource that may be related to the current item being documented.
+   *
+   * @remarks
+   *
+   * For example:
+   *
+   * ```ts
+   * /**
+   *  * Both of these will link to the bar function.
+   *  * @see {@link bar}
+   *  * @see bar
+   *  &#42;/
+   * function foo() {}
+
+   * // Use the inline {@link} tag to include a link within a free-form description.
+   * /**
+   *  * @see {@link foo} for further information.
+   *  * @see {@link http://github.com|GitHub}
+   *  &#42;/
+   * function bar() {}
+   * ```
+   */
+  public static readonly see: TSDocTagDefinition = StandardTags._defineTag({
+    tagName: '@see',
+    syntaxKind: TSDocTagSyntaxKind.BlockTag,
+    standardization: Standardization.Extended
+  });
+
+  /**
+   * (Extended)
+   *
    * Used to document an exception type that may be thrown by a function or property.
    *
    * @remarks
@@ -420,6 +451,7 @@ export class StandardTags {
     StandardTags.remarks,
     StandardTags.returns,
     StandardTags.sealed,
+    StandardTags.see,
     StandardTags.throws,
     StandardTags.typeParam,
     StandardTags.virtual

--- a/tsdoc/src/emitters/TSDocEmitter.ts
+++ b/tsdoc/src/emitters/TSDocEmitter.ts
@@ -130,6 +130,7 @@ export class TSDocEmitter {
           docComment.typeParams,
           docComment.returnsBlock,
           ...docComment.customBlocks,
+          ...docComment.seeBlocks,
           docComment.inheritDocTag
         ]);
         if (docComment.modifierTagSet.nodes.length > 0) {

--- a/tsdoc/src/nodes/DocComment.ts
+++ b/tsdoc/src/nodes/DocComment.ts
@@ -87,6 +87,7 @@ export class DocComment extends DocNode {
    */
   public readonly modifierTagSet: StandardModifierTagSet;
 
+  private _seeBlocks: DocBlock[];
   private _customBlocks: DocBlock[];
 
   /**
@@ -106,6 +107,7 @@ export class DocComment extends DocNode {
 
     this.modifierTagSet = new StandardModifierTagSet();
 
+    this._seeBlocks = []
     this._customBlocks = [];
   }
 
@@ -115,10 +117,24 @@ export class DocComment extends DocNode {
   }
 
   /**
+   * The collection of all `@see` DockBlockTag nodes belonging to this doc comment.
+   */
+  public get seeBlocks(): ReadonlyArray<DocBlock> {
+    return this._seeBlocks;
+  }
+
+  /**
    * The collection of all DocBlock nodes belonging to this doc comment.
    */
   public get customBlocks(): ReadonlyArray<DocBlock> {
     return this._customBlocks;
+  }
+
+  /**
+   * Append an item to the seeBlocks collection.
+   */
+  public appendSeeBlock(block: DocBlock): void {
+    this._seeBlocks.push(block);
   }
 
   /**
@@ -139,6 +155,7 @@ export class DocComment extends DocNode {
       this.typeParams.count > 0 ? this.typeParams : undefined,
       this.returnsBlock,
       ...this.customBlocks,
+      ...this.seeBlocks,
       this.inheritDocTag,
       ...this.modifierTagSet.nodes
     ];

--- a/tsdoc/src/nodes/DocComment.ts
+++ b/tsdoc/src/nodes/DocComment.ts
@@ -132,8 +132,9 @@ export class DocComment extends DocNode {
 
   /**
    * Append an item to the seeBlocks collection.
+   * @internal
    */
-  public appendSeeBlock(block: DocBlock): void {
+  public _appendSeeBlock(block: DocBlock): void {
     this._seeBlocks.push(block);
   }
 

--- a/tsdoc/src/parser/NodeParser.ts
+++ b/tsdoc/src/parser/NodeParser.ts
@@ -330,7 +330,7 @@ export class NodeParser {
         docComment.returnsBlock = block;
         break;
       case StandardTags.see.tagNameWithUpperCase:
-        docComment.appendSeeBlock(block);
+        docComment._appendSeeBlock(block);
         break;
       default:
         docComment.appendCustomBlock(block);

--- a/tsdoc/src/parser/NodeParser.ts
+++ b/tsdoc/src/parser/NodeParser.ts
@@ -329,6 +329,9 @@ export class NodeParser {
       case StandardTags.returns.tagNameWithUpperCase:
         docComment.returnsBlock = block;
         break;
+      case StandardTags.see.tagNameWithUpperCase:
+        docComment.appendSeeBlock(block);
+        break;
       default:
         docComment.appendCustomBlock(block);
     }


### PR DESCRIPTION
We use `eslint-plugin-tsdoc` in some of our projects, but we also use `@see` tags. I would like to be able to keep using both of these. This PR would address https://github.com/microsoft/tsdoc/issues/235.

This is blatantly stolen from https://github.com/microsoft/tsdoc/pull/205. @rbuckton , if you have any feedback, please let me know.

The `205` PR claims that implementing `@see` tag is blocked on [adding support for synonyms](https://github.com/microsoft/tsdoc/pull/204), but in the [JSDoc `@see` tag documentation](https://jsdoc.app/tags-see.html) it does not have a synonym listed. So, I thought we would be able to implement `@see` tag functionality without building synonyms.

I'm a little in over my head here, but I'm happy to learn.