### PR TITLE
Add "supportForTags" field to tsdoc.json schema

### DIFF
--- a/common/changes/@microsoft/tsdoc-config/octogonz-tsdoc-config-features_2021-01-18-03-22.json
+++ b/common/changes/@microsoft/tsdoc-config/octogonz-tsdoc-config-features_2021-01-18-03-22.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/tsdoc-config",
+      "comment": "Add new \"supportForTags\" field to tsdoc.json schema",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@microsoft/tsdoc-config",
+  "email": "4673363+octogonz@users.noreply.github.com"
+}

--- a/common/changes/@microsoft/tsdoc-config/octogonz-tsdoc-config-features_2021-01-18-03-24.json
+++ b/common/changes/@microsoft/tsdoc-config/octogonz-tsdoc-config-features_2021-01-18-03-24.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/tsdoc-config",
+      "comment": "Add new APIs: TSDocConfigFile.supportForTags, .clearTagDefinitions(), .addTagDefinition(), .clearSupportForTags(), .setSupportForTag(), .loadFromParser(), .saveFile(), .saveToObject()",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@microsoft/tsdoc-config",
+  "email": "4673363+octogonz@users.noreply.github.com"
+}

--- a/common/changes/@microsoft/tsdoc/octogonz-tsdoc-config-features_2021-01-18-03-22.json
+++ b/common/changes/@microsoft/tsdoc/octogonz-tsdoc-config-features_2021-01-18-03-22.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/tsdoc",
+      "comment": "Add new APIs: TSDocConfiguration.clear() and TSDocTagDefinition.validateTSDocTagName()",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@microsoft/tsdoc",
+  "email": "4673363+octogonz@users.noreply.github.com"
+}

--- a/common/changes/@microsoft/tsdoc/octogonz-tsdoc-config-features_2021-01-18-03-24.json
+++ b/common/changes/@microsoft/tsdoc/octogonz-tsdoc-config-features_2021-01-18-03-24.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/tsdoc",
+      "comment": "Add new \"supportForTags\" field to tsdoc.json schema",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@microsoft/tsdoc",
+  "email": "4673363+octogonz@users.noreply.github.com"
+}

--- a/tsdoc-config/src/TSDocConfigFile.ts
+++ b/tsdoc-config/src/TSDocConfigFile.ts
@@ -14,7 +14,6 @@ import * as resolve from 'resolve';
 import * as path from 'path';
 import Ajv from 'ajv';
 import * as jju from 'jju';
-import { config } from 'process';
 
 const ajv: Ajv.Ajv = new Ajv({ verbose: true });
 

