### PR TITLE
Ship only production runtime files

### DIFF
--- a/tsdoc-config/package.json
+++ b/tsdoc-config/package.json
@@ -20,7 +20,6 @@
   "main": "lib/index.js",
   "files": [
     "lib/*.js",
-    "lib/*.js.map",
     "lib/**/*.d.ts"
   ],
   "typings": "lib/index.d.ts",

--- a/tsdoc-config/package.json
+++ b/tsdoc-config/package.json
@@ -18,6 +18,11 @@
   },
   "homepage": "https://tsdoc.org/",
   "main": "lib/index.js",
+  "files": [
+    "lib/*.js",
+    "lib/*.js.map",
+    "lib/**/*.d.ts"
+  ],
   "typings": "lib/index.d.ts",
   "license": "MIT",
   "dependencies": {

--- a/tsdoc/package.json
+++ b/tsdoc/package.json
@@ -19,6 +19,14 @@
   "homepage": "https://tsdoc.org/",
   "main": "lib-commonjs/index.js",
   "module": "lib/index.js",
+  "files": [
+    "lib-commonjs/*.js",
+    "lib-commonjs/*.js.map",
+    "lib-commonjs/**/*.d.ts",
+    "lib/*.js",
+    "lib/*.js.map",
+    "lib/**/*.d.ts"
+  ],
   "typings": "lib/index.d.ts",
   "license": "MIT",
   "devDependencies": {

--- a/tsdoc/package.json
+++ b/tsdoc/package.json
@@ -20,11 +20,9 @@
   "main": "lib-commonjs/index.js",
   "module": "lib/index.js",
   "files": [
-    "lib-commonjs/*.js",
-    "lib-commonjs/*.js.map",
+    "lib-commonjs/**/*.js",
     "lib-commonjs/**/*.d.ts",
-    "lib/*.js",
-    "lib/*.js.map",
+    "lib/**/*.js",
     "lib/**/*.d.ts"
   ],
   "typings": "lib/index.d.ts",


### PR DESCRIPTION
this will reduce your on-disk node_modules footprint from ~500K to ~80K.

```
$ du -ahd 1 node_modules/@microsoft/tsdoc-config/lib
12.0K   node_modules/@microsoft/tsdoc-config/lib/TSDocConfigFile.d.ts
4.0K    node_modules/@microsoft/tsdoc-config/lib/index.js
4.0K    node_modules/@microsoft/tsdoc-config/lib/TSDocConfigFile.d.ts.map
420.0K  node_modules/@microsoft/tsdoc-config/lib/__tests__
4.0K    node_modules/@microsoft/tsdoc-config/lib/index.d.ts
4.0K    node_modules/@microsoft/tsdoc-config/lib/index.d.ts.map
28.0K   node_modules/@microsoft/tsdoc-config/lib/TSDocConfigFile.js
4.0K    node_modules/@microsoft/tsdoc-config/lib/index.js.map
44.0K   node_modules/@microsoft/tsdoc-config/lib/TSDocConfigFile.js.map
528.0K  node_modules/@microsoft/tsdoc-config/lib
```

I mean, good work with the tests and all, but don't ship them...

You also don't need to ship map files for `ts`.

P.S.
I would put more accurate numbers like I did for [`resolve`](https://github.com/browserify/resolve/pull/324) -  (which BTW affects you too!), but `npm i` fails... 
I saw you use a different toolchain, but could not get started with this `rush`. all kinds of wierd errors... :P I had to give up.