### PR TITLE
[tsdoc] remove "const" keyword before enum to use with typescript isolatedModules

### DIFF
--- a/common/changes/@microsoft/tsdoc/master_2021-12-07-00-40.json
+++ b/common/changes/@microsoft/tsdoc/master_2021-12-07-00-40.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/tsdoc",
+      "comment": "remove \"const\" keyword before enums to allow use with typescript isolatedModules",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@microsoft/tsdoc",
+  "email": "samisayegh@users.noreply.github.com"
+}

--- a/tsdoc/etc/tsdoc.api.md
+++ b/tsdoc/etc/tsdoc.api.md
@@ -299,7 +299,7 @@ export abstract class DocNodeContainer extends DocNode {
 }
 
 // @public
-export const enum DocNodeKind {
+export enum DocNodeKind {
     // (undocumented)
     Block = "Block",
     // (undocumented)
@@ -440,7 +440,7 @@ export enum EscapeStyle {
 }
 
 // @public
-export const enum ExcerptKind {
+export enum ExcerptKind {
     // (undocumented)
     BlockTag = "BlockTag",
     // (undocumented)
@@ -1095,7 +1095,7 @@ export class PlainTextEmitter {
     }
 
 // @public
-export const enum SelectorKind {
+export enum SelectorKind {
     Error = "error",
     Index = "index",
     Label = "label",
@@ -1103,7 +1103,7 @@ export const enum SelectorKind {
 }
 
 // @public
-export const enum Standardization {
+export enum Standardization {
     Core = "Core",
     Discretionary = "Discretionary",
     Extended = "Extended",
@@ -1269,7 +1269,7 @@ export class TSDocEmitter {
     }
 
 // @public
-export const enum TSDocMessageId {
+export enum TSDocMessageId {
     AtSignInWord = "tsdoc-at-sign-in-word",
     AtSignWithoutTagName = "tsdoc-at-sign-without-tag-name",
     CharactersAfterBlockTag = "tsdoc-characters-after-block-tag",

--- a/tsdoc/src/details/Standardization.ts
+++ b/tsdoc/src/details/Standardization.ts
@@ -2,7 +2,7 @@
  * Used to group the {@link StandardTags} definitions according to the level of support
  * expected from documentation tools that implement the standard.
  */
-export const enum Standardization {
+export enum Standardization {
   /**
    * TSDoc tags in the "Core" standardization group are considered essential.
    * Their meaning is standardized, and every documentation tool is expected

--- a/tsdoc/src/nodes/DocExcerpt.ts
+++ b/tsdoc/src/nodes/DocExcerpt.ts
@@ -7,7 +7,7 @@ import { TokenKind } from '../parser/Token';
 /**
  * Indicates the type of {@link DocExcerpt}.
  */
-export const enum ExcerptKind {
+export enum ExcerptKind {
   Spacing = 'Spacing',
 
   BlockTag = 'BlockTag',

--- a/tsdoc/src/nodes/DocMemberSelector.ts
+++ b/tsdoc/src/nodes/DocMemberSelector.ts
@@ -6,7 +6,7 @@ import { DocExcerpt, ExcerptKind } from './DocExcerpt';
 /**
  * Kinds of TSDoc selectors.
  */
-export const enum SelectorKind {
+export enum SelectorKind {
   /**
    * Used in cases where the parser encounters a string that is incorrect but
    * valid enough that a DocMemberSelector node was created.

--- a/tsdoc/src/nodes/DocNode.ts
+++ b/tsdoc/src/nodes/DocNode.ts
@@ -8,7 +8,7 @@ import { TSDocConfiguration } from '../configuration/TSDocConfiguration';
  * To avoid naming conflicts between projects, the enum value should be a string comprised of your full
  * NPM package name, followed by a "#" symbol, followed by the class name (without the "Doc" prefix).
  */
-export const enum DocNodeKind {
+export enum DocNodeKind {
   Block = 'Block',
   BlockTag = 'BlockTag',
   Excerpt = 'Excerpt',

--- a/tsdoc/src/parser/TSDocMessageId.ts
+++ b/tsdoc/src/parser/TSDocMessageId.ts
@@ -9,7 +9,7 @@
  *
  * @public
  */
-export const enum TSDocMessageId {
+export enum TSDocMessageId {
   /**
    * File not found
    * @remarks


### PR DESCRIPTION
## Summary

When a typescript project is using [isolatedModules](https://www.typescriptlang.org/tsconfig#isolatedModules), referencing exported const enums is not allowed.

## Details

Please refer to [this PR](https://github.com/microsoft/rushstack/pull/3074).