### PR TITLE
[eslint-plugin-tsdoc] Leverage tsConfigRootDir setting

### DIFF
--- a/common/changes/eslint-plugin-tsdoc/tsdoc-rule-tsconfig-path_2024-11-22-22-21.json
+++ b/common/changes/eslint-plugin-tsdoc/tsdoc-rule-tsconfig-path_2024-11-22-22-21.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "eslint-plugin-tsdoc",
+      "comment": "Leverage `parserOptions.tsConfigRootDir` to reduce file system probing. This field is commonly used when eslint is configured with `@typescript-eslint/parser`.",
+      "type": "minor"
+    }
+  ],
+  "packageName": "eslint-plugin-tsdoc"
+}

--- a/eslint-plugin/src/ConfigCache.ts
+++ b/eslint-plugin/src/ConfigCache.ts
@@ -26,6 +26,7 @@ const CACHE_MAX_SIZE: number = 100;
 export class ConfigCache {
   // findConfigPathForFolder() result --> loaded tsdoc.json configuration
   private static _cachedConfigs: Map<string, ICachedConfig> = new Map<string, ICachedConfig>();
+  private static _cachedPaths: Map<string, string> = new Map();
 
   /**
    * Node.js equivalent of performance.now().
@@ -35,11 +36,17 @@ export class ConfigCache {
     return seconds * 1000 + nanoseconds / 1000000;
   }
 
-  public static getForSourceFile(sourceFilePath: string): TSDocConfigFile {
+  public static getForSourceFile(
+    sourceFilePath: string,
+    tsConfigRootDir?: string | undefined
+  ): TSDocConfigFile {
     const sourceFileFolder: string = path.dirname(path.resolve(sourceFilePath));
 
     // First, determine the file to be loaded. If not found, the configFilePath will be an empty string.
-    const configFilePath: string = TSDocConfigFile.findConfigPathForFolder(sourceFileFolder);
+    // If the eslint config has specified where the tsconfig file is, use that path directly without probing the filesystem.
+    const configFilePath: string = tsConfigRootDir
+      ? path.join(tsConfigRootDir, TSDocConfigFile.FILENAME)
+      : TSDocConfigFile.findConfigPathForFolder(sourceFileFolder);
 
     // If configFilePath is an empty string, then we'll use the folder of sourceFilePath as our cache key
     // (instead of an empty string)

--- a/eslint-plugin/src/index.ts
+++ b/eslint-plugin/src/index.ts
@@ -41,13 +41,16 @@ const plugin: IPlugin = {
         }
       },
       create: (context: eslint.Rule.RuleContext) => {
-        const sourceFilePath: string = context.getFilename();
+        const sourceFilePath: string = context.filename;
+        // If eslint is configured with @typescript-eslint/parser, there is a parser option
+        // to explicitly specify where the tsconfig file is. Use that if available.
+        const tsConfigDir: string | undefined = context.parserOptions.tsconfigRootDir;
         Debug.log(`Linting: "${sourceFilePath}"`);
 
         const tsdocConfiguration: TSDocConfiguration = new TSDocConfiguration();
 
         try {
-          const tsdocConfigFile: TSDocConfigFile = ConfigCache.getForSourceFile(sourceFilePath);
+          const tsdocConfigFile: TSDocConfigFile = ConfigCache.getForSourceFile(sourceFilePath, tsConfigDir);
           if (!tsdocConfigFile.fileNotFound) {
             if (tsdocConfigFile.hasErrors) {
               context.report({


### PR DESCRIPTION
Fixes #428 for projects that use `@typescript-eslint/parser` and set `parserOptions.tsConfigRootDir` in the eslint config.

Since the official documentation for configuring `eslint-plugin-tsdoc` tells users to do so (https://github.com/microsoft/tsdoc/blob/main/eslint-plugin/README.md), this should reduce file system probing for tsconfig to zero for the majority of consumers.