### PR TITLE
DocMemberSelector: update to allow 0 as index selector

### DIFF
--- a/common/changes/@microsoft/tsdoc/patch-1_2023-05-03-18-55.json
+++ b/common/changes/@microsoft/tsdoc/patch-1_2023-05-03-18-55.json
@@ -1,0 +1,11 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/tsdoc",
+      "comment": "Improve the docs to clarify that overload indexes count from 1 not 0",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@microsoft/tsdoc",
+  "email": "4673363+octogonz@users.noreply.github.com"
+}

--- a/spec/code-snippets/DeclarationReferences.ts
+++ b/spec/code-snippets/DeclarationReferences.ts
@@ -128,11 +128,13 @@ export namespace B1.B2.B3 {
 }
 
 //---------------------------------------------------------
-// Function overloads using indexes (NOT RECOMMENDED)
+// Function overloads using  positive integer indexes (NOT RECOMMENDED)
 //
 // Generally we recommend to define labels, as shown with functionD1() below.
 // Numeric indexes should only be used e.g. if you are consuming a library that
 // doesn't define labels, and you cannot easily fix that library.
+// Note that overload indexes count from 1 (like documentation list items),
+// not 0 (like arrays).
 
 /**
  * Shortest name:  {@link (functionC1:1)}

--- a/tsdoc/src/beta/DeclarationReference.ts
+++ b/tsdoc/src/beta/DeclarationReference.ts
@@ -1224,6 +1224,9 @@ class Parser {
   private tryParseOverloadIndex(hasMeaning: boolean): number | undefined {
     if (this.optionalToken(Token.OpenParenToken)) {
       const overloadIndex: number = this.parseDecimalDigits();
+      if (overloadIndex < 1) {
+        return this.fail('The overload index must not be less than 1', overloadIndex);
+      }
       this.expectToken(Token.CloseParenToken);
       return overloadIndex;
     } else if (!hasMeaning) {

--- a/tsdoc/src/nodes/DocMemberSelector.ts
+++ b/tsdoc/src/nodes/DocMemberSelector.ts
@@ -57,7 +57,7 @@ export interface IDocMemberSelectorParsedParameters extends IDocNodeParsedParame
 export class DocMemberSelector extends DocNode {
   private static readonly _likeIndexSelectorRegExp: RegExp = /^[0-9]/;
 
-  private static readonly _indexSelectorRegExp: RegExp = /^(0|[1-9][0-9]*)$/;
+  private static readonly _indexSelectorRegExp: RegExp = /^[1-9][0-9]*$/;
 
   private static readonly _likeLabelSelectorRegExp: RegExp = /^[A-Z_]/u;
 

--- a/tsdoc/src/nodes/DocMemberSelector.ts
+++ b/tsdoc/src/nodes/DocMemberSelector.ts
@@ -57,7 +57,7 @@ export interface IDocMemberSelectorParsedParameters extends IDocNodeParsedParame
 export class DocMemberSelector extends DocNode {
   private static readonly _likeIndexSelectorRegExp: RegExp = /^[0-9]/;
 
-  private static readonly _indexSelectorRegExp: RegExp = /^[1-9][0-9]*$/;
+  private static readonly _indexSelectorRegExp: RegExp = /^(0|[1-9][0-9]*)$/;
 
   private static readonly _likeLabelSelectorRegExp: RegExp = /^[A-Z_]/u;
 

--- a/tsdoc/src/nodes/DocMemberSelector.ts
+++ b/tsdoc/src/nodes/DocMemberSelector.ts
@@ -19,14 +19,17 @@ export enum SelectorKind {
   System = 'system',
 
   /**
-   * Index selectors are integer numbers.  They provide an alternative way of referencing
-   * overloaded functions, based on the order in which the declarations appear in
+   * Index selectors are positive integer numbers.  They provide an alternative way of
+   * referencing overloaded functions, based on the order in which the declarations appear in
    * a source file.
    *
    * @remarks
    * Warning:  Index selectors are not recommended; they are intended to provide a temporary
    * workaround for situations where an external library neglected to declare a `{@label}` tag
    * and cannot be easily fixed.
+   *
+   * The number of an overloaded function is called its "overload index".  Note that
+   * overload indexes count from 1 (like documentation list items) not 0 (like arrays).
    */
   Index = 'index',
 
@@ -142,7 +145,7 @@ export class DocMemberSelector extends DocNode {
    * @remarks
    * For system selectors, it will be a predefined lower case name.
    * For label selectors, it will be an upper case name defined using the `{@label}` tag.
-   * For index selectors, it will be a positive integer.
+   * For index selectors, it will be an overload index which is a positive integer.
    */
   public get selector(): string {
     return this._selector;


### PR DESCRIPTION
Quick lil' PR as I ran across this and it seems like a bug. The current RegExp doesn't allow `:0`, but as far as I can tell the index selectors are 0-based.

Just wanted to check if this was the case, and could then work to get this in a mergeable state.