### PR TITLE
Add support for `@since` and `@version` tags

### DIFF
--- a/common/changes/@microsoft/tsdoc-config/main_2024-04-10-09-34.json
+++ b/common/changes/@microsoft/tsdoc-config/main_2024-04-10-09-34.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/tsdoc-config",
+      "comment": "Adding support for '@since' and '@version' tags",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@microsoft/tsdoc-config"
+}

--- a/common/changes/@microsoft/tsdoc-config/main_2024-04-10-09-34.json
+++ b/common/changes/@microsoft/tsdoc-config/main_2024-04-10-09-34.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@microsoft/tsdoc-config",
-      "comment": "Adding support for '@since' and '@version' tags",
+      "comment": "Adding support for `@since` and `@version` tags",
       "type": "minor"
     }
   ],

--- a/common/changes/@microsoft/tsdoc/main_2024-04-10-09-34.json
+++ b/common/changes/@microsoft/tsdoc/main_2024-04-10-09-34.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/tsdoc",
+      "comment": "Adding support for '@since' and '@version' tags",
+      "type": "minor"
+    }
+  ],
+  "packageName": "@microsoft/tsdoc"
+}

--- a/common/changes/@microsoft/tsdoc/main_2024-04-10-09-34.json
+++ b/common/changes/@microsoft/tsdoc/main_2024-04-10-09-34.json
@@ -2,7 +2,7 @@
   "changes": [
     {
       "packageName": "@microsoft/tsdoc",
-      "comment": "Adding support for '@since' and '@version' tags",
+      "comment": "Adding support for `@since` and `@version` tags",
       "type": "minor"
     }
   ],

