### PR TITLE
fix(tsdoc): url typo on README

### DIFF
--- a/tsdoc/README.md
+++ b/tsdoc/README.md
@@ -37,7 +37,7 @@ Check out the [TSDoc Playground](https://microsoft.github.io/tsdoc/) for a cool 
 The [api-demo](https://github.com/microsoft/tsdoc/tree/master/api-demo) folder on GitHub illustrates how
 to invoke the TSDoc parser.
 
-A separate NPM package [`@microsoft/tsdoc-config`](https://www.npmjs.com/package/@microsoft/tsdoc)
+A separate NPM package [`@microsoft/tsdoc-config`](https://www.npmjs.com/package/@microsoft/tsdoc-config)
 is used for loading the **tsdoc.json** file.
 
 


### PR DESCRIPTION
Hey, it seems there is a typo on the README file from tsdoc package.

It should be pointing to other npm package, but it's currently pointing for itself.

😊 