### PR TITLE
🚀 Feature: Add configurable link URL prefixes to parser configuration

### DIFF
--- a/tsdoc/src/configuration/TSDocConfiguration.ts
+++ b/tsdoc/src/configuration/TSDocConfiguration.ts
@@ -18,6 +18,7 @@ export class TSDocConfiguration {
   private readonly _validation: TSDocValidationConfiguration;
   private readonly _docNodeManager: DocNodeManager;
   private readonly _supportedHtmlElements: Set<string>;
+  private readonly _linkUrlPrefixes: Set<string>;
 
   public constructor() {
     this._tagDefinitions = [];
@@ -26,6 +27,7 @@ export class TSDocConfiguration {
     this._validation = new TSDocValidationConfiguration();
     this._docNodeManager = new DocNodeManager();
     this._supportedHtmlElements = new Set();
+    this._linkUrlPrefixes = new Set();
 
     this.clear(false);
 
@@ -46,6 +48,7 @@ export class TSDocConfiguration {
     this._validation.reportUnsupportedTags = false;
     this._validation.reportUnsupportedHtmlElements = false;
     this._supportedHtmlElements.clear();
+    this._linkUrlPrefixes.clear();
 
     if (!noStandardTags) {
       // Define all the standard tags
@@ -87,6 +90,29 @@ export class TSDocConfiguration {
    */
   public get supportedHtmlElements(): string[] {
     return Array.from(this._supportedHtmlElements.values());
+  }
+
+  /**
+   * URI-style prefixes that should be treated as URL destinations in `{@link ...}` tags.
+   */
+  public get linkUrlPrefixes(): string[] {
+    return Array.from(this._linkUrlPrefixes.values());
+  }
+
+  public addLinkUrlPrefix(prefix: string): void {
+    if (!/^[A-Za-z][A-Za-z0-9+.-]*$/.test(prefix)) {
+      throw new Error(`Invalid link URL prefix: "${prefix}"`);
+    }
+
+    this._linkUrlPrefixes.add(prefix.toLowerCase());
+  }
+
+  public clearLinkUrlPrefixes(): void {
+    this._linkUrlPrefixes.clear();
+  }
+
+  public isLinkUrlPrefixAllowed(prefix: string): boolean {
+    return this._linkUrlPrefixes.has(prefix.toLowerCase());
   }
 
   /**

--- a/tsdoc/src/parser/NodeParser.ts
+++ b/tsdoc/src/parser/NodeParser.ts
@@ -78,6 +78,20 @@ export class NodeParser {
     this._currentSection = parserContext.docComment.summarySection;
   }
 
+  private _isConfiguredLinkUrlDestination(linkDestination: string): boolean {
+    const colonIndex: number = linkDestination.indexOf(':');
+    if (colonIndex <= 0) {
+      return false;
+    }
+
+    if (linkDestination.indexOf('://') > 0) {
+      return false;
+    }
+
+    const prefix: string = linkDestination.substring(0, colonIndex);
+    return this._configuration.isLinkUrlPrefixAllowed(prefix);
+  }
+
   public parse(): void {
     const tokenReader: TokenReader = new TokenReader(this._parserContext);
 

--- a/tsdoc/src/parser/__tests__/NodeParserLinkTag.test.ts
+++ b/tsdoc/src/parser/__tests__/NodeParserLinkTag.test.ts
@@ -1,6 +1,7 @@
 // Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
 // See LICENSE in the project root for license information.
 
+import { TSDocConfiguration } from '../../configuration/TSDocConfiguration';
 import { TestHelpers } from './TestHelpers';
 
 test('00 Link text: positive examples', () => {
@@ -51,6 +52,22 @@ test('03 URL destination: negative examples', () => {
       ' * {@link http://}',
       ' */'
     ].join('\n')
+  );
+});
+
+test('03b URL destination: configured URI prefixes', () => {
+  const configuration: TSDocConfiguration = new TSDocConfiguration();
+  configuration.addLinkUrlPrefix('mailto');
+  configuration.addLinkUrlPrefix('xref');
+
+  TestHelpers.parseAndMatchNodeParserSnapshot(
+    [
+      '/**',
+      ' * {@link mailto:bob@example.com}',
+      ' * {@link xref:MyNamespace.MySymbol|link text}',
+      ' */'
+    ].join('\n'),
+    configuration
   );
 });
 


### PR DESCRIPTION
## Problem

Extend `TSDocConfiguration` with a new public setting for URI-style prefixes (e.g. `xref`, `mailto`) that should be recognized as URL destinations in `{@link ...}` tags, even when they do not use `://`. This must preserve existing behavior for `scheme://` while allowing explicit opt-in for additional protocols.

**Severity**: `high`
**File**: `tsdoc/src/configuration/TSDocConfiguration.ts`

## Solution

Add a private normalized set (e.g. `_linkUrlPrefixes: Set<string>`) and public APIs to manage it (getter + mutator methods such as `addLinkUrlPrefix()`, `clearLinkUrlPrefixes()`, possibly `isLinkUrlPrefixAllowed()`). Validate prefixes using a strict scheme-like grammar (`^[A-Za-z][A-Za-z0-9+.-]*$`) and normalize case (lowercase) for matching. Keep default empty so current behavior is unchanged unless configured.

## Changes

- `tsdoc/src/configuration/TSDocConfiguration.ts` (modified)
- `tsdoc/src/parser/NodeParser.ts` (modified)
- `tsdoc/src/parser/__tests__/NodeParserLinkTag.test.ts` (modified)

## Testing

- [ ] Existing tests pass
- [ ] Manual review completed
- [ ] No new warnings/errors introduced


Closes #227