### PR TITLE
Fix duplicated react element key in playground

### DIFF
--- a/playground/src/DocHtmlView.tsx
+++ b/playground/src/DocHtmlView.tsx
@@ -133,7 +133,7 @@ export class DocHtmlView extends React.Component<IDocHtmlViewProps> {
       const heading: string = exampleBlocks.length > 1 ? `Example ${exampleNumber}` : 'Example';
 
       outputElements.push(
-        <React.Fragment key="seeAlso">
+        <React.Fragment key="example">
           <h2 className="doc-heading">{heading}</h2>
           {this._renderContainer(exampleBlock.content)}
         </React.Fragment>


### PR DESCRIPTION
`seeAlso` key is duplicated.  

So I changed it to `example`.  

Check please.