### PR TITLE
Add tsdoc-unsupported-html-name to allTsdocMessageIds. Fixes #453

### DIFF
--- a/common/changes/@microsoft/tsdoc/fix-issue-453_2026-09-11-02-30.json
+++ b/common/changes/@microsoft/tsdoc/fix-issue-453_2026-09-11-02-30.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/tsdoc",
+      "comment": "Add missing tsdoc-unsupported-html-name to TSDocConfiguration.allTsdocMessageIds so eslint-plugin-tsdoc does not crash when reportUnsupportedHtmlElements is enabled (GitHub #453)",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@microsoft/tsdoc"
+}

--- a/tsdoc/src/parser/TSDocMessageId.ts
+++ b/tsdoc/src/parser/TSDocMessageId.ts
@@ -486,6 +486,7 @@ export const allTsdocMessageIds: string[] = [
   'tsdoc-text-after-html-string',
   'tsdoc-missing-html-end-tag',
   'tsdoc-malformed-html-name',
+  'tsdoc-unsupported-html-name',
   'tsdoc-code-fence-opening-indent',
   'tsdoc-code-fence-specifier-syntax',
   'tsdoc-code-fence-closing-indent',

--- a/tsdoc/src/parser/__tests__/TSDocMessageId.test.ts
+++ b/tsdoc/src/parser/__tests__/TSDocMessageId.test.ts
@@ -1,0 +1,38 @@
+// Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
+// See LICENSE in the project root for license information.
+
+import { TSDocConfiguration } from '../../configuration/TSDocConfiguration';
+import type { ParserMessage } from '../ParserMessage';
+import type { ParserContext } from '../ParserContext';
+import { TSDocMessageId } from '../TSDocMessageId';
+import { TSDocParser } from '../TSDocParser';
+
+test('allTsdocMessageIds includes every TSDocMessageId enum value', () => {
+  const configuration: TSDocConfiguration = new TSDocConfiguration();
+  const missing: string[] = [];
+  for (const key of Object.keys(TSDocMessageId)) {
+    const messageId: string = TSDocMessageId[key as keyof typeof TSDocMessageId];
+    if (!configuration.isKnownMessageId(messageId)) {
+      missing.push(messageId);
+    }
+  }
+  expect(missing).toEqual([]);
+});
+
+test('unsupported HTML elements report a known message id', () => {
+  const configuration: TSDocConfiguration = new TSDocConfiguration();
+  configuration.setSupportedHtmlElements([]);
+  configuration.validation.reportUnsupportedHtmlElements = true;
+
+  const tsdocParser: TSDocParser = new TSDocParser(configuration);
+  const parserContext: ParserContext = tsdocParser.parseString(['/**', ' * <b>', ' */'].join('\n'));
+
+  const unsupportedHtmlMessages: ParserMessage[] = parserContext.log.messages.filter(
+    (message: ParserMessage) => message.messageId === TSDocMessageId.UnsupportedHtmlElementName
+  );
+  expect(unsupportedHtmlMessages.length).toBeGreaterThan(0);
+
+  for (const message of parserContext.log.messages) {
+    expect(configuration.isKnownMessageId(message.messageId)).toEqual(true);
+  }
+});


### PR DESCRIPTION
## Summary

- `eslint-plugin-tsdoc` crashes on ESLint 9 when `reportUnsupportedHtmlElements` is enabled, because the parser emits `tsdoc-unsupported-html-name` and that id was missing from `TSDocConfiguration.allTsdocMessageIds` (the list the plugin copies into `meta.messages`).
- Added the missing catalog entry (immediately after `tsdoc-malformed-html-name`, matching enum order) and a test that every `TSDocMessageId` is known, including the unsupported-HTML parse path.
- Fixes #453. Same class of bug as #211 / PR #212.

## Decision

- **Chose:** add `'tsdoc-unsupported-html-name'` to the explicit `allTsdocMessageIds` array, matching #212, plus a completeness test so the two lists cannot silently drift again.
- **Alternative:** derive `allTsdocMessageIds` from the enum (const enums were removed in 0.15.0), and/or also add an `eslint-plugin-tsdoc` patch changefile so a plugin republish depends on the patched `@microsoft/tsdoc`.
- **Why:** smallest reversible fix that matches how this repo already solved the identical ESLint crash. The test is what #212 did not add, which is why this happened again. Happy to switch to an enum-derived catalog and/or a plugin patch bump if you want that in this PR.

The reporter's stack on #453 names `tsdoc-unsupported-html-name` as the missing `messageId`. `NodeParser` already emits `TSDocMessageId.UnsupportedHtmlElementName` when `reportUnsupportedHtmlElements` is true. This is not a missing ESLint rule; there is still one rule, `tsdoc/syntax`.

## Test plan

- [x] `allTsdocMessageIds includes every TSDocMessageId enum value` fails without the catalog line and passes with it
- [x] `unsupported HTML elements report a known message id` fails without the catalog line and passes with it
- [x] Full `@microsoft/tsdoc` tests (257) pass
- [x] `rush change --verify` accepts the patch changefile under `common/changes/@microsoft/tsdoc/`
- [ ] After publish, confirm `eslint-plugin-tsdoc` with `reportUnsupportedHtmlElements: true` reports `tsdoc-unsupported-html-name` instead of throwing (needs an `eslint-plugin-tsdoc` release whose `@microsoft/tsdoc` dependency includes this patch)
