### PR TITLE
Add a missing .d.ts file

### DIFF
--- a/common/changes/@microsoft/tsdoc/octogonz-beta-dts_2020-12-03-06-54.json
+++ b/common/changes/@microsoft/tsdoc/octogonz-beta-dts_2020-12-03-06-54.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/tsdoc",
+      "comment": "Add a missing declaration file",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@microsoft/tsdoc",
+  "email": "4673363+octogonz@users.noreply.github.com"
+}

--- a/tsdoc/config/heft.json
+++ b/tsdoc/config/heft.json
@@ -1,0 +1,23 @@
+{
+  "$schema": "https://developer.microsoft.com/json-schemas/heft/heft.schema.json",
+
+  "extends": "@rushstack/heft-web-rig/profiles/library/config/heft.json",
+
+  "eventActions": [
+    {
+      "actionKind": "copyFiles",
+
+      "heftEvent": "bundle",
+
+      "actionId": "add-dts-file",
+
+      "copyOperations": [
+        {
+          "sourceFolder": "lib/beta",
+          "destinationFolders": ["lib-commonjs/beta"],
+          "fileExtensions": [".d.ts"]
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
API Extractor uses a path-based import to access the "beta" API:
```
import {
  DeclarationReference
} from '@microsoft/tsdoc/lib-commonjs/beta/DeclarationReference';
```
This stopped working when we switched to Heft, because the .d.ts file is not emitted in that folder.

This PR is a temporary workaround until we find a better fix.