### PR TITLE
Reorder TSDoc comments to match HTML rendering for clarity

### DIFF
--- a/playground/src/samples/basicSample.ts
+++ b/playground/src/samples/basicSample.ts
@@ -1,12 +1,12 @@
 /**
  * Returns the average of two numbers.
  *
- * @remarks
- * This method is part of the {@link core-library#Statistics | Statistics subsystem}.
- *
  * @param x - The first input number
  * @param y - The second input number
  * @returns The arithmetic mean of `x` and `y`
+ *
+ * @remarks
+ * This method is part of the {@link core-library#Statistics | Statistics subsystem}.
  *
  * @beta
  */


### PR DESCRIPTION
Reorder TSDoc comments to match rendered HTML order

The sample description for getAverage had its @remarks section before @param and @returns, which differs from how it renders in HTML. This mismatch was confusing for beginners following the playground example. This change reorders the comments to align with their rendered layout for clearer learning.