### PR TITLE
[playground] Add TSDoc parsing, banner

### DIFF
--- a/playground/src/PlaygroundView.tsx
+++ b/playground/src/PlaygroundView.tsx
@@ -139,11 +139,25 @@ export class PlaygroundView extends React.Component<IPlaygroundViewProps, IPlayg
       borderColor: '#c0c0c0'
     };
 
+    const bannerStyle: React.CSSProperties = {
+      width: '100%',
+      padding: '8px 16px',
+      border: '1px solid #006721',
+      borderRadius: '3px',
+      color: 'var(--white)',
+      background: '#108938',
+      marginBottom: '8px',
+      fontSize: '14px'
+    };
+
     return (
       <FlexColDiv className="playground-input-box" style={{ flex: 1 }}>
         <div className="playground-button-bar" style={{ height: '40px', boxSizing: 'border-box' }}>
           {this._renderSelectSample()}
           {this._renderThemeSelector()}
+        </div>
+        <div className="playground-notice-banner" style={bannerStyle}>
+          TSDoc does not parse Typescript. Typescript code used here is for illustrative purposes only.
         </div>
         <CodeEditor
           className="playground-input-text-editor"

--- a/playground/src/PlaygroundView.tsx
+++ b/playground/src/PlaygroundView.tsx
@@ -150,7 +150,7 @@ export class PlaygroundView extends React.Component<IPlaygroundViewProps, IPlayg
           style={editorStyle}
           value={this.state.inputText}
           onChange={this._inputTextArea_onChange}
-          language="typescript"
+          language="tsdocLanguage"
           markers={markers}
           syntaxStyles={syntaxStyles}
           theme={this.state.selectedTheme}


### PR DESCRIPTION
After getting a bit confused TSDoc because of the playground myself (I initially thought the parser would parse the types for me) so I made a quick PR to make two changes that I have seen in #115 and #152:

#### Disable Parsing of Typescript

I just went ahead and made a parser in Monaco for TSDoc. It isn't perfect, but it keeps track of if you're in a block and doesn't parse Typescript/Javascript. As you can see in the screenshot below, the function after the TSDoc is not highlighted.

#### Add Banner to the Playground

Added a small banner to further reinforce that neither TSDoc nor the playground parses Typescript.

<img width="1509" alt="playground-screenshot" src="https://user-images.githubusercontent.com/4841586/148455561-4c7af49b-d0dd-4c19-9dfd-8e2461b893a6.png">
