### PR TITLE
fix(eslint-plugin-tsdoc): declare eslint as a peer dependency

### DIFF
--- a/common/changes/eslint-plugin-tsdoc/fix-issue-479_2026-09-10-21-24.json
+++ b/common/changes/eslint-plugin-tsdoc/fix-issue-479_2026-09-10-21-24.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "eslint-plugin-tsdoc",
+      "comment": "Declare `eslint` as a peer dependency so published typings resolve against the consumer's ESLint under non-hoisted installers.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "eslint-plugin-tsdoc"
+}

--- a/eslint-plugin/package.json
+++ b/eslint-plugin/package.json
@@ -31,6 +31,9 @@
     "@microsoft/tsdoc": "workspace:*",
     "@typescript-eslint/utils": "~8.56.0"
   },
+  "peerDependencies": {
+    "eslint": ">=7"
+  },
   "devDependencies": {
     "tsdoc-build-rig": "workspace:*",
     "@rushstack/heft": "1.2.7",

--- a/eslint-plugin/src/tests/package.test.ts
+++ b/eslint-plugin/src/tests/package.test.ts
@@ -1,0 +1,49 @@
+// Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
+// See LICENSE in the project root for license information.
+
+import * as fs from 'node:fs';
+import * as path from 'node:path';
+
+interface IPackageJson {
+  dependencies?: { [name: string]: string };
+  peerDependencies?: { [name: string]: string };
+}
+
+function getPackageName(moduleSpecifier: string): string {
+  if (moduleSpecifier.startsWith('@')) {
+    return moduleSpecifier.split('/').slice(0, 2).join('/');
+  }
+  return moduleSpecifier.split('/')[0];
+}
+
+function collectImportedPackageNames(sourceText: string): string[] {
+  const importRegExp: RegExp = /(?:from|import)\s+['"]([^'"]+)['"]/g;
+  const packageNames: string[] = [];
+  for (const regExpMatch of sourceText.matchAll(importRegExp)) {
+    const moduleSpecifier: string | undefined = regExpMatch[1];
+    if (!moduleSpecifier || moduleSpecifier.startsWith('.') || moduleSpecifier.startsWith('node:')) {
+      continue;
+    }
+    packageNames.push(getPackageName(moduleSpecifier));
+  }
+  return packageNames;
+}
+
+test('published typings import only packages declared as dependencies or peerDependencies', () => {
+  const packageJsonPath: string = path.join(__dirname, '..', '..', 'package.json');
+  const packageJsonText: string = fs.readFileSync(packageJsonPath, { encoding: 'utf8' });
+  const packageJson: IPackageJson = JSON.parse(packageJsonText) as IPackageJson;
+
+  const declaredPackageNames: Set<string> = new Set<string>([
+    ...Object.keys(packageJson.dependencies ?? {}),
+    ...Object.keys(packageJson.peerDependencies ?? {})
+  ]);
+
+  const typingsPath: string = path.join(__dirname, '..', 'index.d.ts');
+  const typingsText: string = fs.readFileSync(typingsPath, { encoding: 'utf8' });
+  const missingPackageNames: string[] = collectImportedPackageNames(typingsText).filter(
+    (packageName: string) => !declaredPackageNames.has(packageName)
+  );
+
+  expect(missingPackageNames).toEqual([]);
+});


### PR DESCRIPTION
Declare `"peerDependencies": { "eslint": ">=7" }` so the consumer's ESLint is linked into the plugin and the published typings bind to the same types the config is checked against. `eslint` remains a `devDependency` for this repo's tests. Add a test that every non-relative import in the emitted `lib/index.d.ts` is listed in `dependencies` or `peerDependencies`.

Published `lib/index.d.ts` does `import type * as eslint from 'eslint'`, but `eslint-plugin-tsdoc` did not declare `eslint` as a dependency or peer (only a `devDependency`). Under pnpm and Yarn PnP, TypeScript can resolve that import to a transitive `@types/eslint` instead of the consumer's ESLint. A `// @ts-check`ed flat config with `plugins: { tsdoc }` then fails (`IPlugin` not assignable to `Plugin` because `RuleModule` is not `RuleDefinition`).

Fixes https://github.com/microsoft/tsdoc/issues/479

## Decision

The range is the one in the issue, which the reporter verified via pnpm `packageExtensions`. The issue repro (`eslint-plugin-tsdoc@0.5.2`, `eslint@10.8.0`, `typescript@6.0.3`, pnpm, `@types/eslint-scope`) is `tsc --noEmit` failing, then exiting 0 with `packageExtensions` `eslint: ">=7"`. That isolated consumer was not re-run in this tree.

The other option is to remove the `'eslint'` type import from the public surface and type the plugin with `@typescript-eslint/utils` (already a runtime dependency) or `@eslint/core`. That is the "more durable" option in the issue and is the direction of draft PR #425. The peer declaration is the smallest reversible packaging change, and it matches how `@rushstack/eslint-plugin` (already in this repo) declares ESLint. Rewriting `IPlugin` can reintroduce assignability failures against ESLint 10's `Plugin` type.

Can switch to the types-only approach, or to a tighter peer range (`^8 || ^9 || ^10`). `>=7` may be wider than runtime support: this package already uses `context.filename` with no `getFilename()` fallback, and `@typescript-eslint/utils@~8.56.0` peers `^8.57 || ^9 || ^10`.

## Test plan

- [x] `rush test --only eslint-plugin-tsdoc` (existing `tsdoc/syntax` RuleTester cases plus the new packaging invariant).
- [x] Packaging test fails when the peer is removed (`missingPackageNames` is `["eslint"]`) and passes when it is restored.
- [x] `rush change --verify` against `main`.
- [x] `rush install` / `rush update` with the new peer: no `pnpm-lock.yaml` change required (`eslint` is already a devDependency).
- [ ] Confirm no new peer warnings on a real ESLint 8/9/10 app that already depends on `eslint`; report if ESLint 7 should be dropped from the range.

The last box was not run.