--- a/tsdoc-config/src/__tests__/TSDocConfigFile.test.ts
+++ b/tsdoc-config/src/__tests__/TSDocConfigFile.test.ts
@@ -401,7 +401,7 @@ test('Re-serialize p3 with defaults', () => {
         },
         Object {
           "syntaxKind": "block",
-          "tagName": "@since"
+          "tagName": "@since",
         },
         Object {
           "allowMultiple": true,
@@ -414,12 +414,12 @@ test('Re-serialize p3 with defaults', () => {
           "tagName": "@typeParam",
         },
         Object {
-          "syntaxKind": "modifier",
-          "tagName": "@virtual",
-        },
-        Object {
           "syntaxKind": "block",
           "tagName": "@version",
+        },
+        Object {
+          "syntaxKind": "modifier",
+          "tagName": "@virtual",
         },
       ],
     }
@@ -536,8 +536,8 @@ test('Re-serialize p3 with defaults', () => {
           "tagName": "@see",
         },
         Object {
-          syntaxKind: "block",
-          tagName: "@since",
+          "syntaxKind": "block",
+          "tagName": "@since",
         },
         Object {
           "allowMultiple": true,
@@ -550,8 +550,8 @@ test('Re-serialize p3 with defaults', () => {
           "tagName": "@typeParam",
         },
         Object {
-          syntaxKind: "block",
-          tagName: "@version",
+          "syntaxKind": "block",
+          "tagName": "@version",
         },
         Object {
           "syntaxKind": "modifier",

--- a/tsdoc-config/src/__tests__/TSDocConfigFile.test.ts
+++ b/tsdoc-config/src/__tests__/TSDocConfigFile.test.ts
@@ -400,6 +400,10 @@ test('Re-serialize p3 with defaults', () => {
           "tagName": "@see",
         },
         Object {
+          "syntaxKind": "block",
+          "tagName": "@since"
+        },
+        Object {
           "allowMultiple": true,
           "syntaxKind": "block",
           "tagName": "@throws",
@@ -412,6 +416,10 @@ test('Re-serialize p3 with defaults', () => {
         Object {
           "syntaxKind": "modifier",
           "tagName": "@virtual",
+        },
+        Object {
+          "syntaxKind": "block",
+          "tagName": "@version",
         },
       ],
     }
@@ -528,6 +536,10 @@ test('Re-serialize p3 with defaults', () => {
           "tagName": "@see",
         },
         Object {
+          syntaxKind: "block",
+          tagName: "@since",
+        },
+        Object {
           "allowMultiple": true,
           "syntaxKind": "block",
           "tagName": "@throws",
@@ -536,6 +548,10 @@ test('Re-serialize p3 with defaults', () => {
           "allowMultiple": true,
           "syntaxKind": "block",
           "tagName": "@typeParam",
+        },
+        Object {
+          syntaxKind: "block",
+          tagName: "@version",
         },
         Object {
           "syntaxKind": "modifier",

--- a/tsdoc/etc/tsdoc.api.md
+++ b/tsdoc/etc/tsdoc.api.md
@@ -1150,8 +1150,10 @@ export class StandardTags {
     static readonly returns: TSDocTagDefinition;
     static readonly sealed: TSDocTagDefinition;
     static readonly see: TSDocTagDefinition;
+    static readonly since: TSDocTagDefinition;
     static readonly throws: TSDocTagDefinition;
     static readonly typeParam: TSDocTagDefinition;
+    static readonly version: TSDocTagDefinition;
     static readonly virtual: TSDocTagDefinition;
 }
 

--- a/tsdoc/src/details/StandardTags.ts
+++ b/tsdoc/src/details/StandardTags.ts
@@ -418,6 +418,32 @@ export class StandardTags {
   /**
    * (Extended)
    *
+   * Used to document the version number of the API since which the item has been created.
+   *
+   * @remarks
+   *
+   * Even if this tag is a block, so it can contain as much text as you want, it is recommended to use only the version number.
+   *
+   * For example:
+   * ```ts
+   * /**
+   *  * Fetches a book by its ISBN code.
+   *  * @since 1.0.0
+   *  &#42;/
+   * function fetchBookByIsbn(isbnCode: string): Book;
+   * ```
+   *
+   * This function has been created since version 1.0.0. This tag mustn't be changed in the future, even if the function is updated. In this case the `@version` tag should be used/updated instead.
+   */
+  public static readonly since: TSDocTagDefinition = StandardTags._defineTag({
+    tagName: '@since',
+    syntaxKind: TSDocTagSyntaxKind.BlockTag,
+    standardization: Standardization.Extended
+  });
+
+  /**
+   * (Extended)
+   *
    * Used to document an exception type that may be thrown by a function or property.
    *
    * @remarks
@@ -470,6 +496,32 @@ export class StandardTags {
   /**
    * (Extended)
    *
+   * Used to document the version number of the API item.
+   *
+   * @remarks
+   *
+   * Even if this tag is a block, so it can contain as much text as you want, it is recommended to use only the version number.
+   *
+   * For example:
+   * ```ts
+   * /**
+   * * Fetches a book by its ISBN code.
+   * * @version 1.0.0
+   * &#42;/
+   * function fetchBookByIsbn(isbnCode: string): Book;
+   * ```
+   *
+   * This function version is currently 1.0.0. This tag must be updated every time the function is updated. If you want to document the version of the API since which the item has been created, the `@since` tag should be used instead.
+   */
+  public static readonly version: TSDocTagDefinition = StandardTags._defineTag({
+    tagName: '@version',
+    syntaxKind: TSDocTagSyntaxKind.BlockTag,
+    standardization: Standardization.Extended
+  });
+
+  /**
+   * (Extended)
+   *
    * This modifier has similar semantics to the `virtual` keyword in C# or Java.
    * For a member function or property, explicitly indicates that subclasses may override
    * (i.e. redefine) the member.
@@ -510,8 +562,10 @@ export class StandardTags {
     StandardTags.returns,
     StandardTags.sealed,
     StandardTags.see,
+    StandardTags.since,
     StandardTags.throws,
     StandardTags.typeParam,
+    StandardTags.version,
     StandardTags.virtual
   ];
 

--- a/tsdoc/src/details/StandardTags.ts
+++ b/tsdoc/src/details/StandardTags.ts
@@ -418,11 +418,11 @@ export class StandardTags {
   /**
    * (Extended)
    *
-   * Used to document the version number of the API since which the item has been created.
+   * Used to document the version number of the API on which the item was created.
    *
    * @remarks
    *
-   * Even if this tag is a block, so it can contain as much text as you want, it is recommended to use only the version number.
+   * Even if this tag is a block, it can contain as much text as you want, however it is recommended to use only the version number.
    *
    * For example:
    * ```ts
@@ -433,7 +433,8 @@ export class StandardTags {
    * function fetchBookByIsbn(isbnCode: string): Book;
    * ```
    *
-   * This function has been created since version 1.0.0. This tag mustn't be changed in the future, even if the function is updated. In this case the `@version` tag should be used/updated instead.
+   * This function has been created on version 1.0.0. This tag must not be changed in the future, even if the function is updated.
+   * In this case the `@version` tag should be used/updated instead.
    */
   public static readonly since: TSDocTagDefinition = StandardTags._defineTag({
     tagName: '@since',
@@ -500,7 +501,7 @@ export class StandardTags {
    *
    * @remarks
    *
-   * Even if this tag is a block, so it can contain as much text as you want, it is recommended to use only the version number.
+   * Even if this tag is a block, it can contain as much text as you want, however it is recommended to use only the version number.
    *
    * For example:
    * ```ts
@@ -511,7 +512,8 @@ export class StandardTags {
    * function fetchBookByIsbn(isbnCode: string): Book;
    * ```
    *
-   * This function version is currently 1.0.0. This tag must be updated every time the function is updated. If you want to document the version of the API since which the item has been created, the `@since` tag should be used instead.
+   * This function version is currently 1.0.0. This tag must be updated every time the function is updated.
+   * If you want to document the version of the API on which the item was created, the `@since` tag should be used instead.
    */
   public static readonly version: TSDocTagDefinition = StandardTags._defineTag({
     tagName: '@version',


### PR DESCRIPTION
Adding a support for `@since` and `@version` tags.

Refers to #136.