### PR TITLE
🚀 Feature: Create DocHeading node type for Markdown headings

### DIFF
--- a/tsdoc/src/nodes/DocHeading.ts
+++ b/tsdoc/src/nodes/DocHeading.ts
@@ -1,0 +1,63 @@
+// Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
+// See LICENSE in the project root for license information.
+
+import { DocNode, type IDocNodeParameters } from './DocNode';
+import { DocNodeContainer, type IDocNodeContainerParameters } from './DocNodeContainer';
+import { DocNodeKind } from './DocNodeKind';
+
+/**
+ * Constructor parameters for {@link DocHeading}.
+ */
+export interface IDocHeadingParameters extends IDocNodeContainerParameters {
+  /**
+   * The heading level from 1 to 6, similar to Markdown headings.
+   */
+  headingLevel?: number;
+}
+
+/**
+ * Represents a heading section in the documentation, similar to Markdown headings (#, ##, etc.).
+ *
+ * @remarks
+ * This node type stores a heading level (1-6) and contains the heading content as child nodes.
+ */
+export class DocHeading extends DocNodeContainer {
+  private static _kind: string = DocNodeKind.Heading;
+  private _headingLevel: number;
+
+  public constructor(parameters: IDocHeadingParameters | DocHeading) {
+    super(parameters);
+    if (parameters instanceof DocHeading) {
+      this._headingLevel = parameters._headingLevel;
+    } else {
+      this._headingLevel = parameters.headingLevel ?? 1;
+    }
+  }
+
+  /** @override */
+  public get kind(): string {
+    return DocHeading._kind;
+  }
+
+  /**
+   * The heading level from 1 to 6.
+   */
+  public get headingLevel(): number {
+    return this._headingLevel;
+  }
+
+  /**
+   * Sets the heading level (must be between 1 and 6).
+   */
+  public set headingLevel(value: number) {
+    if (value < 1 || value > 6) {
+      throw new Error('Heading level must be between 1 and 6');
+    }
+    this._headingLevel = value;
+  }
+
+  /** @override */
+  protected onGetChildNodes(): ReadonlyArray<DocNode> {
+    return this.nodes;
+  }
+}


### PR DESCRIPTION
## Problem

Create a new DocNode type to represent Markdown headings in the TSDoc AST. This will be similar to DocParagraph but will store heading level and text content.

**Severity**: `critical`
**File**: `tsdoc/src/nodes/DocHeading.ts`

## Solution

Create a new DocNode type to represent Markdown headings in the TSDoc AST. This will be similar to DocParagraph but will store heading level and text content.

## Changes

- `tsdoc/src/nodes/DocHeading.ts` (new)

## Testing

- [ ] Existing tests pass
- [ ] Manual review completed
- [ ] No new warnings/errors introduced


Closes #197