### PR TITLE
Change import path to avoid circular reference

### DIFF
--- a/common/changes/@microsoft/tsdoc/fix-remove-circular-reference_2022-07-16-06-37.json
+++ b/common/changes/@microsoft/tsdoc/fix-remove-circular-reference_2022-07-16-06-37.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/tsdoc",
+      "comment": "Change import path to avoid circular reference",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@microsoft/tsdoc",
+  "email": "7829098+magic-akari@users.noreply.github.com"
+}

--- a/tsdoc/src/emitters/TSDocEmitter.ts
+++ b/tsdoc/src/emitters/TSDocEmitter.ts
@@ -24,7 +24,7 @@ import type {
   DocMemberSelector,
   DocParamBlock
 } from '../nodes';
-import { DocNodeKind } from '../nodes';
+import { DocNodeKind } from '../nodes/DocNode';
 import { IStringBuilder } from './StringBuilder';
 import { DocNodeTransforms } from '../transforms/DocNodeTransforms';
 import { StandardTags } from '../details/StandardTags';


### PR DESCRIPTION
follow up #327 
I noticed that the DocNodeKind import still causes circular reference (because require doesn't work like import).
Changing it to a reference to the internal path would solve this issue.