### PR TITLE
Add TSDocConfigFile.loadFromObject()

### DIFF
--- a/common/changes/@microsoft/tsdoc-config/octogonz-load-from-object_2021-04-16-22-59.json
+++ b/common/changes/@microsoft/tsdoc-config/octogonz-load-from-object_2021-04-16-22-59.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/tsdoc-config",
+      "comment": "Add a new API TSDocConfigFile.loadFromObject()",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@microsoft/tsdoc-config",
+  "email": "4673363+octogonz@users.noreply.github.com"
+}

--- a/tsdoc-config/src/__tests__/TSDocConfigFile.test.ts
+++ b/tsdoc-config/src/__tests__/TSDocConfigFile.test.ts
@@ -1,4 +1,4 @@
-import { Standardization, TSDocConfiguration, TSDocTagDefinition, TSDocTagSyntaxKind } from '@microsoft/tsdoc';
+import { TSDocConfiguration, TSDocTagDefinition, TSDocTagSyntaxKind } from '@microsoft/tsdoc';
 import * as path from 'path';
 
 import { TSDocConfigFile } from '../TSDocConfigFile';


### PR DESCRIPTION
This PR adds an API that is needed for PR https://github.com/microsoft/rushstack/pull/1950.

The `TSDocConfigFile.loadFromObject()` is the loading operation that corresponds to `TSDocConfigFile.saveToObject()` 