### PR TITLE
Honor TokenReader subrange bounds in peek and backtrack.

### DIFF
--- a/common/changes/@microsoft/tsdoc/fix-tokenreader-bounds_2026-09-11-13-00.json
+++ b/common/changes/@microsoft/tsdoc/fix-tokenreader-bounds_2026-09-11-13-00.json
@@ -1,0 +1,10 @@
+{
+  "changes": [
+    {
+      "packageName": "@microsoft/tsdoc",
+      "comment": "Fix TokenReader peek and backtrack methods so they honor an embedded token sequence's bounds.",
+      "type": "patch"
+    }
+  ],
+  "packageName": "@microsoft/tsdoc"
+}

--- a/tsdoc/src/parser/TokenReader.ts
+++ b/tsdoc/src/parser/TokenReader.ts
@@ -120,6 +120,10 @@ export class TokenReader {
    * consuming anything.
    */
   public peekToken(): Token {
+    if (this._currentIndex >= this._readerEndIndex) {
+      // Always return a real Token, matching peekTokenKind() === EndOfInput.
+      return this.tokens[this.tokens.length - 1];
+    }
     return this.tokens[this._currentIndex];
   }
 
@@ -180,7 +184,7 @@ export class TokenReader {
    * Returns the kind of the token immediately before the current token.
    */
   public peekPreviousTokenKind(): TokenKind {
-    if (this._currentIndex === 0) {
+    if (this._currentIndex === this._readerStartIndex) {
       return TokenKind.EndOfInput;
     }
     return this.tokens[this._currentIndex - 1].kind;
@@ -200,6 +204,10 @@ export class TokenReader {
     if (marker > this._currentIndex) {
       // If this happens, it's a parser bug
       throw new Error('The marker has expired');
+    }
+    if (marker < this._readerStartIndex) {
+      // If this happens, it's a parser bug
+      throw new Error('The marker is outside the TokenReader range');
     }
 
     this._currentIndex = marker;

--- a/tsdoc/src/parser/__tests__/TokenReader.test.ts
+++ b/tsdoc/src/parser/__tests__/TokenReader.test.ts
@@ -1,0 +1,84 @@
+// Copyright (c) Microsoft Corporation. All rights reserved. Licensed under the MIT license.
+// See LICENSE in the project root for license information.
+
+import { TSDocParser } from '../TSDocParser';
+import { type Token, TokenKind } from '../Token';
+import { TokenReader } from '../TokenReader';
+import { TokenSequence } from '../TokenSequence';
+import type { ParserContext } from '../ParserContext';
+
+function parseComment(buffer: string): ParserContext {
+  const tsdocParser: TSDocParser = new TSDocParser();
+  return tsdocParser.parseString(buffer);
+}
+
+function indexOfTokenText(parserContext: ParserContext, text: string): number {
+  const tokens: ReadonlyArray<Token> = parserContext.tokens;
+  for (let i: number = 0; i < tokens.length; ++i) {
+    if (tokens[i].toString() === text) {
+      return i;
+    }
+  }
+  throw new Error('Token not found: ' + JSON.stringify(text));
+}
+
+function createEmbeddedReader(
+  parserContext: ParserContext,
+  startIndex: number,
+  endIndex: number
+): TokenReader {
+  return new TokenReader(
+    parserContext,
+    new TokenSequence({
+      parserContext: parserContext,
+      startIndex: startIndex,
+      endIndex: endIndex
+    })
+  );
+}
+
+test('peekPreviousTokenKind does not leak the token before an embedded window', () => {
+  const parserContext: ParserContext = parseComment('/** prefix {@link Dest} suffix */');
+  const destIndex: number = indexOfTokenText(parserContext, 'Dest');
+  const tokenReader: TokenReader = createEmbeddedReader(parserContext, destIndex, destIndex + 1);
+
+  expect(parserContext.tokens[destIndex - 1].kind).toEqual(TokenKind.Spacing);
+  expect(tokenReader.peekPreviousTokenKind()).toEqual(TokenKind.EndOfInput);
+});
+
+test('peekToken at the end of an embedded window is EndOfInput, not the following token', () => {
+  const parserContext: ParserContext = parseComment('/** prefix {@link Dest} suffix */');
+  const destIndex: number = indexOfTokenText(parserContext, 'Dest');
+  const tokenReader: TokenReader = createEmbeddedReader(parserContext, destIndex, destIndex + 1);
+
+  expect(tokenReader.readToken().toString()).toEqual('Dest');
+  expect(tokenReader.peekTokenKind()).toEqual(TokenKind.EndOfInput);
+
+  expect(parserContext.tokens[destIndex + 1].kind).toEqual(TokenKind.RightCurlyBracket);
+  expect(tokenReader.peekToken()).toBeDefined();
+  expect(tokenReader.peekToken().kind).toEqual(TokenKind.EndOfInput);
+});
+
+test('peekToken for an empty TokenSequence is EndOfInput, not tokens[0]', () => {
+  const parserContext: ParserContext = parseComment('/** prefix {@link Dest} suffix */');
+  const tokenReader: TokenReader = new TokenReader(parserContext, TokenSequence.createEmpty(parserContext));
+
+  expect(parserContext.tokens[0].toString()).toEqual('prefix');
+  expect(tokenReader.peekTokenKind()).toEqual(TokenKind.EndOfInput);
+  expect(tokenReader.peekToken().kind).toEqual(TokenKind.EndOfInput);
+});
+
+test('backtrackToMarker rejects a marker before the embedded start', () => {
+  const parserContext: ParserContext = parseComment('/** prefix {@link Dest} suffix */');
+  const destIndex: number = indexOfTokenText(parserContext, 'Dest');
+  const tokenReader: TokenReader = createEmbeddedReader(parserContext, destIndex, destIndex + 1);
+
+  tokenReader.readToken();
+
+  expect(() => {
+    tokenReader.backtrackToMarker(destIndex - 1);
+  }).toThrowError('The marker is outside the TokenReader range');
+
+  tokenReader.backtrackToMarker(destIndex);
+  expect(tokenReader.peekToken().toString()).toEqual('Dest');
+});


### PR DESCRIPTION
`TokenReader.peekToken()`, `peekPreviousTokenKind()`, and `backtrackToMarker()` now honor the same `[_readerStartIndex, _readerEndIndex)` window that `peekTokenKind()` / `peekTokenAfterKind()` / `peekTokenAfterAfterKind()` already enforce. Fixes #481: an embedded reader could observe the token before its start or after its end, and `backtrackToMarker` could rewind into the outer stream. `TokenReader` is not a public export. Current `NodeParser` hot paths already call `peekTokenKind()` first, which is why existing parser snapshots did not fail.

## Decision

`peekToken()` past the window returns the stream's `EndOfInput` token (`tokens[tokens.length - 1]`); `peekPreviousTokenKind()` treats `_readerStartIndex` as start-of-input; `backtrackToMarker` throws if `marker < _readerStartIndex`.

Alternative: throw from `peekToken()` (like `readToken()`), or clamp an out-of-range marker to the window start. Open PR #482 takes the throw-from-`peekToken()` option.

`readToken()` already states that peek must always return a valid `Token`, and the other peek methods already signal `EndOfInput` at the window edge. Expired markers already throw as a parser bug. Can switch to throw-on-peek or clamp-on-backtrack.

## Test plan

- [x] New `tsdoc/src/parser/__tests__/TokenReader.test.ts` fails without the source change and passes with it (embedded predecessor leak, next-token leak, empty `TokenSequence.createEmpty`, out-of-range backtrack).
- [x] Full `@microsoft/tsdoc` Heft test run (typecheck / ESLint / API Extractor / 259 Jest tests).
- [ ] `rush change --verify` on CI (change file included).
- [ ] Optional: playground / api-demo smoke; no parser grammar change.

## Change log

Rush change file: `common/changes/@microsoft/tsdoc/fix-tokenreader-bounds_2026-09-11-13-00.json` (`patch`).