--- a/tsdoc-config/src/__tests__/TSDocConfigFile.test.ts
+++ b/tsdoc-config/src/__tests__/TSDocConfigFile.test.ts
@@ -45,6 +45,7 @@ test('Load p1', () => {
     }
   `);
 });
+
 test('Load p2', () => {
   expect(testLoadingFolder('assets/p2')).toMatchInlineSnapshot(`
     Object {
@@ -72,6 +73,7 @@ test('Load p2', () => {
     }
   `);
 });
+
 test('Load p3', () => {
   expect(testLoadingFolder('assets/p3')).toMatchInlineSnapshot(`
     Object {
@@ -149,6 +151,7 @@ test('Load p3', () => {
     }
   `);
 });
+
 test('Load p4', () => {
   expect(testLoadingFolder('assets/p4')).toMatchInlineSnapshot(`
     Object {
@@ -189,6 +192,24 @@ test('Load p4', () => {
         },
       ],
       "tsdocSchema": "https://developer.microsoft.com/json-schemas/tsdoc/v0/tsdoc.schema.json",
+    }
+  `);
+});
+
+test('Re-serialize p2', () => {
+  const configFile: TSDocConfigFile = TSDocConfigFile.loadForFolder(path.join(__dirname, 'assets/p3'));
+  expect(configFile.saveToObject()).toMatchInlineSnapshot(`
+    Object {
+      "$schema": "https://developer.microsoft.com/json-schemas/tsdoc/v0/tsdoc.schema.json",
+      "supportForTags": Object {
+        "@base2": true,
+      },
+      "tagDefinitions": Array [
+        Object {
+          "syntaxKind": "modifier",
+          "tagName": "@root",
+        },
+      ],
     }
   `);
 });

--- a/tsdoc-config/src/__tests__/TSDocConfigFile.test.ts
+++ b/tsdoc-config/src/__tests__/TSDocConfigFile.test.ts
@@ -215,10 +215,56 @@ test('Re-serialize p2', () => {
       ],
     }
   `);
+});
 
-  const configuration: TSDocConfiguration = new TSDocConfiguration();
+test('Re-serialize p2 without defaults', () => {
+  const parserConfiguration: TSDocConfiguration = new TSDocConfiguration();
+  parserConfiguration.clear(true);
 
-  const defaultsConfigFile: TSDocConfigFile = TSDocConfigFile.loadFromParser(configuration);
+  const defaultsConfigFile: TSDocConfigFile = TSDocConfigFile.loadFromParser(parserConfiguration);
+  // This is the default configuration created by the TSDocConfigFile constructor.
+  expect(defaultsConfigFile.saveToObject()).toMatchInlineSnapshot(`
+    Object {
+      "$schema": "https://developer.microsoft.com/json-schemas/tsdoc/v0/tsdoc.schema.json",
+    }
+  `);
+
+  const configFile: TSDocConfigFile = TSDocConfigFile.loadForFolder(path.join(__dirname, 'assets/p3'));
+  configFile.configureParser(parserConfiguration);
+
+  const mergedConfigFile: TSDocConfigFile = TSDocConfigFile.loadFromParser(parserConfiguration);
+
+  // This is the result of merging p3/tsdoc.json, tsdoc-base1.json, tsdoc-base2.json, and
+  // the TSDocConfiguration defaults.
+  expect(mergedConfigFile.saveToObject()).toMatchInlineSnapshot(`
+    Object {
+      "$schema": "https://developer.microsoft.com/json-schemas/tsdoc/v0/tsdoc.schema.json",
+      "supportForTags": Object {
+        "@base1": true,
+        "@base2": true,
+      },
+      "tagDefinitions": Array [
+        Object {
+          "syntaxKind": "modifier",
+          "tagName": "@base1",
+        },
+        Object {
+          "syntaxKind": "modifier",
+          "tagName": "@base2",
+        },
+        Object {
+          "syntaxKind": "modifier",
+          "tagName": "@root",
+        },
+      ],
+    }
+  `);
+});
+
+test('Re-serialize p2 with defaults', () => {
+  const parserConfiguration: TSDocConfiguration = new TSDocConfiguration();
+
+  const defaultsConfigFile: TSDocConfigFile = TSDocConfigFile.loadFromParser(parserConfiguration);
   // This is the default configuration created by the TSDocConfigFile constructor.
   expect(defaultsConfigFile.saveToObject()).toMatchInlineSnapshot(`
     Object {
@@ -334,12 +380,14 @@ test('Re-serialize p2', () => {
     }
   `);
 
-  configFile.configureParser(configuration);
-  const roundtripConfigFile: TSDocConfigFile = TSDocConfigFile.loadFromParser(configuration);
+  const configFile: TSDocConfigFile = TSDocConfigFile.loadForFolder(path.join(__dirname, 'assets/p3'));
+  configFile.configureParser(parserConfiguration);
+
+  const mergedConfigFile: TSDocConfigFile = TSDocConfigFile.loadFromParser(parserConfiguration);
 
   // This is the result of merging p3/tsdoc.json, tsdoc-base1.json, tsdoc-base2.json, and
   // the TSDocConfiguration defaults.
-  expect(roundtripConfigFile.saveToObject()).toMatchInlineSnapshot(`
+  expect(mergedConfigFile.saveToObject()).toMatchInlineSnapshot(`
     Object {
       "$schema": "https://developer.microsoft.com/json-schemas/tsdoc/v0/tsdoc.schema.json",
       "supportForTags": Object {

--- a/tsdoc-config/src/__tests__/TSDocConfigFile.test.ts
+++ b/tsdoc-config/src/__tests__/TSDocConfigFile.test.ts
@@ -21,6 +21,7 @@ expect.addSnapshotSerializer({
       extendsPaths: configFile.extendsPaths,
       extendsFiles: configFile.extendsFiles,
       tagDefinitions: configFile.tagDefinitions,
+      supportForTags: Array.from(configFile.supportForTags).map(([tagName, supported]) => ({ tagName, supported })),
       messages: configFile.log.messages,
     });
   },
@@ -38,6 +39,7 @@ test('Load p1', () => {
       "fileNotFound": false,
       "filePath": "assets/p1/tsdoc.json",
       "messages": Array [],
+      "supportForTags": Array [],
       "tagDefinitions": Array [],
       "tsdocSchema": "https://developer.microsoft.com/json-schemas/tsdoc/v0/tsdoc.schema.json",
     }
@@ -64,6 +66,7 @@ test('Load p2', () => {
           "unformattedText": "File not found",
         },
       ],
+      "supportForTags": Array [],
       "tagDefinitions": Array [],
       "tsdocSchema": "",
     }
@@ -79,6 +82,12 @@ test('Load p3', () => {
           "fileNotFound": false,
           "filePath": "assets/p3/base1/tsdoc-base1.json",
           "messages": Array [],
+          "supportForTags": Array [
+            Object {
+              "supported": true,
+              "tagName": "@base1",
+            },
+          ],
           "tagDefinitions": Array [
             TSDocTagDefinition {
               "allowMultiple": false,
@@ -96,6 +105,12 @@ test('Load p3', () => {
           "fileNotFound": false,
           "filePath": "assets/p3/base2/tsdoc-base2.json",
           "messages": Array [],
+          "supportForTags": Array [
+            Object {
+              "supported": false,
+              "tagName": "@base2",
+            },
+          ],
           "tagDefinitions": Array [
             TSDocTagDefinition {
               "allowMultiple": false,
@@ -115,6 +130,12 @@ test('Load p3', () => {
       "fileNotFound": false,
       "filePath": "assets/p3/tsdoc.json",
       "messages": Array [],
+      "supportForTags": Array [
+        Object {
+          "supported": true,
+          "tagName": "@base2",
+        },
+      ],
       "tagDefinitions": Array [
         TSDocTagDefinition {
           "allowMultiple": false,
@@ -138,6 +159,7 @@ test('Load p4', () => {
           "fileNotFound": false,
           "filePath": "assets/p4/node_modules/example-lib/dist/tsdoc-example.json",
           "messages": Array [],
+          "supportForTags": Array [],
           "tagDefinitions": Array [
             TSDocTagDefinition {
               "allowMultiple": false,
@@ -156,6 +178,7 @@ test('Load p4', () => {
       "fileNotFound": false,
       "filePath": "assets/p4/tsdoc.json",
       "messages": Array [],
+      "supportForTags": Array [],
       "tagDefinitions": Array [
         TSDocTagDefinition {
           "allowMultiple": false,

--- a/tsdoc-config/src/__tests__/TSDocConfigFile.test.ts
+++ b/tsdoc-config/src/__tests__/TSDocConfigFile.test.ts
@@ -1,4 +1,6 @@
+import { TSDocConfiguration } from '@microsoft/tsdoc';
 import * as path from 'path';
+import { config } from 'process';
 
 import { TSDocConfigFile } from '../TSDocConfigFile';
 
@@ -198,6 +200,7 @@ test('Load p4', () => {
 
 test('Re-serialize p2', () => {
   const configFile: TSDocConfigFile = TSDocConfigFile.loadForFolder(path.join(__dirname, 'assets/p3'));
+  // This is the data from p3/tsdoc.json, ignoring its "extends" field.
   expect(configFile.saveToObject()).toMatchInlineSnapshot(`
     Object {
       "$schema": "https://developer.microsoft.com/json-schemas/tsdoc/v0/tsdoc.schema.json",
@@ -205,6 +208,259 @@ test('Re-serialize p2', () => {
         "@base2": true,
       },
       "tagDefinitions": Array [
+        Object {
+          "syntaxKind": "modifier",
+          "tagName": "@root",
+        },
+      ],
+    }
+  `);
+
+  const configuration: TSDocConfiguration = new TSDocConfiguration();
+
+  const defaultsConfigFile: TSDocConfigFile = TSDocConfigFile.loadFromParser(configuration);
+  // This is the default configuration created by the TSDocConfigFile constructor.
+  expect(defaultsConfigFile.saveToObject()).toMatchInlineSnapshot(`
+    Object {
+      "$schema": "https://developer.microsoft.com/json-schemas/tsdoc/v0/tsdoc.schema.json",
+      "tagDefinitions": Array [
+        Object {
+          "syntaxKind": "modifier",
+          "tagName": "@alpha",
+        },
+        Object {
+          "syntaxKind": "modifier",
+          "tagName": "@beta",
+        },
+        Object {
+          "syntaxKind": "block",
+          "tagName": "@defaultValue",
+        },
+        Object {
+          "allowMultiple": true,
+          "syntaxKind": "block",
+          "tagName": "@decorator",
+        },
+        Object {
+          "syntaxKind": "block",
+          "tagName": "@deprecated",
+        },
+        Object {
+          "syntaxKind": "modifier",
+          "tagName": "@eventProperty",
+        },
+        Object {
+          "allowMultiple": true,
+          "syntaxKind": "block",
+          "tagName": "@example",
+        },
+        Object {
+          "syntaxKind": "modifier",
+          "tagName": "@experimental",
+        },
+        Object {
+          "syntaxKind": "inline",
+          "tagName": "@inheritDoc",
+        },
+        Object {
+          "syntaxKind": "modifier",
+          "tagName": "@internal",
+        },
+        Object {
+          "syntaxKind": "inline",
+          "tagName": "@label",
+        },
+        Object {
+          "allowMultiple": true,
+          "syntaxKind": "inline",
+          "tagName": "@link",
+        },
+        Object {
+          "syntaxKind": "modifier",
+          "tagName": "@override",
+        },
+        Object {
+          "syntaxKind": "modifier",
+          "tagName": "@packageDocumentation",
+        },
+        Object {
+          "allowMultiple": true,
+          "syntaxKind": "block",
+          "tagName": "@param",
+        },
+        Object {
+          "syntaxKind": "block",
+          "tagName": "@privateRemarks",
+        },
+        Object {
+          "syntaxKind": "modifier",
+          "tagName": "@public",
+        },
+        Object {
+          "syntaxKind": "modifier",
+          "tagName": "@readonly",
+        },
+        Object {
+          "syntaxKind": "block",
+          "tagName": "@remarks",
+        },
+        Object {
+          "syntaxKind": "block",
+          "tagName": "@returns",
+        },
+        Object {
+          "syntaxKind": "modifier",
+          "tagName": "@sealed",
+        },
+        Object {
+          "syntaxKind": "block",
+          "tagName": "@see",
+        },
+        Object {
+          "allowMultiple": true,
+          "syntaxKind": "block",
+          "tagName": "@throws",
+        },
+        Object {
+          "allowMultiple": true,
+          "syntaxKind": "block",
+          "tagName": "@typeParam",
+        },
+        Object {
+          "syntaxKind": "modifier",
+          "tagName": "@virtual",
+        },
+      ],
+    }
+  `);
+
+  configFile.configureParser(configuration);
+  const roundtripConfigFile: TSDocConfigFile = TSDocConfigFile.loadFromParser(configuration);
+
+  // This is the result of merging p3/tsdoc.json, tsdoc-base1.json, tsdoc-base2.json, and
+  // the TSDocConfiguration defaults.
+  expect(roundtripConfigFile.saveToObject()).toMatchInlineSnapshot(`
+    Object {
+      "$schema": "https://developer.microsoft.com/json-schemas/tsdoc/v0/tsdoc.schema.json",
+      "supportForTags": Object {
+        "@base1": true,
+        "@base2": true,
+      },
+      "tagDefinitions": Array [
+        Object {
+          "syntaxKind": "modifier",
+          "tagName": "@alpha",
+        },
+        Object {
+          "syntaxKind": "modifier",
+          "tagName": "@beta",
+        },
+        Object {
+          "syntaxKind": "block",
+          "tagName": "@defaultValue",
+        },
+        Object {
+          "allowMultiple": true,
+          "syntaxKind": "block",
+          "tagName": "@decorator",
+        },
+        Object {
+          "syntaxKind": "block",
+          "tagName": "@deprecated",
+        },
+        Object {
+          "syntaxKind": "modifier",
+          "tagName": "@eventProperty",
+        },
+        Object {
+          "allowMultiple": true,
+          "syntaxKind": "block",
+          "tagName": "@example",
+        },
+        Object {
+          "syntaxKind": "modifier",
+          "tagName": "@experimental",
+        },
+        Object {
+          "syntaxKind": "inline",
+          "tagName": "@inheritDoc",
+        },
+        Object {
+          "syntaxKind": "modifier",
+          "tagName": "@internal",
+        },
+        Object {
+          "syntaxKind": "inline",
+          "tagName": "@label",
+        },
+        Object {
+          "allowMultiple": true,
+          "syntaxKind": "inline",
+          "tagName": "@link",
+        },
+        Object {
+          "syntaxKind": "modifier",
+          "tagName": "@override",
+        },
+        Object {
+          "syntaxKind": "modifier",
+          "tagName": "@packageDocumentation",
+        },
+        Object {
+          "allowMultiple": true,
+          "syntaxKind": "block",
+          "tagName": "@param",
+        },
+        Object {
+          "syntaxKind": "block",
+          "tagName": "@privateRemarks",
+        },
+        Object {
+          "syntaxKind": "modifier",
+          "tagName": "@public",
+        },
+        Object {
+          "syntaxKind": "modifier",
+          "tagName": "@readonly",
+        },
+        Object {
+          "syntaxKind": "block",
+          "tagName": "@remarks",
+        },
+        Object {
+          "syntaxKind": "block",
+          "tagName": "@returns",
+        },
+        Object {
+          "syntaxKind": "modifier",
+          "tagName": "@sealed",
+        },
+        Object {
+          "syntaxKind": "block",
+          "tagName": "@see",
+        },
+        Object {
+          "allowMultiple": true,
+          "syntaxKind": "block",
+          "tagName": "@throws",
+        },
+        Object {
+          "allowMultiple": true,
+          "syntaxKind": "block",
+          "tagName": "@typeParam",
+        },
+        Object {
+          "syntaxKind": "modifier",
+          "tagName": "@virtual",
+        },
+        Object {
+          "syntaxKind": "modifier",
+          "tagName": "@base1",
+        },
+        Object {
+          "syntaxKind": "modifier",
+          "tagName": "@base2",
+        },
         Object {
           "syntaxKind": "modifier",
           "tagName": "@root",

--- a/tsdoc-config/src/__tests__/TSDocConfigFile.test.ts
+++ b/tsdoc-config/src/__tests__/TSDocConfigFile.test.ts
@@ -1,6 +1,5 @@
 import { TSDocConfiguration } from '@microsoft/tsdoc';
 import * as path from 'path';
-import { config } from 'process';
 
 import { TSDocConfigFile } from '../TSDocConfigFile';
 

--- a/tsdoc-config/src/__tests__/assets/p3/base1/tsdoc-base1.json
+++ b/tsdoc-config/src/__tests__/assets/p3/base1/tsdoc-base1.json
@@ -5,5 +5,8 @@
       "tagName": "@base1",
       "syntaxKind": "modifier"
     }
-  ]
+  ],
+  "supportForTags": {
+    "@base1": true
+  }
 }

--- a/tsdoc-config/src/__tests__/assets/p3/base2/tsdoc-base2.json
+++ b/tsdoc-config/src/__tests__/assets/p3/base2/tsdoc-base2.json
@@ -5,5 +5,8 @@
       "tagName": "@base2",
       "syntaxKind": "modifier"
     }
-  ]
+  ],
+  "supportForTags": {
+    "@base2": false
+  }
 }

--- a/tsdoc-config/src/__tests__/assets/p3/tsdoc.json
+++ b/tsdoc-config/src/__tests__/assets/p3/tsdoc.json
@@ -6,5 +6,8 @@
       "tagName": "@root",
       "syntaxKind": "modifier"
     }
-  ]
+  ],
+  "supportForTags": {
+    "@base2": true
+  }
 }

--- a/tsdoc/schemas/tsdoc.schema.json
+++ b/tsdoc/schemas/tsdoc.schema.json
@@ -22,6 +22,17 @@
       "items": {
         "$ref": "#/definitions/tsdocTagDefinition"
       }
+    },
+
+    "supportForTags": {
+      "description": "A collection of key/value pairs.  The key is a TSDoc tag name (e.g. \"@myTag\") that must be defined in this configuration.  The value is a boolean indicating whether the tag is supported.  The TSDoc parser may report warnings when unsupported tags are encountered.  If \"supportForTags\" is specified for at least one tag, then the \"reportUnsupportedTags\" validation check is enabled by default.",
+      "type": "object",
+      "patternProperties": {
+        "@[a-zA-Z][a-zA-Z0-9]*$": {
+          "type": "boolean"
+        }
+      },
+      "additionalItems": false
     }
   },
   "required": ["$schema"],

--- a/tsdoc/src/configuration/TSDocConfiguration.ts
+++ b/tsdoc/src/configuration/TSDocConfiguration.ts
@@ -22,11 +22,28 @@ export class TSDocConfiguration {
     this._validation = new TSDocValidationConfiguration();
     this._docNodeManager = new DocNodeManager();
 
-    // Define all the standard tags
-    this.addTagDefinitions(StandardTags.allDefinitions);
+    this.clear(false);
 
     // Register the built-in node kinds
     BuiltInDocNodes.register(this);
+  }
+
+  /**
+   * Resets the `TSDocConfiguration` object to its initial empty state.
+   * @param noStandardTags - The `TSDocConfiguration` constructor normally adds definitions for the
+   * standard TSDoc tags.  Set `noStandardTags` to true for a completely empty `tagDefinitions` collection.
+   */
+  public clear(noStandardTags: boolean = false): void {
+    this._tagDefinitions.length = 0;
+    this._tagDefinitionsByName.clear();
+    this._supportedTagDefinitions.clear();
+    this._validation.ignoreUndefinedTags = false;
+    this._validation.reportUnsupportedTags = false;
+
+    if (!noStandardTags) {
+      // Define all the standard tags
+      this.addTagDefinitions(StandardTags.allDefinitions);
+    }
   }
 
   /**

--- a/tsdoc/src/configuration/TSDocTagDefinition.ts
+++ b/tsdoc/src/configuration/TSDocTagDefinition.ts
@@ -81,4 +81,11 @@ export class TSDocTagDefinition {
       (parameters as ITSDocTagDefinitionInternalParameters).standardization || Standardization.None;
     this.allowMultiple = !!parameters.allowMultiple;
   }
+
+  /**
+   * Throws an exception if `tagName` is not a valid TSDoc tag name.
+   */
+  public static validateTSDocTagName(tagName: string): void {
+    StringChecks.validateTSDocTagName(tagName);
+  }
 }

--- a/tsdoc/src/parser/TSDocMessageId.ts
+++ b/tsdoc/src/parser/TSDocMessageId.ts
@@ -412,6 +412,7 @@ export const allTsdocMessageIds: string[] = [
   'tsdoc-config-unresolved-extends',
   'tsdoc-config-undefined-tag',
   'tsdoc-config-duplicate-tag-name',
+  'tsdoc-config-invalid-tag-name',
 
   'tsdoc-comment-not-found',
   'tsdoc-comment-missing-opening-delimiter',

--- a/tsdoc/src/parser/TSDocMessageId.ts
+++ b/tsdoc/src/parser/TSDocMessageId.ts
@@ -48,8 +48,24 @@ export const enum TSDocMessageId {
 
   /**
    * The "supportForTags" field refers to an undefined tag "___".
+   * @remarks
+   * Reported by the `@microsoft/tsdoc-config` package when loading the tsdoc.json config file.
    */
   ConfigFileUndefinedTag = 'tsdoc-config-undefined-tag',
+
+  /**
+   * The "tagDefinitions" field specifies more than one tag with the name "___".
+   * @remarks
+   * Reported by the `@microsoft/tsdoc-config` package when loading the tsdoc.json config file.
+   */
+  ConfigFileDuplicateTagName = 'tsdoc-config-duplicate-tag-name',
+
+  /**
+   * A TSDoc tag name must start with a letter and contain only letters and numbers.
+   * @remarks
+   * Reported by the `@microsoft/tsdoc-config` package when loading the tsdoc.json config file.
+   */
+  ConfigFileInvalidTagName = 'tsdoc-config-invalid-tag-name',
 
   /**
    * Expecting a `/**` comment.
@@ -395,6 +411,7 @@ export const allTsdocMessageIds: string[] = [
   'tsdoc-config-cyclic-extends',
   'tsdoc-config-unresolved-extends',
   'tsdoc-config-undefined-tag',
+  'tsdoc-config-duplicate-tag-name',
 
   'tsdoc-comment-not-found',
   'tsdoc-comment-missing-opening-delimiter',

--- a/tsdoc/src/parser/TSDocMessageId.ts
+++ b/tsdoc/src/parser/TSDocMessageId.ts
@@ -47,6 +47,11 @@ export const enum TSDocMessageId {
   ConfigFileUnresolvedExtends = 'tsdoc-config-unresolved-extends',
 
   /**
+   * The "supportForTags" field refers to an undefined tag "___".
+   */
+  ConfigFileUndefinedTag = 'tsdoc-config-undefined-tag',
+
+  /**
    * Expecting a `/**` comment.
    * Unexpected end of input.
    */
@@ -389,6 +394,8 @@ export const allTsdocMessageIds: string[] = [
   'tsdoc-config-schema-error',
   'tsdoc-config-cyclic-extends',
   'tsdoc-config-unresolved-extends',
+  'tsdoc-config-undefined-tag',
+
   'tsdoc-comment-not-found',
   'tsdoc-comment-missing-opening-delimiter',
   'tsdoc-comment-missing-closing-delimiter',


### PR DESCRIPTION
This PR also adds the ability to generate a **tsdoc.json** file containing the `TSDocConfiguration` state.