### PR TITLE
🚀 Feature: Add a first-class AST node for Markdown headings

### DIFF
--- a/tsdoc/src/nodes/DocHeading.ts
+++ b/tsdoc/src/nodes/DocHeading.ts
@@ -1,0 +1,33 @@
+// Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
+// See LICENSE in the project root for license information.
+
+import { DocNodeKind } from './DocNode';
+import { type IDocNodeContainerParameters, DocNodeContainer } from './DocNodeContainer';
+
+export type DocHeadingLevel = 1 | 2 | 3 | 4 | 5 | 6;
+
+export interface IDocHeadingParameters extends IDocNodeContainerParameters {
+  headingLevel: DocHeadingLevel;
+}
+
+export class DocHeading extends DocNodeContainer {
+  private readonly _headingLevel: DocHeadingLevel;
+
+  public constructor(parameters: IDocHeadingParameters) {
+    super(parameters);
+
+    if (!Number.isInteger(parameters.headingLevel) || parameters.headingLevel < 1 || parameters.headingLevel > 6) {
+      throw new Error('The headingLevel must be an integer between 1 and 6');
+    }
+
+    this._headingLevel = parameters.headingLevel;
+  }
+
+  public get kind(): DocNodeKind.Heading {
+    return DocNodeKind.Heading;
+  }
+
+  public get headingLevel(): DocHeadingLevel {
+    return this._headingLevel;
+  }
+}


### PR DESCRIPTION
## Problem

Introduce a new `DocHeading` node type so Markdown headings are represented explicitly in the parsed TSDoc tree (instead of being folded into paragraph text). This matches the maintainer guidance in the issue: headings should be regular section members, not a nested section hierarchy.

**Severity**: `high`
**File**: `tsdoc/src/nodes/DocHeading.ts`

## Solution

Define `DocHeading` as a container-like node (parallel to `DocParagraph`) with:

## Changes

- `tsdoc/src/nodes/DocHeading.ts` (new)

## Testing

- [ ] Existing tests pass
- [ ] Manual review completed
- [ ] No new warnings/errors introduced


Closes #197